### PR TITLE
Add 4 new mock eval sites + full-eval observation report

### DIFF
--- a/eval/AGENTS.md
+++ b/eval/AGENTS.md
@@ -1,0 +1,73 @@
+# eval/ — Agent Notes
+
+Implementation knowledge for the mock sites under `eval/`. Repo-wide conventions live in `../AGENTS.md`. Read **both** before editing sites or test cases.
+
+## Source of truth
+
+- **`SPEC_NEW_SITES.md`** is the design brief that generated the four post-2026-03 sites: `mapquest/`, `staybnb/`, `taskflow/`, `vidhub/`. When regenerating or extending a site, re-read the relevant section there instead of reverse-engineering from the rendered HTML. The spec pins the **intended behaviours**; the HTML only reflects what actually shipped.
+- Test-case YAMLs in `dataset/` are the second source of truth — a site change that breaks a criterion's expected event shape is a site bug, not a criterion bug, unless the spec disagrees.
+
+## Tracker contract
+
+- Every site uses the shared `eval/js/tracker.js` — `window.tracker = new AgentTracker('<site>', '<difficulty>')`. Do not create site-local trackers.
+- Emitted event values must match YAML criteria **exactly**, including case. Normalize at the emit site, not in the criterion. Concrete case: StayBnB amenity checkboxes render "Wifi"/"Kitchen" but `staybnb_book.yaml` expects `amenity: "wifi"`. The fix is `.toLowerCase()` in the tracker call, not capitalizing the YAML.
+- When instruction text references a button label, the label must be the literal DOM text. StayBnB's filter apply button reads "Show N stays" (live count), so the instruction and criterion description both say "Show N stays" — never a generic "Apply".
+
+## Default-state events — do not auto-credit
+
+Tempting anti-pattern: if a criterion expects `route_select` / `transport_mode_select` but the UI **pre-selects** the default option (shortest route, drive mode, etc.), a user who agrees with the default never clicks, so no event fires and the criterion would fail. The tempting "fix" is to emit a synthetic `*_select` on state entry with `defaultSelected: true`.
+
+**Don't do this.** The synthetic event also fires when the agent does nothing, so the criterion passes for a no-op run — and in tests like `mapquest_nearby_pins` where "Choose driving mode" is scored, the agent gets credit without ever identifying the icon. It silently dilutes the test signal.
+
+**Rules:**
+
+1. Criteria must match only on explicit user interaction events. No state-entry auto-emits for `*_select` style events.
+2. If a test asks the agent to click a pre-selected default, it is the test author's job to make the target unambiguous. Either:
+   - Change the task to select a **non-default** option (e.g., `mode: "walk"` instead of `"drive"`), or
+   - Pin the criterion to specific field values (e.g., `routeIndex: 0`) so explicit clicks still match, and accept that re-clicking the default is part of the task.
+3. When naming the criterion "Select the shortest route", pin `routeIndex: 0` in the YAML so the scorer distinguishes shortest from non-shortest.
+
+History: `mapquest.js` briefly emitted both events as state-entry defaults; the pattern was removed after a review showed `mapquest_nearby_pins` was auto-crediting `transport_mode_select: drive` on directions-panel entry.
+
+## Panel-state machines vs page routes
+
+MapQuest and StayBnB both have panels whose views swap in place rather than navigating. Keep state transitions **stateful** (class toggles on panel containers, `switchPanelState(...)`), not URL-based — the spec intentionally tests panel-state navigation.
+
+Consequence: if two tests need the same control in different panel states, duplicate the DOM rather than routing between states. Concrete case: `mapquest_navigate` wants the Directions flow inside `place-detail`, but `mapquest_nearby_pins` wants the category chip bar visible from inside `place-detail` too. The chip bar is duplicated inside the place-detail state; active-class sync is done across both copies via `document.querySelectorAll('.chip[data-category="..."]')`.
+
+## Deep-link entry points
+
+Some tests start pre-loaded into a non-home view so the agent doesn't have to traverse navigation it isn't being scored on. StayBnB supports `#results` in `staybnb/js/staybnb.js#init()` to jump straight into results with Tokyo listings rendered. The test YAML's `start_url` ends with `/staybnb/#results`. Add a similar hash handler whenever a new test needs a non-home starting view.
+
+## Stacking contexts — popovers and headers
+
+Popovers anchored inside a header will be clipped to the header's effective z-order because the header's own `z-index` creates a stacking context. If a full-screen dismiss backdrop sits above that header z-index, clicks on the popover input land on the backdrop instead and close the popover immediately.
+
+Concrete case: StayBnB's search pill popovers were unclickable until `.topbar` was raised from `z-index: 100` to `300`, above the `.popover-backdrop` at `150`. When adding any overlay that uses a backdrop pattern, verify the anchoring element's stacking context dominates the backdrop.
+
+## Real images
+
+Agents occasionally need real visual content (thumbnails, destination cards, gallery photos). Use **Lorem Picsum seeded URLs** so images are deterministic across runs:
+
+```
+https://picsum.photos/seed/<stable-seed>/<W>/<H>
+```
+
+Seeds used so far live in `staybnb/index.html` (home cards) and `staybnb/js/staybnb.js` (results + detail + gallery — seeds of form `staybnb-<listingId>-<k>`). Prefer `background-image: url(...)` with `background-size: cover` so the layout tolerates any aspect ratio.
+
+## Drag-and-drop primitives
+
+- **StayBnB price slider** is dual-handle. Each handle drag emits `price_slider_change` with `handle: "min"` or `handle: "max"`. The two criteria are independent, so the handles must be draggable independently — don't couple them.
+- **TaskFlow cards** use HTML5 drag-and-drop, not click-to-move. Criteria expect `card_drop` with source and destination column IDs.
+
+## Manual-test harness workflow
+
+When validating a new or changed test via `evaluate_browser_agent.py --manual`:
+
+1. `mkfifo /tmp/eval_in` and hold the write end open with a background `sleep` so the harness's `stdin` stays open across multiple tests.
+2. The harness clears events at instruction display time — timing starts then, not at page load.
+3. Sending `ok\n` to the FIFO completes a test and prints the score breakdown. A criterion that reports 0 despite visibly correct behaviour is almost always an event-shape mismatch (case, missing field, or default-state pattern above).
+
+## Scope discipline
+
+Keep site code minimal and aligned with the spec's stated challenges. Do **not** add extra animations, fallbacks, or abstractions beyond what a criterion exercises. The sites exist to probe specific agent weaknesses; incidental complexity dilutes the signal and creates spurious event noise.

--- a/eval/HARD_MOCK_SITES_SPEC.md
+++ b/eval/HARD_MOCK_SITES_SPEC.md
@@ -1,0 +1,629 @@
+# Hard-Only Mock Website SPEC
+
+This document defines 5 new pure-frontend mock websites to extend the eval suite under `eval/`.
+
+All new dataset cases under `eval/dataset/` should be `hard` or `very hard`.
+Do not add simple or single-action cases for these sites.
+
+## Goals
+
+- Expand coverage into stateful real-world workflows instead of adding more easy search-and-click tasks.
+- Challenge OpenBrowser with long, multi-surface, ambiguity-heavy flows.
+- Keep all sites pure frontend, deterministic, and easy to reset between runs.
+- Make scoring strict through semantic tracker events and stable seeded IDs.
+
+## Global Requirements
+
+### Architecture
+
+- Each website lives in `eval/<site>/`.
+- Each site is pure frontend only: HTML, CSS, JS, embedded JSON/JS seed data, and local browser state.
+- No real backend should be introduced for site logic. The only server dependency remains the existing tracker API in `eval/server.py`.
+- Every site must support deterministic reset via `?reset=1` or equivalent local state clearing on load.
+
+### Difficulty Policy
+
+- Every new dataset file must be `hard` or `very hard`.
+- Each workflow should require 6 to 12 meaningful actions.
+- Each workflow must cross at least 2 surfaces, for example:
+  - list -> detail -> modal -> list
+  - search -> results -> detail -> checkout
+  - issue list -> issue -> PR -> files changed
+- Each workflow must include exact-target discrimination:
+  - near-duplicate names
+  - repeated buttons
+  - similar cards
+  - misleading but plausible decoys
+- Each workflow must include at least one state dependency where a later step is only valid if an earlier step was correct.
+
+### Interaction Design Rules
+
+- Prefer realistic UI ambiguity over artificial randomness.
+- Do not require unsupported OS-level file pickers, native downloads, CAPTCHAs, or external logins.
+- If a real site normally uses upload, attachment, or drag/drop, provide an in-page mocked alternative.
+- Use nested scroll containers, sticky toolbars, hidden actions after selection, and repeated labels to increase difficulty.
+- Avoid impossible puzzles or hidden controls that a careful human could not reasonably find.
+
+### Tracking Rules
+
+- Emit semantic events for all workflow-critical actions.
+- All tracked objects must have stable seeded IDs even if the ID is not visible in the UI.
+- Dataset scoring should prioritize semantic checkpoints and final state, not generic click counts.
+
+### Dataset Rules
+
+- Each site ships exactly 3 dataset files:
+  - 2 hard
+  - 1 very hard
+- Recommended time limits:
+  - hard: 480 to 720 seconds
+  - very hard: 720 to 1100 seconds
+- Recommended cost limits:
+  - hard: 1.0 to 1.8 RMB
+  - very hard: 1.8 to 3.0 RMB
+
+## 1. Gmail Mock
+
+### Route
+
+- `/gmail/`
+
+### Why This Site
+
+Current eval coverage already includes search, forums, dashboards, social feed interaction, console chat, and basic ecommerce. It does not cover inbox triage, threaded context, selection-dependent toolbars, or search operators.
+
+### Real Website Behaviors To Mock
+
+- Inbox categories such as Primary, Promotions, and Updates
+- Left navigation with labels and nested labels
+- Thread list with unread, starred, and attachment states
+- Thread detail view with collapsed older replies
+- Search bar with Gmail-style operator behavior
+- Bulk selection checkboxes and selection toolbar
+- Archive, mark unread, star, move, and label actions
+- Compose modal and inline reply box
+- Draft autosave
+- Attachment insertion through a frontend picker modal
+
+### Main Challenge
+
+The challenge is not just finding a thread. The agent must preserve object identity across inbox, thread view, search results, and compose state. Important actions only appear after selection or after opening the correct thread, and many threads should look plausible.
+
+### Main Interaction Types
+
+- Search
+- Open thread
+- Expand collapsed messages
+- Select one or many threads
+- Apply existing label
+- Create new label
+- Archive
+- Mark unread
+- Star
+- Compose or reply
+- Add mock attachment
+- Save draft
+- Send
+
+### Difficulty Levers
+
+- Similar sender names and near-duplicate subject lines
+- One correct thread and one decoy with almost the same search result
+- Nested labels such as `Finance/Q2`
+- Toolbar changes only after thread selection
+- Compose modal remains open while inbox state is still visible beneath it
+- One attachment path inserts a mock file and another inserts a mock Drive link
+
+### Seeded State
+
+- 35 to 45 threads
+- At least 3 subject clusters with similar naming
+- At least 1 urgent thread in Primary
+- At least 1 convincing decoy in Promotions
+- At least 1 multi-message thread where the correct clue is only in the latest reply
+- At least 1 thread already associated with a label tree
+
+### Dataset Files
+
+- `gmail_exec_followup.yaml` (`hard`)
+  - Search with operators
+  - Open the correct finance thread
+  - Create or apply the correct label
+  - Reply with exact text
+  - Attach the correct mock PDF
+  - Send
+- `gmail_inbox_cleanup.yaml` (`hard`)
+  - Navigate categories
+  - Bulk-select specific campaign threads
+  - Archive them
+  - Star one urgent thread
+  - Mark another thread unread
+  - Avoid one decoy
+- `gmail_vendor_escalation.yaml` (`very hard`)
+  - Find a buried vendor thread with search
+  - Expand collapsed conversation history
+  - Inspect the newest message
+  - Reply or forward with exact recipients and CC
+  - Save as draft
+  - Reopen draft
+  - Add mock Drive attachment
+  - Send
+
+### Semantic Events
+
+- `mail_search_execute`
+- `thread_open`
+- `thread_expand`
+- `thread_select`
+- `thread_archive`
+- `thread_mark_unread`
+- `thread_star_toggle`
+- `label_create`
+- `label_apply`
+- `compose_open`
+- `reply_open`
+- `attachment_add`
+- `draft_autosave`
+- `mail_send`
+
+## 2. Google Drive Mock
+
+### Route
+
+- `/drive/`
+
+### Why This Site
+
+The current suite does not test nested file management, move/share workflows, selection state, or permission changes across several surfaces.
+
+### Real Website Behaviors To Mock
+
+- My Drive
+- Shared with me
+- Recent
+- Breadcrumb navigation
+- Folder tree navigation
+- List and grid view toggle
+- Search bar
+- Details pane
+- Multi-select toolbar
+- Context menu
+- Rename
+- Move dialog with destination tree
+- Shortcut creation
+- Share dialog with role selector
+- Frontend-only upload modal
+
+### Main Challenge
+
+The agent must track file identity across search results, folder views, move dialogs, and sharing modals. Similar filenames should make naive text matching fail.
+
+### Main Interaction Types
+
+- Search
+- Open folder
+- Switch view mode
+- Select one or many items
+- Rename
+- Move
+- Create shortcut
+- Open share dialog
+- Add collaborator
+- Change permissions
+- Upload replacement asset
+- Delete obsolete duplicate
+
+### Difficulty Levers
+
+- Identical or near-identical filenames in different folders
+- Shared and owned copies of similar files
+- Hidden bulk toolbar until exact selection happens
+- Destination picker with nested scroll container
+- Permission dropdown inside modal
+- Existing shortcut that looks similar to a real file
+
+### Seeded State
+
+- 50 to 70 files/folders
+- At least 3 levels of nesting
+- Duplicate names such as `Launch Brief`, `Launch Brief Final`, `Launch Brief v5`
+- Shared items with badges and owner metadata
+- At least 1 shortcut already present
+- At least 1 project area containing visually similar assets
+
+### Dataset Files
+
+- `drive_project_reorg.yaml` (`hard`)
+  - Search for a specific file
+  - Move it into the correct nested folder
+  - Rename it
+  - Create a shortcut in a second destination
+- `drive_permission_cleanup.yaml` (`hard`)
+  - Locate a shared folder
+  - Open share dialog
+  - Add two collaborators with different roles
+  - Downgrade an existing editor
+  - Confirm final access state
+- `drive_bulk_release_assets.yaml` (`very hard`)
+  - Switch to list view
+  - Multi-select several similarly named assets
+  - Move them in one action
+  - Upload a replacement asset with the mock picker
+  - Delete one obsolete duplicate
+  - Avoid touching the wrong file
+
+### Semantic Events
+
+- `drive_search_execute`
+- `folder_open`
+- `view_mode_change`
+- `item_select`
+- `multi_select_commit`
+- `item_move`
+- `item_rename`
+- `shortcut_create`
+- `share_dialog_open`
+- `permission_add`
+- `permission_change`
+- `mock_upload_complete`
+- `item_delete`
+
+## 3. Booking.com Mock
+
+### Route
+
+- `/booking/`
+
+### Why This Site
+
+The suite currently lacks calendar-heavy travel workflows, guest/room allocation, multi-step result filtering, room policy comparison, and reservation completion.
+
+### Real Website Behaviors To Mock
+
+- Destination autocomplete
+- Dual-month date picker
+- Guest and room counters
+- Search submit
+- Search results list with sticky filters
+- Sort controls
+- Shortlist or save
+- Property detail page
+- Room-rate table
+- Free cancellation and breakfast badges
+- Traveler form
+- Reservation confirmation page
+
+### Main Challenge
+
+The difficult part is policy discrimination. Many properties and room cards should look nearly valid. The correct path depends on subtle constraints such as cancellation policy, breakfast inclusion, neighborhood, or occupancy fit.
+
+### Main Interaction Types
+
+- Destination selection
+- Date range selection
+- Guest count changes
+- Search
+- Filter application
+- Sorting
+- Open property
+- Shortlist toggle
+- Select room/rate plan
+- Fill traveler form
+- Submit reservation
+
+### Difficulty Levers
+
+- Repeated `See availability` buttons
+- Similar hotel names
+- Similar room cards differing only in policy text
+- Sticky filters and overlays
+- Multi-room guest allocation
+- Traveler form validation tied to earlier room selection
+
+### Seeded State
+
+- 18 to 25 properties in one city
+- At least 3 hotels with highly similar names
+- Each target hotel has multiple room-rate combinations
+- Cancellation, breakfast, and payment timing vary independently
+- At least 1 decoy hotel that matches most but not all constraints
+
+### Dataset Files
+
+- `booking_room_selection.yaml` (`hard`)
+  - Choose destination, dates, and guests
+  - Filter by review score and cancellation policy
+  - Open the correct property
+  - Select the one room plan matching breakfast and cancellation constraints
+  - Continue toward reservation
+- `booking_compare_and_book.yaml` (`hard`)
+  - Shortlist two similar hotels
+  - Compare them
+  - Reopen the correct one
+  - Choose the valid room offer
+  - Fill traveler details
+  - Confirm reservation
+- `booking_family_trip_edgecase.yaml` (`very hard`)
+  - Configure multi-room guests
+  - Apply neighborhood and meal filters
+  - Avoid decoy offers
+  - Select two exact room types
+  - Fill traveler forms
+  - Add special request
+  - Complete booking
+
+### Semantic Events
+
+- `destination_select`
+- `date_range_select`
+- `guest_count_change`
+- `search_submit`
+- `filter_apply`
+- `sort_apply`
+- `property_open`
+- `shortlist_toggle`
+- `rate_plan_select`
+- `traveler_form_submit`
+- `reservation_submit`
+
+## 4. GitHub Mock
+
+### Route
+
+- `/github/`
+
+### Why This Site
+
+The current suite does not test multi-surface code review, issue triage, file-diff navigation, or review actions anchored to exact files and hunks.
+
+### Real Website Behaviors To Mock
+
+- Repository tabs
+- Issues list
+- Pull requests list
+- Filter/query bar
+- Labels, assignee, and milestone sidebar
+- Issue comments
+- PR Conversation tab
+- PR Files changed tab
+- Changed-file tree
+- File filters
+- Inline diff comments
+- Mark-as-viewed
+- Review submit modal with `Comment`, `Approve`, and `Request changes`
+
+### Main Challenge
+
+Many actions use the same language but have different meaning based on context. A generic comment is not a review comment. A label added to the issue is not a label added to the PR. The agent must land on the correct object, file, and diff hunk.
+
+### Main Interaction Types
+
+- Enter query filters
+- Open issue
+- Add label
+- Set assignee
+- Set milestone
+- Add issue comment
+- Open PR
+- Switch PR tabs
+- Filter changed files
+- Add inline diff comment
+- Mark file viewed
+- Submit review
+
+### Difficulty Levers
+
+- Similar issue titles
+- Similar file paths
+- Review sidebar and file tree crowd the page
+- Repeated `Comment` controls
+- Two visually similar hunks where only one is correct
+- Linked issue visible from PR sidebar but not necessarily opened yet
+
+### Seeded State
+
+- 10 to 15 issues
+- 4 to 6 PRs
+- At least 1 release-blocker issue
+- At least 1 PR with 8 to 12 changed files
+- Similar issue titles and labels
+- At least 1 linked issue tied to the target PR
+
+### Dataset Files
+
+- `github_issue_triage_deep.yaml` (`hard`)
+  - Filter issues with qualifiers
+  - Open the correct issue
+  - Add the right label
+  - Assign the right owner
+  - Set milestone
+  - Leave an exact triage comment
+- `github_pr_review.yaml` (`hard`)
+  - Open a PR
+  - Switch to `Files changed`
+  - Filter to the right file path
+  - Add an inline diff comment on the correct hunk
+  - Mark another file viewed
+  - Submit `Request changes`
+  - Traverse linked issue and PR context
+  - Inspect multiple changed files
+  - Add two targeted review comments
+  - Set a PR label
+  - Submit the correct review state based on a blocker rule
+
+### Semantic Events
+
+- `repo_nav`
+- `issue_filter_apply`
+- `issue_open`
+- `label_add`
+- `assignee_set`
+- `milestone_set`
+- `issue_comment_add`
+- `pr_open`
+- `pr_tab_change`
+- `files_changed_filter_apply`
+- `diff_comment_add`
+- `file_mark_viewed`
+- `review_submit`
+
+## 5. Amazon Mock
+
+### Route
+
+- `/amazon/`
+
+### Why This Site
+
+Northstar currently covers only a focused product-detail and add-to-bag flow. It does not test retail search noise, variant selection, seller/offers disambiguation, cart recovery, or full checkout.
+
+### Real Website Behaviors To Mock
+
+- Homepage search
+- Search autocomplete
+- Search results with sponsored cards
+- Facet filters
+- Sort dropdown
+- Product detail page gallery
+- Variant swatches or dropdowns
+- Buy box
+- Seller/offers panel
+- Cart
+- Save for later
+- Restore from saved
+- Address selection
+- Shipping speed selection
+- Payment selection
+- Review order
+- Place order
+
+### Main Challenge
+
+The main challenge is dense decision-making. The correct product may not be the first result, the default variant may be wrong, and the default seller may not satisfy the required delivery or condition constraints.
+
+### Main Interaction Types
+
+- Search
+- Filter
+- Sort
+- Open PDP
+- Select variant
+- Open offers
+- Select seller/offer
+- Add to cart
+- Adjust quantity
+- Save for later
+- Restore from saved
+- Select address
+- Select shipping
+- Select payment
+- Place order
+
+### Difficulty Levers
+
+- Sponsored result noise
+- Sticky buy box
+- Default wrong variant
+- Offer selection hidden behind secondary control
+- Accessory upsell in cart
+- Delivery promise changes after address selection
+- Repeated `Buy Now` and `Add to Cart` paths
+
+### Seeded State
+
+- 30 to 40 products
+- 6 to 8 near-matching results for at least one target query
+- At least 1 sponsored decoy
+- PDPs with color, size, or configuration variants
+- Multiple offers with seller, condition, and delivery differences
+- Two addresses with different shipping ETA outcomes
+
+### Dataset Files
+
+- `amazon_variant_checkout.yaml` (`hard`)
+  - Search through noisy results
+  - Open the correct PDP
+  - Select exact color and size
+  - Add to cart
+  - Remove an auto-added accessory
+  - Choose address, shipping, payment
+  - Place order
+  - Add an item
+  - Save it for later
+  - Restore it
+  - Adjust quantity
+  - Remove wrong accessory
+  - Change address so shipping updates
+  - Complete checkout
+- `amazon_offer_disambiguation.yaml` (`very hard`)
+  - Search and open correct product
+  - Open offers surface
+  - Choose exact seller and condition
+  - Verify delivery promise
+  - Add correct offer to cart
+  - Complete checkout without using the wrong `Buy Now` path
+
+### Semantic Events
+
+- `amazon_search_execute`
+- `facet_select`
+- `results_sort_apply`
+- `product_open`
+- `variant_select`
+- `offer_open`
+- `offer_select`
+- `cart_add`
+- `cart_qty_change`
+- `save_for_later`
+- `restore_from_saved`
+- `address_select`
+- `shipping_option_select`
+- `payment_select`
+- `place_order_click`
+
+## Cross-Site Scoring Guidance
+
+- Score exact object targeting, not approximate intent.
+- Require stable seeded IDs in expected events:
+  - `threadId`
+  - `folderId`
+  - `propertyId`
+  - `issueNumber`
+  - `prNumber`
+  - `productId`
+  - `offerId`
+- Combine checkpoint scoring with final state scoring.
+- Do not award full credit for reaching the right page if the wrong object was modified.
+- Prefer semantic events over generic click selectors whenever possible.
+
+## Suggested File Additions
+
+### New Frontend Sites
+
+- `eval/gmail/`
+- `eval/drive/`
+- `eval/booking/`
+- `eval/github/`
+- `eval/amazon/`
+
+### New Dataset Files
+
+- `eval/dataset/gmail_exec_followup.yaml`
+- `eval/dataset/gmail_inbox_cleanup.yaml`
+- `eval/dataset/gmail_vendor_escalation.yaml`
+- `eval/dataset/drive_project_reorg.yaml`
+- `eval/dataset/drive_permission_cleanup.yaml`
+- `eval/dataset/drive_bulk_release_assets.yaml`
+- `eval/dataset/booking_room_selection.yaml`
+- `eval/dataset/booking_compare_and_book.yaml`
+- `eval/dataset/booking_family_trip_edgecase.yaml`
+- `eval/dataset/github_issue_triage_deep.yaml`
+- `eval/dataset/github_pr_review.yaml`
+- `eval/dataset/amazon_variant_checkout.yaml`
+- `eval/dataset/amazon_offer_disambiguation.yaml`
+
+## Notes
+
+- This spec is challenge-first. The goal is to test OpenBrowser under realistic, difficult workflows, not to reproduce existing easy capabilities.
+- Long workflows, repeated controls, contextual toolbars, multi-surface transitions, and decoy objects are desirable.
+- The implementations should feel close enough to real websites that the model must genuinely interpret the UI rather than solve a toy puzzle.

--- a/eval/README.md
+++ b/eval/README.md
@@ -73,6 +73,87 @@ This directory contains mocked frontend websites designed to test browser-operat
   - Comment like / reply interactions with author-specific tracking
   - Shared tracker integration plus site-specific events
 
+### 7. MapQuest (Hard) — Google Maps mock
+- **URL**: `/mapquest/`
+- **Difficulty**: Hard
+- **Purpose**: Test panel-state navigation, search autocomplete, icon-only transport buttons, and spatial pin interaction on a map canvas
+- **Features**:
+  - Left search panel with state machine: `search → results → place-detail → directions`
+  - Autocomplete dropdown that appears as the user types (no page reload)
+  - Horizontally-scrollable category chip bar ("Restaurants", "Gas", "Coffee"…) duplicated inside `place-detail` so it stays reachable after drilling in
+  - Icon-only transport mode bar (drive / transit / walk / bike) above directions
+  - Route result cards with duration + distance; shortest route is pre-selected and emits a `route_select` event on panel entry
+  - Spatial pin clicks on the canvas with hover → label reveal
+  - Test cases: `mapquest_navigate`, `mapquest_nearby_pins`
+- **Main challenges**:
+  - Autocomplete timing — suggestions only appear mid-typing, not on submit
+  - Icon-only transport buttons with no text labels
+  - Ambiguous pin targets on a dense map
+  - Panel-state (not page) navigation — back/forward is stateful, not a route change
+  - Default-selection events: the shortest route and "drive" mode are pre-selected; the site emits synthetic `*_select` events on entry so criteria don't require a redundant click
+
+### 8. StayBnB (Hard → Very Hard) — Airbnb mock
+- **URL**: `/staybnb/`
+- **Difficulty**: Hard → Very Hard
+- **Purpose**: Test segmented search pill, date-range calendar, dual-handle price slider drag, multi-amenity filter modal, gallery viewer, and two-step reserve → confirm booking
+- **Features**:
+  - Home page with real Lorem Picsum destination cards
+  - Top search pill with Where / Check-in / Check-out / Who popovers that share a dismiss backdrop
+  - Guest stepper (adults / children / infants) with per-row +/- buttons
+  - Results view reachable via `#results` deep link (pre-loaded with Tokyo listings for tests)
+  - Card carousel (left/right arrows) plus card-hover → map-pin highlight sync
+  - Filter modal with **dual-handle price slider** (drag both ends), amenity checkboxes, and an "Instant Book" toggle
+  - "Show N stays" apply button whose label updates live with the filtered count
+  - Detail page with 5-photo grid, fullscreen gallery (scrollable), and a Reserve → Confirm-and-pay two-step checkout
+  - Test cases: `staybnb_search`, `staybnb_book`
+- **Main challenges**:
+  - Drag interaction on a dual-handle slider — min and max handles must be dragged independently
+  - Segmented popover stacking: header must sit **above** the dismiss backdrop or the popover inputs become click-dead (header `z-index` raised to 300 to resolve)
+  - Sequential checkout with hidden second step
+  - Amenity events normalized to lowercase so checker criteria match regardless of display casing
+  - Live apply-button label ("Show N stays") — test instructions and criteria reference the actual label rather than a generic "Apply"
+
+### 9. TaskFlow (Medium → Hard) — Trello mock
+- **URL**: `/taskflow/`
+- **Difficulty**: Medium → Hard
+- **Purpose**: Test drag-and-drop, hover-reveal controls, inline editing, color-only label selection, and board-menu space theft
+- **Features**:
+  - Kanban board with 4 columns and draggable cards (HTML5 drag-and-drop)
+  - Hover-reveal pencil icon on cards for inline rename
+  - Card detail modal with description, labels, checklist, comments
+  - Color-swatch label picker (no text labels — hue only)
+  - Due-date picker and member assignment
+  - Right-side board menu that pushes board content left when opened
+  - Test cases: `taskflow_drag_and_edit`, `taskflow_full_workflow`
+- **Main challenges**:
+  - True drag-and-drop between columns (not click-to-move)
+  - Hover-to-reveal pencil — the affordance is invisible until the pointer enters the card
+  - Color-only label picker requires visual discrimination without text
+  - Board menu steals horizontal space on open, shifting downstream click targets
+  - Inline editing: click to enter edit mode, Enter/blur to commit
+
+### 10. VidHub (Medium → Hard) — YouTube mock
+- **URL**: `/vidhub/`
+- **Difficulty**: Medium → Hard
+- **Purpose**: Test auto-hide player controls, thin-bar timeline scrub, nested settings popup, hover-reveal volume slider, and nested comment reply threads
+- **Features**:
+  - Home feed grid with thumbnail + title + channel cards
+  - Search box in masthead with result filter chips
+  - Video watch page with poster + overlaid control bar that **auto-hides after 3s** of inactivity
+  - Icon-only player controls: play/pause, volume, CC, settings, theater, miniplayer, fullscreen
+  - Thin progress bar (~4px, thickens to ~8px on hover) for timeline seek
+  - Volume icon with **hover-reveal** horizontal slider (two-step hover-then-drag)
+  - Nested settings popup: gear → Playback speed → submenu (0.25x … 2x)
+  - Like/dislike, red → gray Subscribe toggle, expandable description
+  - Comment section with sort dropdown and nested reply threads
+  - Test cases: `vidhub_player`, `vidhub_comment`
+- **Main challenges**:
+  - Control bar auto-hide forces repeated hover-to-reveal between actions
+  - Thin-bar scrub precision for percentage-based seek targets
+  - Two-step hover-reveal volume slider
+  - Nested popup navigation — settings opens a popup, submenu opens inside the same popup
+  - Scroll-to-comments below fold followed by scroll-back-up to player area
+
 ## Event Tracking
 
 All websites include comprehensive event tracking that records:
@@ -201,7 +282,15 @@ eval/
 │   ├── cloudstack_interactive.yaml
 │   ├── finviz_simple.yaml
 │   ├── finviz_complex.yaml
-│   └── dataflow.yaml
+│   ├── dataflow.yaml
+│   ├── mapquest_navigate.yaml
+│   ├── mapquest_nearby_pins.yaml
+│   ├── staybnb_search.yaml
+│   ├── staybnb_book.yaml
+│   ├── taskflow_drag_and_edit.yaml
+│   ├── taskflow_full_workflow.yaml
+│   ├── vidhub_player.yaml
+│   └── vidhub_comment.yaml
 ├── css/
 │   ├── gbr.css           # GBR styles
 │   ├── techforum.css     # TechForum styles
@@ -222,8 +311,24 @@ eval/
 │   └── *.html
 ├── dataflow/             # Dashboard visualization
 │   └── index.html
-└── finviz/               # Stock screener
-    └── index.html
+├── finviz/               # Stock screener
+│   └── index.html
+├── mapquest/             # Google Maps mock (panel state machine)
+│   ├── index.html
+│   ├── css/mapquest.css
+│   └── js/mapquest.js
+├── staybnb/              # Airbnb mock (filter modal, gallery, booking)
+│   ├── index.html
+│   ├── css/staybnb.css
+│   └── js/staybnb.js
+├── taskflow/             # Trello mock (drag-and-drop board)
+│   ├── index.html
+│   ├── css/taskflow.css
+│   └── js/taskflow.js
+└── vidhub/               # YouTube mock (player, comments)
+    ├── index.html
+    ├── css/vidhub.css
+    └── js/vidhub.js
 ```
 
 ## Testing

--- a/eval/SPEC_NEW_SITES.md
+++ b/eval/SPEC_NEW_SITES.md
@@ -1,0 +1,681 @@
+# SPEC: New Mock Evaluation Sites
+
+Four new pure-frontend mock websites targeting interaction patterns not covered
+by the existing seven sites (GBR, TechForum, CloudStack, DataFlow, Finviz,
+BlueBook, Northstar).
+
+Design goal: **challenge the agent**, not reproduce capability it already
+handles.  Each site is designed around one or two interaction patterns that are
+genuinely hard for a vision-based browser agent and that no existing eval site
+tests.
+
+All sites are self-contained HTML/CSS/JS served by the existing `eval/server.py`
+static-file mechanism, with event tracking via the shared `tracker.js` library
+plus site-specific custom events.
+
+Research basis: real-website layout, interaction sequences, and agent-tripping
+edge cases were verified against current Google Maps help docs, Airbnb help
+center, Atlassian/Trello support docs, and YouTube accessibility/support docs
+(April 2026).
+
+---
+
+## 1. MapQuest — Google Maps mock
+
+**Directory:** `eval/mapquest/`
+**Difficulty:** Hard
+**Real-world model:** Google Maps (maps.google.com)
+
+### Why this is hard
+
+Maps is a spatial UI.  The agent must reason about autocomplete dropdown
+timing, distinguish visually similar pin clusters, read a directions panel that
+changes dynamically, and operate transport-mode toggle buttons that look nearly
+identical.  There is no clean DOM shortcut — the map canvas is an image, and
+the side panel is dense.
+
+### Real layout to reproduce
+
+Google Maps desktop uses a **left search/results panel** (collapsible via an
+arrow on its right edge) plus a **full map canvas** to the right.  Key layout
+elements:
+
+- **Search box** at the top-left inside the panel.
+- **Category/filter chips** appear below the search box after a category query.
+- **Panel body** swaps between: search results list, place detail view,
+  directions form — these are _panel states_, not separate pages.
+- **Map controls** float over the map canvas: zoom +/– (bottom-right), compass
+  (top-right), layers/satellite toggle, Street View pegman, fullscreen.
+- **Map pins**: red for main results, mini-pins/dots for secondary results,
+  **square ad pins** that look like real results (distractor).
+
+The collapsible panel is important: collapsing it changes the usable map
+viewport and can shift which pins are visible.
+
+### Behaviours to mock
+
+| Behaviour | Notes |
+|-----------|-------|
+| Search bar with debounced autocomplete | Typing shows a dropdown of suggested places after ~300ms debounce.  Suggestions include both places and recent searches.  Agent must **wait for the dropdown** and click the correct suggestion rather than pressing Enter on partial text.  Pressing Enter before autocomplete renders should yield different (less precise) results. |
+| Panel state transitions | Selecting a result **swaps** the panel from list-view into place-detail view (not a new page navigation).  "Back" arrow returns to list.  Directions button swaps into directions form state. |
+| Place detail panel | Name, address, rating (stars), hours, reviews, photos, "Directions" button, "Save" button, "Share" button.  Scrollable within the panel. |
+| Directions mode | "Directions" button swaps panel into a two-field form (origin / destination) with transport-mode tabs above.  Swapping the origin/destination has a swap button. |
+| Transport mode toggle — icon-only | Four icon-only buttons (car, transit, walk, bike) with **no text labels**.  Agent must identify mode by icon shape alone.  Active mode has a blue underline. |
+| Route result list | After filling origin + destination and choosing a mode, 2–3 route options appear with time / distance.  Routes highlighted on map in blue (selected) and gray (alternatives).  Agent must click the correct route. |
+| Map pin interaction | Clickable pins on an SVG map.  Include: clustered pins close together (agent must click the correct one), ad-style square pins (distractor, opens different panel content). |
+| Pin hover preview | Hovering a pin shows a small tooltip with place name.  The tooltip disappears on mouseout. |
+| "Nearby" category chips | Horizontal chip bar: "Restaurants", "Gas stations", "Coffee", "Hotels", "Parking", "Groceries", "Attractions", "Pharmacies".  Bar is **horizontally scrollable** — "Parking" and later chips are off-screen initially.  Clicking a chip filters the map pins. |
+| Panel collapse / expand | Arrow button on panel right edge collapses/expands the panel.  Collapsing changes the map viewport. |
+
+### Main challenges for the agent
+
+1. **Autocomplete timing** — dropdown appears after a 300ms debounce; pressing
+   Enter early yields a generic "search results" list rather than selecting the
+   specific place.  The agent must learn to wait.
+2. **Icon-only buttons** — transport mode tabs have no text labels; the agent
+   must identify drive/transit/walk/bike by icon recognition alone.
+3. **Panel state (not page) transitions** — the panel body changes without a
+   URL change; the agent cannot rely on page navigation events.
+4. **Ambiguous pins** — two pins close together (e.g., Pike Place Market and
+   Pike Place Chowder); the agent must click the correct one based on the
+   panel content it expects.  Ad pins add further distraction.
+5. **Scroll-to-reveal chips** — the "Nearby" chip bar requires horizontal
+   scroll to find "Parking" or later categories.
+6. **Collapse interaction** — the panel collapse arrow is a small target; the
+   agent might accidentally click it when trying to interact with the panel
+   edge.
+
+### Interaction types
+
+- Text input with debounced autocomplete selection
+- Panel state transitions (no page nav)
+- Panel collapse / expand
+- Icon-only button clicks (no text)
+- SVG spatial click targeting (pins)
+- Pin hover previews
+- Horizontal scroll within a chip bar
+- Multi-field form (origin + destination) with field swap
+- Tab switching (transport modes)
+
+### Test cases
+
+#### mapquest_navigate.yaml — Hard
+
+**Instruction:** Search for "Pike Place Market" and select it from the
+autocomplete dropdown (do NOT just press Enter — wait for suggestions).  From
+the place detail panel, click "Directions".  Set the origin to "Space Needle"
+(again selecting from autocomplete).  Switch to the walking mode (the
+pedestrian icon — there are no text labels, only icons).  From the route
+results, select the shortest route.  Then collapse the left panel using the
+arrow on its right edge.
+
+**Criteria (total ~11 pts):**
+
+| # | Criterion | Event | Points |
+|---|-----------|-------|--------|
+| 1 | Select "Pike Place Market" from autocomplete (not Enter) | `autocomplete_select`, itemText contains "Pike Place Market" | 1.5 |
+| 2 | Click Directions in place panel | `click` on `#directions-btn` | 0.5 |
+| 3 | Panel transitions to directions state | `panel_state_change`, state = "directions" | 0.5 |
+| 4 | Enter and select "Space Needle" as origin | `autocomplete_select`, field = "origin", itemText contains "Space Needle" | 1.5 |
+| 5 | Select walking mode (icon-only, no text) | `transport_mode_select`, mode = "walk" | 2.0 |
+| 6 | Select the shortest route from results | `route_select`, routeIndex = shortest | 1.5 |
+| 7 | Collapse the left panel via edge arrow | `panel_collapse` | 1.5 |
+| 8 | Map viewport changes after collapse | `map_viewport_change` | 0.5 (optional) |
+
+Note: The walking icon is a small pedestrian silhouette among four icon-only
+buttons (car, bus, walk, bike).  The agent must identify it purely by shape.
+
+#### mapquest_nearby_pins.yaml — Very Hard
+
+**Instruction:** Search for "Pike Place Market" and select it from the
+autocomplete dropdown.  Then scroll the Nearby category bar to the right until
+you find the "Parking" chip (it is off-screen initially) and click it.
+Multiple parking pins will appear on the map.  Two pins are very close
+together — click specifically on "Pike Place Market Parking Garage" (NOT
+"Pacific Place Parking" which is the adjacent pin).  Once the correct detail
+panel opens, click "Directions" and set the origin to "Pike Place Market"
+(already searched).  Choose the driving mode.
+
+**Criteria (total ~13 pts):**
+
+| # | Criterion | Event | Points |
+|---|-----------|-------|--------|
+| 1 | Select "Pike Place Market" from autocomplete | `autocomplete_select`, itemText contains "Pike Place Market" | 1.0 |
+| 2 | Scroll the Nearby chip bar to reveal "Parking" | `chip_bar_scroll`, direction = "right" | 1.5 |
+| 3 | Click the "Parking" chip | `nearby_chip_select`, category = "parking" | 1.0 |
+| 4 | Click the correct parking pin (not the distractor) | `pin_click`, pinId = "pike-place-parking-garage" | 3.0 |
+| 5 | Verify correct panel content | `panel_state_change`, state = "place-detail", placeId = "pike-place-parking-garage" | 1.0 |
+| 6 | Click Directions from parking detail | `click` on `#directions-btn` | 0.5 |
+| 7 | Set origin to Pike Place Market | `autocomplete_select`, field = "origin", itemText contains "Pike Place Market" | 1.5 |
+| 8 | Choose driving mode (car icon) | `transport_mode_select`, mode = "drive" | 1.5 |
+| 9 | Route results display | `route_results_render` | 1.0 (optional) |
+
+---
+
+## 2. StayBnB — Airbnb mock
+
+**Directory:** `eval/staybnb/`
+**Difficulty:** Hard
+**Real-world model:** Airbnb (airbnb.com)
+
+### Why this is hard
+
+Airbnb's search flow chains several complex widgets in sequence: a location
+autocomplete, a **date-range calendar** (two-month view, click check-in then
+check-out), a guest counter with +/– steppers, and a faceted filter panel with
+price sliders and checkbox groups.  Each widget has precise click targets and
+stateful transitions.  A date-range calendar is one of the hardest standard UI
+patterns for a vision agent — the agent must click two specific dates across a
+grid of ~60 cells that all look alike.
+
+### Real layout to reproduce
+
+Current Airbnb desktop homepage has:
+
+- **Top-level category tabs**: "Homes", "Experiences" (switching changes the
+  page context — mock "Homes" only but show tabs as distractors).
+- **Search bar** as a segmented pill with three sections: "Where", "When",
+  "Who".  Clicking each section expands its popover below.
+- **"Where" popover**: text input with location autocomplete + "I'm flexible"
+  region grid below.
+- **"When" popover**: dual-month calendar with three sub-tabs: "Dates"
+  (specific), "Flexible", "Months".  Calendar shows two months side-by-side.
+  Some dates may be **disabled/grayed out** (unavailable).  Hover on a date
+  after check-in selection shows range preview.  Forward/back arrows navigate
+  months.
+- **"Who" popover**: stepper rows for Adults, Children, Infants, Pets.  Each
+  has +/– buttons.  Adults minimum is 1 (– button is disabled at 1).
+- **Search results page**: split layout — listing cards on the left, map on
+  the right.  Cards have image carousel (dots), title, type, price/night,
+  rating.  Hovering a card highlights its pin on the map.  Moving the map
+  surfaces new listings.
+- **Filter bar**: row of pill buttons ("Price", "Type of place", "Rooms and
+  beds", etc.) plus a "Filters" button that opens a full-screen modal.
+- **Filter modal**: price range with **dual-handle slider** (drag interaction),
+  property type chips, amenity checkboxes, "Instant Book" toggle.
+- **Listing detail page**: photo grid (1 large + 4 thumbnails), "Show all
+  photos" button opens fullscreen gallery.  Sticky booking card on right rail
+  shows dates, guests, price breakdown, and **"Reserve"** button.  Note:
+  "Reserve" may lead to "Confirm and pay" (instant book) or "Request to book"
+  — mock the instant-book path.
+- **Booking confirmation panel**: shows dates, guests, price breakdown, total.
+  "Confirm and pay" button completes the flow.
+
+### Behaviours to mock
+
+| Behaviour | Notes |
+|-----------|-------|
+| Segmented search pill | Three clickable segments ("Where", "When", "Who").  Only one popover open at a time.  Clicking a different segment closes the current popover and opens the new one. |
+| Location autocomplete | Text input in "Where" popover.  Suggestions appear below.  Also show "I'm flexible" region grid as distractor. |
+| Dual-month date-range calendar | Two-month side-by-side view inside "When" popover.  Sub-tabs: "Dates" / "Flexible" / "Months" (mock "Dates" as primary, others as distractors).  Click a date to set check-in, then click another to set check-out.  **Disabled dates** (grayed, unclickable) scattered in the calendar for realism.  Range preview on hover after first date selected.  Month navigation arrows. |
+| Guest stepper | +/– buttons per category (Adults, Children, Infants, Pets).  Adults ≥ 1 enforced (– disabled at 1).  Total guests displayed in the search pill. |
+| Listing card grid with map | Left column: 20+ listing cards with image, title, price, rating.  Right column: map with pins.  **Card-pin hover sync**: hovering a card highlights its map pin and vice versa. |
+| Image carousel on cards | Each listing card has 3–5 dots; left/right arrows appear on hover to cycle images.  Small, timing-sensitive targets. |
+| Filter modal with price slider | Full-screen overlay.  Dual-handle price slider: agent must **drag** min and max handles.  Below: property type chips, amenity checkboxes (10+), "Instant Book" toggle. |
+| Listing detail page | Photo grid (1 large + 4 small), "Show all photos" → fullscreen scrollable gallery.  Amenity list, reviews, host info.  Sticky booking card on right. |
+| Reserve → Confirm flow | Click "Reserve" → booking summary with price breakdown → "Confirm and pay" completes booking.  Two-step: Reserve first, then Confirm. |
+
+### Main challenges for the agent
+
+1. **Date-range calendar** — ~60 visually identical cells.  The agent must
+   navigate to the correct month (forward arrows), then click the exact date
+   for check-in, then a different date for check-out.  Disabled dates are
+   traps — clicking them does nothing.  This is the single hardest widget.
+2. **Dual-handle price slider** — the agent must drag (mousedown → mousemove →
+   mouseup) two separate handles on the same track.  The handles are ~16px
+   circles.  No existing eval site tests drag interaction.
+3. **Segmented search pill** — the popover switch behavior (click "When"
+   closes "Where" popover) is confusing if the agent doesn't understand that
+   only one section is active at a time.
+4. **Guest stepper precision** — +/– buttons are small (~24px).  The agent
+   must click the correct button for the correct guest type and may need
+   multiple clicks (e.g., 2 adults requires one extra + click since default
+   is 1).
+5. **Card-pin hover sync** — hovering a listing card changes the map; the
+   agent might get confused by the visual state change.
+6. **Two-step reserve** — "Reserve" doesn't immediately confirm; the agent
+   must also click "Confirm and pay".
+
+### Interaction types
+
+- Segmented pill navigation (popover switching)
+- Text input with autocomplete popover
+- Calendar date-cell clicking (two sequential picks across a grid)
+- Month navigation arrows
+- Stepper buttons (+/– click, repeated)
+- Drag interaction (dual-handle price slider)
+- Checkbox and toggle interactions
+- Card hover interactions (image carousel arrows, card-pin sync)
+- Modal open / scroll / close
+- Photo gallery scrolling
+- Multi-step form with state carry-over (search → filter → detail → reserve → confirm)
+
+### Test cases
+
+#### staybnb_search.yaml — Hard
+
+**Instruction:** On the StayBnB homepage, search for stays in "Tokyo" using
+the segmented search bar.  Click the "When" section, navigate forward to June
+2026 in the calendar (the default view shows the current month), and select
+June 10 as check-in and June 17 as check-out.  Note: some dates in the
+calendar are grayed out and unclickable — make sure to pick available dates.
+Then click the "Who" section and set 3 adults, 1 child, and 1 infant.  Click
+"Search".
+
+**Criteria (total ~11 pts):**
+
+| # | Criterion | Event | Points |
+|---|-----------|-------|--------|
+| 1 | Click "Where" and select "Tokyo" from autocomplete | `autocomplete_select`, value contains "Tokyo" | 1.0 |
+| 2 | Click "When" to open date picker | `search_section_click`, section = "when" | 0.5 |
+| 3 | Navigate calendar forward to June | `calendar_month_nav`, direction = "forward", count >= 1 | 1.0 |
+| 4 | Select check-in June 10 (avoid disabled dates) | `date_select`, role = "checkin", date = "2026-06-10" | 1.5 |
+| 5 | Select check-out June 17 | `date_select`, role = "checkout", date = "2026-06-17" | 1.5 |
+| 6 | Click "Who" to open guest stepper | `search_section_click`, section = "who" | 0.5 |
+| 7 | Increment adults to 3 (click + twice) | `guest_stepper_click`, guestType = "adults", finalCount = 3 | 1.0 |
+| 8 | Increment children to 1 | `guest_stepper_click`, guestType = "children", finalCount = 1 | 1.0 |
+| 9 | Increment infants to 1 | `guest_stepper_click`, guestType = "infants", finalCount = 1 | 1.0 |
+| 10 | Click Search | `search_submit` | 1.5 |
+
+Note: adults default to 1, so the agent must click + twice.  The calendar
+shows two months side-by-side; the agent must use the forward arrow to reach
+June if it's not already displayed.  Disabled (grayed) dates are traps.
+
+#### staybnb_book.yaml — Very Hard
+
+**Instruction:** On the StayBnB search results page (pre-loaded with Tokyo
+listings), open the "Filters" modal.  Drag the price slider to set a range of
+approximately $50–$150/night (the slider has two handles — drag both).
+Check the "Wifi" and "Kitchen" amenity checkboxes.  Toggle on "Instant Book".
+Apply filters.  From the filtered results, open the listing "Shibuya Loft with
+Skyline View".  Click "Show all photos" to open the fullscreen gallery and
+scroll through at least 5 photos.  Close the gallery, then click "Reserve"
+and complete the booking by clicking "Confirm and pay" on the confirmation
+panel.
+
+**Criteria (total ~15 pts):**
+
+| # | Criterion | Event | Points |
+|---|-----------|-------|--------|
+| 1 | Open filter modal | `filter_modal_open` | 0.5 |
+| 2 | Drag price min handle to ~$50 | `price_slider_change`, handle = "min", value within [40, 60] | 2.0 |
+| 3 | Drag price max handle to ~$150 | `price_slider_change`, handle = "max", value within [140, 160] | 2.0 |
+| 4 | Check "Wifi" amenity | `amenity_toggle`, amenity = "wifi", checked = true | 0.5 |
+| 5 | Check "Kitchen" amenity | `amenity_toggle`, amenity = "kitchen", checked = true | 0.5 |
+| 6 | Toggle "Instant Book" on | `instant_book_toggle`, checked = true | 0.5 |
+| 7 | Apply filters | `filter_apply` | 0.5 |
+| 8 | Open "Shibuya Loft" listing | `listing_open`, listingId = "shibuya-loft" | 1.0 |
+| 9 | Click "Show all photos" | `gallery_open`, listingId = "shibuya-loft" | 1.0 |
+| 10 | Scroll through gallery (5+ photos viewed) | `gallery_scroll`, photos_viewed >= 5 | 1.5 |
+| 11 | Close gallery | `gallery_close` | 0.5 |
+| 12 | Click Reserve | `reserve_click`, listingId = "shibuya-loft" | 1.5 |
+| 13 | Click Confirm and pay | `booking_confirm`, listingId = "shibuya-loft" | 3.0 |
+
+Note: the dual-handle price slider is the hardest element — the agent must
+perform drag (mousedown + mousemove + mouseup) on two separate 16px handles.
+The "Confirm and pay" step is a distinct second action after "Reserve" — the
+agent must not assume Reserve alone completes the booking.
+
+---
+
+## 3. TaskFlow — Trello mock
+
+**Directory:** `eval/taskflow/`
+**Difficulty:** Medium → Hard
+**Real-world model:** Trello (trello.com)
+
+### Why this is hard
+
+Trello's core interaction is **drag-and-drop**, which no existing eval site
+tests.  The agent must mousedown on a card, hold, move to a different column,
+and mouseup to drop.  This is a fundamentally different interaction primitive
+from click or type.  Beyond drag-and-drop, the agent must handle inline
+editing (click-to-edit title), card detail modals with checklists, and label
+assignment from a color palette popover.
+
+### Real layout to reproduce
+
+Trello desktop board has two header bars plus the board body:
+
+- **Global header** (top): app switcher, Trello logo, search box, Create
+  button, notifications bell, user avatar.
+- **Board header** (below global): board name (editable), star toggle,
+  visibility indicator, board members (avatars), Power-Ups button, Automation
+  button, Filter button, "..." board menu.  The board menu is a slide-in right
+  panel (steals horizontal space from board body when open).
+- **Board body**: horizontally scrollable strip of **lists** (columns).  Each
+  list has a header (list name, "..." menu), vertically stacked cards, and an
+  "Add a card" footer.
+- **Card anatomy**: title text, optional colored label chips (top), optional
+  badges (due date, checklist progress, comment count, attachment count).
+  **Hover reveals a pencil icon** (quick-edit) in the top-right corner of the
+  card — this is hidden by default.
+- **Card-back modal** (click a card): title (click-to-edit), description
+  (click-to-edit), activity/comments.  Right sidebar: "Add" section (Members,
+  Labels, Checklist, Dates, Attachment, Cover).  "Actions" section (Move,
+  Copy, Archive).  New layout: "Add" is under title, "Actions" at top-right.
+- **Label picker popover**: click "Labels" in card-back → popover with 6
+  colored swatches (green, yellow, orange, red, purple, blue).  Labels have
+  **no text names by default** — agent must pick by color.  Click to toggle.
+- **Checklist**: inside card-back.  Items with checkboxes.  Progress bar at
+  top.  "Add an item" input at bottom.
+- **Drag feedback**: dragged card becomes semi-transparent with a shadow.  A
+  **placeholder gap** appears at the drop position.  **Auto-scroll** triggers
+  when the cursor nears the left/right edges of the board.
+
+### Behaviours to mock
+
+| Behaviour | Notes |
+|-----------|-------|
+| Kanban board with 4 columns | "To Do", "In Progress", "Review", "Done".  Each column has 4–5 cards. |
+| Card drag-and-drop | mousedown on card → card lifts with shadow, becomes semi-transparent → mousemove to target column → placeholder gap appears → mouseup to drop.  Auto-scroll near edges. |
+| Hover-reveal pencil (quick-edit) | Pencil icon hidden by default; appears on card hover in top-right corner.  Clicking it opens inline title edit + label/member quick-assign. |
+| Card-back modal | Click a card to open.  Title: click-to-edit.  Description: click-to-edit.  Checklist with checkable items.  Label picker.  Member assignment.  Due date.  "Archive" button. |
+| Inline card creation | "Add a card" button at bottom of each column.  Click → textarea appears inline → type title → Enter or "Add Card" button. |
+| Label picker popover — color-only | 6 colored swatches, no text names.  Click to toggle on/off.  Selected labels show a checkmark overlay. |
+| Checklist interaction | Items with checkboxes.  Progress bar updates.  "Add an item" text input at bottom.  Agent must check specific items and add new ones. |
+| Board menu side panel | "..." button opens a right-side panel that **steals horizontal space** from the board.  This can push rightmost columns partially off-screen. |
+| Card title inline edit | In card-back: click title text → text becomes an input → type → click away or press Enter to save. |
+| Board filter bar | Filter button opens a filter popover.  Filter by label color, member, due date.  Filtering dims non-matching cards (they are still visible but grayed out). |
+
+### Main challenges for the agent
+
+1. **Drag-and-drop** — requires coordinated mousedown → mousemove → mouseup
+   across different DOM elements.  The agent must identify source card and
+   target column precisely.  The placeholder gap and auto-scroll add visual
+   state that the agent must interpret correctly.  This is the single most
+   important missing interaction pattern in the current eval suite.
+2. **Hover-reveal pencil** — the quick-edit icon is **invisible until hover**.
+   The agent must know to hover a card to reveal it.  This is similar to
+   YouTube's auto-hide control bar but on individual cards.
+3. **Inline editing** — no visible input field until the agent clicks.  Both
+   the card title in the modal and the "Add a card" flow use click-to-reveal
+   inputs.
+4. **Color-only label picker** — labels are pure color swatches with no text;
+   the agent must pick by color (e.g., "assign the red label").  Selected
+   labels have a subtle checkmark overlay that may be hard to distinguish.
+5. **Board menu steals space** — opening the board menu pushes columns
+   partially off-screen, changing the visual layout.  The agent must handle
+   this gracefully.
+
+### Interaction types
+
+- Drag-and-drop (mousedown + mousemove + mouseup)
+- Hover-to-reveal (pencil icon on card hover)
+- Click-to-edit inline fields (title, description)
+- Modal open / close
+- Checkbox toggling (checklist items)
+- Color-swatch selection (visual-only, no text)
+- Inline form creation (add card)
+- Popover menus (label picker, card menu)
+- Side panel that changes board layout
+- Board-level filtering (dims non-matching cards)
+
+### Test cases
+
+#### taskflow_drag_and_edit.yaml — Hard
+
+**Instruction:** On the TaskFlow board, drag the card "Write unit tests" from
+"To Do" and drop it into the "In Progress" column.  Then open the card
+"Design API schema" (in "In Progress") by clicking it.  In the card-back
+modal, check off the checklist item "Define endpoints" and add a new checklist
+item "Add rate limiting".  Then close the modal.  Finally, hover over the
+card "Deploy staging build" in the "Review" column to reveal the pencil
+quick-edit icon, and click it to rename the card to "Deploy production build".
+
+**Criteria (total ~12 pts):**
+
+| # | Criterion | Event | Points |
+|---|-----------|-------|--------|
+| 1 | Drag "Write unit tests" | `card_drag_start`, cardTitle = "Write unit tests", fromColumn = "To Do" | 1.0 |
+| 2 | Drop in "In Progress" | `card_drop`, cardTitle = "Write unit tests", toColumn = "In Progress" | 2.5 |
+| 3 | Open "Design API schema" card-back | `card_modal_open`, cardTitle = "Design API schema" | 0.5 |
+| 4 | Check "Define endpoints" | `checklist_check`, itemText = "Define endpoints", checked = true | 1.5 |
+| 5 | Add "Add rate limiting" checklist item | `checklist_add_submit`, itemText contains "rate limiting" | 1.5 |
+| 6 | Close card-back modal | `card_modal_close` | 0.5 |
+| 7 | Hover "Deploy staging build" to reveal pencil | `card_hover_edit_reveal`, cardTitle = "Deploy staging build" | 1.5 |
+| 8 | Click pencil to enter quick-edit | `card_quick_edit_open`, cardTitle = "Deploy staging build" | 1.0 |
+| 9 | Rename to "Deploy production build" | `card_quick_edit_save`, newTitle = "Deploy production build" | 1.5 |
+
+Note: the pencil icon is invisible until hover — the agent must move the
+cursor over the card to reveal it, then click it before moving away.
+
+#### taskflow_full_workflow.yaml — Very Hard
+
+**Instruction:** Create a new card in the "Review" column titled "Security
+audit".  Open the card-back, assign the red label (fourth color swatch from
+left — there are no text names, only colors), add a new checklist item "Run
+OWASP scan" and check it off.  Close the card-back.  Then drag "Security
+audit" from "Review" to "Done".  After dropping it, open the board menu
+(the "..." button in the board header) — note that this slides in a panel
+from the right that shrinks the board.  Use the filter in the board menu to
+filter by the red label, confirming that only red-labeled cards remain fully
+visible (others should be dimmed).
+
+**Criteria (total ~14 pts):**
+
+| # | Criterion | Event | Points |
+|---|-----------|-------|--------|
+| 1 | Click "Add a card" in Review | `add_card_click`, column = "Review" | 0.5 |
+| 2 | Type and submit "Security audit" | `card_create_submit`, cardTitle = "Security audit", column = "Review" | 1.0 |
+| 3 | Open card-back | `card_modal_open`, cardTitle = "Security audit" | 0.5 |
+| 4 | Open label picker | `label_picker_open` | 0.5 |
+| 5 | Assign red label (4th swatch, color-only) | `label_assign`, color = "red" | 1.5 |
+| 6 | Add checklist item "Run OWASP scan" | `checklist_add_submit`, itemText contains "OWASP" | 1.0 |
+| 7 | Check off the item | `checklist_check`, itemText contains "OWASP", checked = true | 1.0 |
+| 8 | Close card-back | `card_modal_close` | 0.5 |
+| 9 | Drag "Security audit" from Review | `card_drag_start`, cardTitle = "Security audit", fromColumn = "Review" | 1.0 |
+| 10 | Drop in Done | `card_drop`, cardTitle = "Security audit", toColumn = "Done" | 2.0 |
+| 11 | Open board menu ("...") | `board_menu_open` | 0.5 |
+| 12 | Board menu steals horizontal space | `board_layout_shift` | 0.5 (optional) |
+| 13 | Apply filter by red label | `board_filter_apply`, filterType = "label", color = "red" | 2.0 |
+| 14 | Non-matching cards are dimmed | `board_filter_active`, matchingCards >= 1 | 0.5 (optional) |
+
+Note: the board menu opening changes the board width, potentially shifting
+columns.  The label picker shows 6 color swatches with no text — "red" is
+positional (4th from left: green, yellow, orange, red, purple, blue).
+
+---
+
+## 4. VidHub — YouTube mock
+
+**Directory:** `eval/vidhub/`
+**Difficulty:** Medium → Hard
+**Real-world model:** YouTube (youtube.com)
+
+### Why this is hard
+
+YouTube combines a recommendation feed, video player controls, and a social
+interaction layer.  The main challenge is **video player interaction**: the
+agent must operate a custom player control bar that **auto-hides on idle** —
+small, icon-only targets on a dark bar overlaid on video content.  The
+timeline scrub requires a click on a thin (~4px) progress bar that only
+thickens to ~8px on hover.  The comment section is below the fold and has
+nested reply threads.
+
+### Real layout to reproduce
+
+YouTube desktop has:
+
+- **Fixed masthead** (top): hamburger menu, YouTube logo, search box (center,
+  with voice search mic icon), Create button, notifications bell, user avatar.
+- **Home feed** (default page): grid of video thumbnail cards.  Each card has
+  thumbnail (with duration badge), title, channel name + avatar, view count,
+  upload age.  Thumbnail hover shows animated preview (mock as a slight
+  overlay change).
+- **Video watch page** (click a video):
+  - **Player area** (top-left, dominant): video poster/frame with overlaid
+    control bar at bottom.
+  - **Control bar elements** (left to right): play/pause, next, volume
+    icon + hover-reveal slider, current time / duration, progress bar
+    (thin line, full width, clickable + draggable scrubber dot), CC button,
+    settings gear, theater mode, miniplayer, fullscreen.
+    - The bar **auto-hides after 3s of inactivity**.  Hovering/clicking the
+      video area reveals it.
+    - **Settings gear** opens a nested popup: Playback speed (submenu),
+      Quality (submenu), Subtitles/CC.  Nested — clicking "Playback speed"
+      opens a second-level menu inside the same popup.
+    - **Autoplay toggle** is at the bottom of the player area.
+  - **Below player** (left column): video title, channel avatar + name +
+    subscriber count + "Subscribe" button (red → gray on click), like/dislike
+    buttons (icon + count), Share button, "...more" overflow, Save button.
+  - **Description** (expandable): truncated by default, "...more" link expands
+    full description.
+  - **Comment section** (below description): comment count, sort dropdown
+    ("Top comments" / "Newest first"), comment input field at top.  Each
+    comment has: avatar, name, timestamp, text, like button + count, dislike,
+    reply button, "N replies" expand link.
+  - **Reply thread**: clicking "N replies" expands nested replies below the
+    parent comment.  Reply input appears when clicking "Reply" on a specific
+    comment.
+  - **Right sidebar**: recommended/up-next video cards (thumbnail + title +
+    channel + view count).
+
+### Behaviours to mock
+
+| Behaviour | Notes |
+|-----------|-------|
+| Home feed grid | Video thumbnail cards with title, channel, views, age.  Clicking a card navigates to watch page. |
+| Search with results | Search box in masthead.  Enter triggers search results page.  Filter chips below results: "Today", "This week", "4–20 minutes", etc. |
+| Video player with auto-hide controls | Poster image + control overlay.  Controls appear on hover/click, **hide after 3s idle**.  Agent must hover to reveal, then act before they hide. |
+| Play/pause toggle | Single button, icon changes between play (▶) and pause (❚❚).  No text label. |
+| Timeline progress bar | Thin red line (~4px height, thickens to ~8px on hover).  Clickable to seek.  Draggable scrubber dot.  Hover shows timestamp tooltip. |
+| Volume: click to mute + hover to reveal slider | Volume icon click toggles mute.  Hovering the icon **reveals a horizontal slider** (hidden by default).  Agent must hover to see the slider, then drag or click it. |
+| Settings — nested popup | Gear icon opens popup.  Items: "Playback speed", "Quality", "Subtitles/CC".  Clicking an item opens a **second-level submenu** inside the same popup (e.g., speed options: 0.25x, 0.5x, Normal, 1.25x, 1.5x, 2x).  Agent must navigate two popup levels. |
+| Like / Dislike | Icon-only buttons below video.  Like fills blue on click, count increments.  Dislike has no visible count. |
+| Subscribe button | Red "Subscribe" → gray "Subscribed" on click.  Has bell icon for notifications. |
+| Description expand/collapse | "...more" link expands truncated description.  "Show less" collapses. |
+| Comment sort dropdown | "Top comments" / "Newest first" dropdown at top of comment section. |
+| Comment reply thread expand | "N replies" link expands nested replies.  Each reply has its own like/reply affordances. |
+| Comment reply input | Click "Reply" on a comment → nested input field appears below that comment.  Submit button. |
+| Recommended sidebar | Right column on watch page.  Video cards.  Clicking navigates to a different video (watch page reloads). |
+
+### Main challenges for the agent
+
+1. **Control bar auto-hide** — controls disappear after 3s.  The agent must
+   hover the player area to reveal controls, then click the target button
+   before they hide again.  If the agent is too slow, controls disappear
+   mid-action.
+2. **Timeline scrub precision** — the progress bar is a thin line; the agent
+   must click at a specific horizontal percentage (e.g., "skip to halfway").
+   The scrubber dot is ~12px.  The bar thickens on hover but is very thin
+   otherwise.
+3. **Volume hover-reveal slider** — the volume slider is invisible until the
+   agent hovers the volume icon.  Two-step interaction: hover to reveal, then
+   interact with the slider.
+4. **Nested settings popup** — settings opens a popup, and sub-items open a
+   second-level popup.  The agent must navigate into the correct submenu and
+   select an option, all within a single popup flow.
+5. **Scroll-to-comments** — the comment section is below the fold; the agent
+   must scroll past video metadata, description, and possibly ads to reach it.
+6. **Nested reply threads** — expanding replies and then replying within the
+   thread requires navigating nested, dynamically-appearing UI elements.
+7. **Icon-only player buttons** — play, pause, volume, CC, settings,
+   fullscreen are all icons with no text labels.
+
+### Interaction types
+
+- Hover-to-reveal (control bar, volume slider)
+- Auto-hide timing (3s control bar)
+- Icon-only button clicks (player controls)
+- Progress bar click / drag (timeline seek)
+- Hover-reveal slider (volume)
+- Nested popup navigation (settings → submenu)
+- Toggle buttons (play/pause, like, subscribe)
+- Scroll to off-screen content (comments)
+- Expand/collapse (description, reply threads)
+- Nested comment reply with text input
+- Sort dropdown
+- Search with filter chips
+- Sidebar card navigation
+
+### Test cases
+
+#### vidhub_player.yaml — Hard
+
+**Instruction:** On the VidHub homepage, search for "machine learning
+tutorial" and open the first result.  On the video page, hover over the player
+area to reveal the control bar (it auto-hides after 3 seconds), then click
+play.  Seek to approximately the 75% mark on the timeline by clicking the
+progress bar.  Then open the Settings menu (gear icon) and navigate into the
+"Playback speed" submenu to select "1.5x".  Finally, like the video and
+subscribe to the channel.
+
+**Criteria (total ~12 pts):**
+
+| # | Criterion | Event | Points |
+|---|-----------|-------|--------|
+| 1 | Search and submit query | `search_submit`, query contains "machine learning" | 0.5 |
+| 2 | Open first result | `video_open`, videoId = target | 0.5 |
+| 3 | Hover player to reveal controls | `player_controls_show` | 1.0 |
+| 4 | Click play (icon-only) | `player_play` | 1.0 |
+| 5 | Seek to ~75% on thin progress bar | `player_seek`, position within [0.60, 0.90] | 2.0 |
+| 6 | Open Settings (gear icon, icon-only) | `settings_open` | 1.0 |
+| 7 | Navigate to Playback speed submenu | `settings_submenu_open`, submenu = "playback-speed" | 1.5 |
+| 8 | Select 1.5x speed | `playback_speed_change`, speed = 1.5 | 1.5 |
+| 9 | Like the video (icon-only) | `video_like`, videoId = target | 1.5 |
+| 10 | Subscribe to channel | `channel_subscribe`, channelId = target | 1.5 |
+
+Note: the control bar hides after 3s of inactivity — the agent must hover to
+re-reveal it for each player interaction.  The settings gear opens a popup,
+and "Playback speed" opens a nested second-level submenu within that popup.
+All player buttons are icon-only with no text labels.
+
+#### vidhub_comment.yaml — Very Hard
+
+**Instruction:** Navigate to the video "Understanding Transformers — Visual
+Guide" from the homepage feed.  First, expand the video description by
+clicking "...more" below the title.  Then scroll down past the description to
+the comments section.  Change the comment sort to "Newest first" using the
+dropdown.  Find the comment by "Dr. Sarah Chen" (you may need to scroll within
+the comments).  Expand her reply thread by clicking "4 replies".  Reply to her
+comment with a message that includes the phrase "attention mechanism".  After
+submitting the reply, scroll back up and hover over the player to reveal
+controls, then hover over the volume icon to reveal the volume slider and
+adjust it to approximately 50%.
+
+**Criteria (total ~15 pts):**
+
+| # | Criterion | Event | Points |
+|---|-----------|-------|--------|
+| 1 | Open target video from feed | `video_open`, videoId = "transformers-visual-guide" | 0.5 |
+| 2 | Expand description ("...more") | `description_expand` | 1.0 |
+| 3 | Scroll to comments section | `comments_section_visible` | 0.5 |
+| 4 | Open sort dropdown | `comment_sort_open` | 0.5 |
+| 5 | Select "Newest first" | `comment_sort_change`, sort = "newest" | 1.0 |
+| 6 | Locate Dr. Sarah Chen's comment | `comment_visible`, authorName = "Dr. Sarah Chen" | 1.0 |
+| 7 | Expand "4 replies" thread | `reply_thread_expand`, parentCommentAuthor = "Dr. Sarah Chen" | 1.5 |
+| 8 | Click Reply on her comment | `reply_click`, parentCommentAuthor = "Dr. Sarah Chen" | 1.0 |
+| 9 | Type reply with "attention mechanism" | `reply_input`, value_contains = "attention mechanism" | 1.5 |
+| 10 | Submit reply | `reply_submit`, parentCommentAuthor = "Dr. Sarah Chen" | 2.0 |
+| 11 | Scroll back up to player area | `player_area_visible` (scroll up) | 0.5 |
+| 12 | Hover player to reveal controls | `player_controls_show` | 0.5 |
+| 13 | Hover volume icon to reveal slider | `volume_slider_reveal` | 1.5 |
+| 14 | Adjust volume to ~50% | `volume_change`, level within [0.35, 0.65] | 2.0 |
+
+Note: this test combines scroll-down + interact + scroll-back-up + hover-reveal
+patterns.  The volume slider is hidden until the agent hovers the volume icon —
+a two-step hover-then-interact sequence.  The reply thread is nested and only
+appears after clicking "4 replies".
+
+---
+
+## Summary
+
+| Site | Mocks | Dir | Difficulty | Primary challenge | Key missing pattern filled |
+|------|-------|-----|------------|-------------------|--------------------------|
+| MapQuest | Google Maps | `eval/mapquest/` | Hard | Autocomplete timing, icon-only transport buttons, ambiguous spatial pins, panel state transitions | Autocomplete, spatial clicks, icon-only UI, panel-state (not page) nav |
+| StayBnB | Airbnb | `eval/staybnb/` | Hard → Very Hard | Date-range calendar, dual-handle price slider drag, segmented search pill, multi-step booking | Date picker, drag interaction, stepper precision, sequential checkout |
+| TaskFlow | Trello | `eval/taskflow/` | Medium → Hard | Drag-and-drop cards, hover-reveal pencil, color-only labels, inline edit, board menu space theft | Drag-and-drop, hover-to-reveal, inline editing, color-swatch selection |
+| VidHub | YouTube | `eval/vidhub/` | Medium → Hard | Auto-hide control bar, timeline scrub, nested settings popup, volume hover-reveal, nested reply threads | Auto-hide timing, media controls, nested popups, hover-reveal slider |
+
+### Implementation order (suggested)
+
+1. **TaskFlow** — cleanest scope, drag-and-drop is the highest-value missing
+   primitive
+2. **VidHub** — well-defined layout, player controls and auto-hide are a clear
+   gap
+3. **MapQuest** — spatial UI adds visual complexity, panel-state transitions
+   are novel
+4. **StayBnB** — most widgets, most test-case points, hardest date picker
+   challenge, builds on patterns from the others

--- a/eval/amazon/css/amazon.css
+++ b/eval/amazon/css/amazon.css
@@ -1,0 +1,175 @@
+.amazon-body {
+  --mock-accent: #ff9900;
+  --mock-accent-soft: rgba(255, 153, 0, 0.16);
+  background:
+    radial-gradient(circle at top right, rgba(255, 239, 214, 0.95), transparent 30%),
+    linear-gradient(180deg, #fffaf1, #f7f0e4 40%, #f3ede3 100%);
+}
+
+.amazon-topbar {
+  display: grid;
+  grid-template-columns: 240px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 18px;
+  padding: 16px 24px;
+}
+
+.amazon-brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-weight: 800;
+}
+
+.amazon-brand-mark {
+  display: grid;
+  place-items: center;
+  width: 42px;
+  height: 42px;
+  border-radius: 14px;
+  background: linear-gradient(135deg, #ffeac3, #ffffff);
+  border: 1px solid rgba(255, 153, 0, 0.18);
+  color: #8a5a00;
+}
+
+.amazon-shell {
+  padding: 22px 24px 30px;
+}
+
+.amazon-search-card,
+.amazon-results,
+.amazon-product,
+.amazon-cart,
+.amazon-checkout,
+.amazon-confirmation {
+  padding: 18px;
+}
+
+.amazon-search-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  gap: 12px;
+  align-items: end;
+}
+
+.amazon-layout {
+  display: grid;
+  grid-template-columns: 280px minmax(0, 1fr);
+  gap: 18px;
+}
+
+.amazon-sidebar {
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.amazon-result-list,
+.amazon-offer-list,
+.amazon-cart-list,
+.amazon-saved-list {
+  display: grid;
+  gap: 14px;
+}
+
+.amazon-result-card,
+.amazon-offer-card,
+.amazon-cart-card,
+.amazon-product-card {
+  padding: 16px;
+  border-radius: 20px;
+  border: 1px solid var(--mock-border);
+  background: rgba(255, 255, 255, 0.94);
+  display: grid;
+  gap: 10px;
+}
+
+.amazon-offer-card.selected {
+  border-color: rgba(255, 153, 0, 0.34);
+  background: rgba(255, 247, 231, 0.98);
+  box-shadow: 0 12px 24px rgba(255, 153, 0, 0.1);
+}
+
+.amazon-offer-selected,
+.amazon-buy-box-status {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: rgba(255, 153, 0, 0.14);
+  color: #8a5a00;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.amazon-result-head,
+.amazon-product-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 280px;
+  gap: 18px;
+}
+
+.amazon-result-title,
+.amazon-product-title {
+  font-weight: 800;
+  font-size: 22px;
+  line-height: 1.18;
+}
+
+.amazon-meta,
+.amazon-variant-grid,
+.amazon-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.amazon-variant-button.active,
+.amazon-address-button.active,
+.amazon-shipping-button.active,
+.amazon-payment-button.active {
+  background: rgba(255, 153, 0, 0.14);
+  border-color: rgba(255, 153, 0, 0.24);
+  color: #8a5a00;
+}
+
+.amazon-buy-box {
+  padding: 16px;
+  border-radius: 18px;
+  background: rgba(255, 153, 0, 0.08);
+  display: grid;
+  gap: 12px;
+}
+
+.amazon-checkout-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.amazon-step {
+  padding: 14px;
+  border-radius: 18px;
+  background: rgba(15, 23, 34, 0.03);
+}
+
+@media (max-width: 1180px) {
+  .amazon-layout,
+  .amazon-result-head,
+  .amazon-product-layout,
+  .amazon-checkout-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 900px) {
+  .amazon-topbar {
+    grid-template-columns: 1fr;
+  }
+
+  .amazon-search-row {
+    grid-template-columns: 1fr;
+  }
+}

--- a/eval/amazon/index.html
+++ b/eval/amazon/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Amazon Mock</title>
+  <link rel="stylesheet" href="/css/hard-mock-base.css">
+  <link rel="stylesheet" href="/amazon/css/amazon.css">
+</head>
+<body class="amazon-body">
+  <div id="app"></div>
+  <script src="/js/tracker.js"></script>
+  <script src="/js/hard-mock-core.js"></script>
+  <script src="/amazon/js/amazon.js"></script>
+</body>
+</html>

--- a/eval/amazon/js/amazon.js
+++ b/eval/amazon/js/amazon.js
@@ -400,17 +400,21 @@ window.tracker = new AgentTracker("amazon.com", "hard");
   }
 
   function renderCart(state) {
+    const primaryItems = state.cart.items.filter((item) => !item.accessory);
+    const accessoryItems = state.cart.items.filter((item) => item.accessory);
+
     return `
       <section class="amazon-cart mock-card">
         <div class="amazon-actions" style="justify-content: space-between; margin-bottom: 14px;">
           <div>
             <p class="mock-kicker">Cart</p>
-            <h2 class="mock-title">${state.cart.items.length} active item(s)</h2>
+            <h2 class="mock-title">${primaryItems.length} active item(s)</h2>
           </div>
           <button class="mock-btn-secondary" data-action="go-home">Keep shopping</button>
         </div>
         <div class="amazon-cart-list">
-          ${state.cart.items
+          ${primaryItems.length
+            ? primaryItems
             .map(
               (item) => `
                 <article class="amazon-cart-card">
@@ -425,8 +429,8 @@ window.tracker = new AgentTracker("amazon.com", "hard");
                 </article>
               `,
             )
-            .join("")}
-          ${state.cart.items.filter((item) => item.accessory).map((item) => "").join("")}
+            .join("")
+            : '<div class="mock-subtle">Your main cart is empty.</div>'}
         </div>
         <div style="margin-top: 18px;">
           <p class="mock-kicker">Saved for later</p>
@@ -450,8 +454,7 @@ window.tracker = new AgentTracker("amazon.com", "hard");
         <div style="margin-top: 18px;">
           <p class="mock-kicker">Accessories</p>
           <div class="amazon-saved-list">
-            ${state.cart.items
-              .filter((item) => item.accessory)
+            ${accessoryItems
               .map(
                 (item) => `
                   <article class="amazon-cart-card">
@@ -648,7 +651,15 @@ window.tracker = new AgentTracker("amazon.com", "hard");
     const offerId = state.selectedOfferId || product.offers[0]?.id || "";
     const itemId = `cart-${product.id}`;
     store.update((draft) => {
-      draft.cart.items = draft.cart.items.filter((item) => item.itemId !== itemId && item.productId !== product.id);
+      draft.cart.items = draft.cart.items.filter((item) => {
+        if (item.itemId === itemId || item.productId === product.id) {
+          return false;
+        }
+        if (product.autoAccessoryId && item.accessoryId === product.autoAccessoryId) {
+          return false;
+        }
+        return true;
+      });
       draft.cart.items.push({
         itemId,
         productId: product.id,
@@ -657,7 +668,10 @@ window.tracker = new AgentTracker("amazon.com", "hard");
         offerId,
         quantity: 1,
       });
-      if (product.autoAccessoryId) {
+      if (
+        product.autoAccessoryId &&
+        !draft.cart.removedAccessoryIds.includes(product.autoAccessoryId)
+      ) {
         draft.cart.items.push({
           itemId: `accessory-${product.autoAccessoryId}`,
           accessory: true,

--- a/eval/amazon/js/amazon.js
+++ b/eval/amazon/js/amazon.js
@@ -1,0 +1,971 @@
+window.tracker = new AgentTracker("amazon.com", "hard");
+
+(function () {
+  const { createSeededStore, escapeHtml, formatCurrency } = window.HardMockSite;
+
+  function createProduct(config) {
+    return {
+      id: config.id,
+      title: config.title,
+      queryTerms: config.queryTerms,
+      brand: config.brand,
+      sponsored: Boolean(config.sponsored),
+      variants: config.variants || {},
+      offers: config.offers || [],
+      autoAccessoryId: config.autoAccessoryId || null,
+      description: config.description,
+      price: config.price,
+    };
+  }
+
+  function buildSeedState() {
+    const products = [
+      createProduct({
+        id: "product-aurora-trail-shell",
+        title: "Aurora Trail Shell Jacket",
+        queryTerms: ["trail shell", "rain shell", "aurora shell"],
+        brand: "Aurora Ridge",
+        sponsored: false,
+        price: 189,
+        description: "Lightweight weather shell with color and size variants.",
+        autoAccessoryId: "acc-rain-care-kit",
+        variants: {
+          color: ["Canyon Red", "Glacier Blue", "Ink"],
+          size: ["S", "M", "L"],
+        },
+        offers: [
+          { id: "offer-aurora-default", seller: "Aurora Ridge", condition: "New", delivery: "Arrives tomorrow", price: 189 },
+        ],
+      }),
+      createProduct({
+        id: "product-aurora-trail-shell-sponsored",
+        title: "Aurora Trail Shells Clearance Bundle",
+        queryTerms: ["trail shell", "rain shell"],
+        brand: "Aurora Outlet",
+        sponsored: true,
+        price: 164,
+        description: "Sponsored decoy listing with bundle accessories.",
+        variants: {
+          color: ["Canyon Red"],
+          size: ["M"],
+        },
+        offers: [
+          { id: "offer-aurora-sponsored", seller: "Aurora Outlet", condition: "New", delivery: "Arrives next week", price: 164 },
+        ],
+      }),
+      createProduct({
+        id: "product-orbit-carry-on-spinner",
+        title: "Orbit Carry-On Spinner 20",
+        queryTerms: ["carry on spinner", "orbit luggage", "spinner"],
+        brand: "Orbit Line",
+        sponsored: false,
+        price: 134,
+        description: "Hard-shell carry-on with color variants.",
+        autoAccessoryId: "acc-packing-cubes-mini",
+        variants: {
+          color: ["Graphite", "Clay", "Midnight"],
+          size: ["20"],
+        },
+        offers: [
+          { id: "offer-orbit-default", seller: "Orbit Line", condition: "New", delivery: "Arrives in 2 days", price: 134 },
+        ],
+      }),
+      createProduct({
+        id: "product-north-lake-monitor-16",
+        title: "North Lake Portable Monitor 16",
+        queryTerms: ["portable monitor", "north lake monitor", "monitor 16"],
+        brand: "North Lake",
+        sponsored: false,
+        price: 259,
+        description: "Portable monitor with multiple seller offers and delivery differences.",
+        variants: {
+          finish: ["Matte Black", "Silver"],
+          size: ["16"],
+        },
+        offers: [
+          { id: "offer-monitor-harbor-tech-new", seller: "Harbor Tech", condition: "New", delivery: "Arrives tomorrow to Office Loft", price: 259 },
+          { id: "offer-monitor-harbor-tech-used", seller: "Harbor Tech", condition: "Used - Like New", delivery: "Arrives in 4 days", price: 219 },
+          { id: "offer-monitor-lumen-direct", seller: "Lumen Direct", condition: "New", delivery: "Arrives in 5 days", price: 248 },
+        ],
+      }),
+    ];
+
+    for (let index = 1; index <= 28; index += 1) {
+      products.push(
+        createProduct({
+          id: `product-seeded-${index}`,
+          title: `Seeded Product ${index}`,
+          queryTerms: ["outdoor", "daily use"],
+          brand: index % 2 ? "Seeded Goods" : "Metro Supply",
+          sponsored: index % 7 === 0,
+          price: 39 + index,
+          description: "Seeded result card for dense search pages.",
+          variants: {
+            style: ["Standard"],
+          },
+          offers: [
+            { id: `offer-seeded-${index}`, seller: "Marketplace", condition: "New", delivery: "Arrives later this week", price: 39 + index },
+          ],
+        }),
+      );
+    }
+
+    return {
+      products,
+      ui: {
+        surface: "home",
+        searchQuery: "",
+      },
+      filters: {
+        brand: "",
+        sponsoredOnly: false,
+      },
+      sort: "featured",
+      selectedProductId: null,
+      selectedVariant: {},
+      selectedOfferId: "",
+      offersOpen: false,
+      cart: {
+        items: [],
+        saved: [],
+        removedAccessoryIds: [],
+      },
+      checkout: {
+        addressId: "",
+        shippingOptionId: "",
+        paymentId: "",
+        checkoutPath: "",
+      },
+      confirmation: null,
+    };
+  }
+
+  const store = createSeededStore({
+    storageKey: "openbrowser.eval.amazon",
+    seedState: buildSeedState(),
+  });
+
+  const ADDRESSES = [
+    { id: "address-office-loft", label: "Office Loft", promise: "Next-day locker delivery" },
+    { id: "address-warehouse-annex", label: "Warehouse Annex", promise: "Two-day dock delivery" },
+  ];
+
+  const PAYMENTS = [
+    { id: "payment-visa-4242", label: "Visa ending 4242" },
+    { id: "payment-amex-1100", label: "Amex ending 1100" },
+  ];
+
+  const ACCESSORIES = {
+    "acc-rain-care-kit": "Rain Care Kit",
+    "acc-packing-cubes-mini": "Packing Cubes Mini",
+  };
+
+  const app = document.getElementById("app");
+
+  function getProduct(state, productId) {
+    return state.products.find((product) => product.id === productId) || null;
+  }
+
+  function getCurrentProduct(state) {
+    return getProduct(state, state.selectedProductId);
+  }
+
+  function getSearchResults(state) {
+    return state.products
+      .filter((product) => {
+        const query = state.ui.searchQuery.trim().toLowerCase();
+        if (!query) {
+          return false;
+        }
+        const matchesQuery = `${product.title} ${product.queryTerms.join(" ")}`.toLowerCase().includes(query);
+        if (!matchesQuery) {
+          return false;
+        }
+        if (state.filters.brand && product.brand !== state.filters.brand) {
+          return false;
+        }
+        if (state.filters.sponsoredOnly && !product.sponsored) {
+          return false;
+        }
+        return true;
+      })
+      .sort((left, right) => {
+        if (state.sort === "price-asc") {
+          return left.price - right.price;
+        }
+        return Number(right.sponsored) - Number(left.sponsored);
+      });
+  }
+
+  function getSelectedVariantId(state, product) {
+    if (!product) {
+      return "";
+    }
+    const parts = [];
+    Object.keys(product.variants).forEach((key) => {
+      const value = state.selectedVariant[key];
+      if (value) {
+        parts.push(value.toLowerCase().replace(/\s+/g, "-"));
+      }
+    });
+    return parts.join("__");
+  }
+
+  function renderTopbar(state) {
+    return `
+      <header class="mock-topbar">
+        <div class="amazon-topbar">
+          <div class="amazon-brand">
+            <div class="amazon-brand-mark">A</div>
+            <div>
+              <div>Retail Mock</div>
+              <div class="mock-subtle">Search noise, variant state, offers, cart recovery</div>
+            </div>
+          </div>
+          <div class="mock-subtle">The correct product may be hidden behind sponsored cards, the default variant can be wrong, and the safest checkout path is not always the most obvious button.</div>
+          <div style="display: flex; gap: 10px;">
+            <span class="mock-pill">30+ products</span>
+            <button class="mock-btn-secondary" data-action="open-cart">Cart (${state.cart.items.length})</button>
+          </div>
+        </div>
+      </header>
+    `;
+  }
+
+  function renderHome(state) {
+    return `
+      <section class="amazon-search-card mock-card">
+        <div>
+          <p class="mock-kicker">Search retail</p>
+          <h1 class="mock-title">Dense retail search with offers, cart recovery, and checkout state.</h1>
+        </div>
+        <div class="amazon-search-row">
+          <div>
+            <label class="mock-kicker" for="amazon-search-input">Search</label>
+            <input id="amazon-search-input" class="mock-input" value="${escapeHtml(state.ui.searchQuery)}" placeholder="Search products">
+          </div>
+          <button class="mock-btn-secondary" data-action="set-search-query" data-query="trail shell">Trail shell</button>
+          <button class="mock-btn" data-action="search-submit">Search</button>
+        </div>
+      </section>
+    `;
+  }
+
+  function renderResultCard(product) {
+    return `
+      <article class="amazon-result-card">
+        <div class="amazon-result-head">
+          <div>
+            <div class="amazon-result-title">${escapeHtml(product.title)}</div>
+            <div class="amazon-meta">
+              ${product.sponsored ? '<span class="mock-badge">Sponsored</span>' : ""}
+              <span class="mock-badge">${escapeHtml(product.brand)}</span>
+              <span class="mock-badge">${formatCurrency(product.price, "$")}</span>
+            </div>
+            <div class="mock-subtle">${escapeHtml(product.description)}</div>
+          </div>
+          <div class="amazon-actions">
+            <button class="mock-btn" data-action="open-product" data-product-id="${product.id}">Open product</button>
+          </div>
+        </div>
+      </article>
+    `;
+  }
+
+  function renderResults(state) {
+    const results = getSearchResults(state);
+    return `
+      <div class="amazon-layout">
+        <aside class="amazon-sidebar mock-card mock-sticky-panel">
+          <div>
+            <p class="mock-kicker">Filters</p>
+            <label class="mock-kicker" for="amazon-brand-filter">Brand</label>
+            <select id="amazon-brand-filter" class="mock-select">
+              <option value="">Any</option>
+              <option value="Aurora Ridge" ${state.filters.brand === "Aurora Ridge" ? "selected" : ""}>Aurora Ridge</option>
+              <option value="Orbit Line" ${state.filters.brand === "Orbit Line" ? "selected" : ""}>Orbit Line</option>
+              <option value="North Lake" ${state.filters.brand === "North Lake" ? "selected" : ""}>North Lake</option>
+            </select>
+          </div>
+          <label class="mock-pill" style="justify-content: flex-start;">
+            <input type="checkbox" id="amazon-sponsored-filter" ${state.filters.sponsoredOnly ? "checked" : ""}>
+            Sponsored only
+          </label>
+        </aside>
+        <section class="amazon-results mock-card">
+          <div class="amazon-actions" style="justify-content: space-between; margin-bottom: 14px;">
+            <div>
+              <p class="mock-kicker">Results</p>
+              <h2 class="mock-title">${results.length} products</h2>
+            </div>
+            <div class="amazon-actions">
+              <select id="amazon-sort" class="mock-select">
+                <option value="featured" ${state.sort === "featured" ? "selected" : ""}>Featured</option>
+                <option value="price-asc" ${state.sort === "price-asc" ? "selected" : ""}>Price: Low to High</option>
+              </select>
+            </div>
+          </div>
+          <div class="amazon-result-list">
+            ${results.map((product) => renderResultCard(product)).join("")}
+          </div>
+        </section>
+      </div>
+    `;
+  }
+
+  function renderProduct(state) {
+    const product = getCurrentProduct(state);
+    if (!product) {
+      return renderResults(state);
+    }
+
+    const hasExplicitOfferSelection = Boolean(state.selectedOfferId);
+    const variantId = getSelectedVariantId(state, product);
+    const selectedOffer = product.offers.find((offer) => offer.id === state.selectedOfferId) || product.offers[0];
+
+    return `
+      <section class="amazon-product mock-card">
+        <div class="amazon-product-layout">
+          <div class="amazon-product-card">
+            <div class="amazon-product-title">${escapeHtml(product.title)}</div>
+            <div class="amazon-meta">
+              <span class="mock-badge">${escapeHtml(product.brand)}</span>
+              <span class="mock-badge">${formatCurrency(product.price, "$")}</span>
+            </div>
+            <div class="mock-subtle">${escapeHtml(product.description)}</div>
+            ${Object.entries(product.variants)
+              .map(
+                ([key, values]) => `
+                  <div>
+                    <p class="mock-kicker">${escapeHtml(key)}</p>
+                    <div class="amazon-variant-grid">
+                      ${values
+                        .map(
+                          (value) => `
+                            <button class="mock-btn-secondary amazon-variant-button ${state.selectedVariant[key] === value ? "active" : ""}" data-action="select-variant" data-variant-key="${key}" data-variant-value="${value}">
+                              ${escapeHtml(value)}
+                            </button>
+                          `,
+                        )
+                        .join("")}
+                    </div>
+                  </div>
+                `,
+              )
+              .join("")}
+            <div class="amazon-actions">
+              <button class="mock-btn-secondary" data-action="open-offers">See all offers</button>
+            </div>
+            ${
+              state.offersOpen
+                ? `
+                  <div class="amazon-offer-list">
+                    ${product.offers
+                      .map(
+                        (offer) => {
+                          const isSelected = state.selectedOfferId === offer.id;
+                          return `
+                          <article class="amazon-offer-card ${isSelected ? "selected" : ""}">
+                            <div><strong>${escapeHtml(offer.seller)}</strong> · ${escapeHtml(offer.condition)}</div>
+                            <div class="mock-subtle">${escapeHtml(offer.delivery)}</div>
+                            ${isSelected ? '<div class="amazon-offer-selected">Selected offer</div>' : ""}
+                            <div class="amazon-actions">
+                              <button class="${isSelected ? "mock-btn" : "mock-btn-secondary"}" data-action="select-offer" data-offer-id="${offer.id}">${isSelected ? "Selected" : "Choose offer"}</button>
+                            </div>
+                          </article>
+                        `;
+                        },
+                      )
+                      .join("")}
+                  </div>
+                `
+                : ""
+            }
+          </div>
+          <aside class="amazon-buy-box">
+            <div class="mock-kicker">Buy box</div>
+            <div class="mock-title">${formatCurrency(selectedOffer.price, "$")}</div>
+            <div class="amazon-buy-box-status">${hasExplicitOfferSelection ? "Selected from offers" : "Default listing preview"}</div>
+            <div class="mock-subtle">${escapeHtml(selectedOffer.seller)} · ${escapeHtml(selectedOffer.condition)}</div>
+            <div class="mock-subtle">${escapeHtml(selectedOffer.delivery)}</div>
+            <div class="mock-subtle">Variant ID: ${escapeHtml(variantId || "default")}</div>
+            <div class="amazon-actions">
+              <button class="mock-btn" data-action="add-to-cart">Add to Cart</button>
+              <button class="mock-btn-secondary" data-action="buy-now">Buy Now</button>
+            </div>
+          </aside>
+        </div>
+      </section>
+    `;
+  }
+
+  function renderCart(state) {
+    return `
+      <section class="amazon-cart mock-card">
+        <div class="amazon-actions" style="justify-content: space-between; margin-bottom: 14px;">
+          <div>
+            <p class="mock-kicker">Cart</p>
+            <h2 class="mock-title">${state.cart.items.length} active item(s)</h2>
+          </div>
+          <button class="mock-btn-secondary" data-action="go-home">Keep shopping</button>
+        </div>
+        <div class="amazon-cart-list">
+          ${state.cart.items
+            .map(
+              (item) => `
+                <article class="amazon-cart-card">
+                  <div><strong>${escapeHtml(item.title)}</strong></div>
+                  <div class="mock-subtle">Variant: ${escapeHtml(item.variantId || "default")} · Offer: ${escapeHtml(item.offerId || "default")}</div>
+                  <div class="amazon-actions">
+                    <button class="mock-btn-secondary" data-action="qty-change" data-item-id="${item.itemId}" data-qty="${item.quantity - 1}">-</button>
+                    <span class="mock-pill">Qty ${item.quantity}</span>
+                    <button class="mock-btn-secondary" data-action="qty-change" data-item-id="${item.itemId}" data-qty="${item.quantity + 1}">+</button>
+                    <button class="mock-btn-secondary" data-action="save-for-later" data-item-id="${item.itemId}">Save for later</button>
+                  </div>
+                </article>
+              `,
+            )
+            .join("")}
+          ${state.cart.items.filter((item) => item.accessory).map((item) => "").join("")}
+        </div>
+        <div style="margin-top: 18px;">
+          <p class="mock-kicker">Saved for later</p>
+          <div class="amazon-saved-list">
+            ${state.cart.saved.length
+              ? state.cart.saved
+                  .map(
+                    (item) => `
+                      <article class="amazon-cart-card">
+                        <div><strong>${escapeHtml(item.title)}</strong></div>
+                        <div class="amazon-actions">
+                          <button class="mock-btn" data-action="restore-item" data-item-id="${item.itemId}">Restore</button>
+                        </div>
+                      </article>
+                    `,
+                  )
+                  .join("")
+              : '<div class="mock-subtle">Nothing saved yet.</div>'}
+          </div>
+        </div>
+        <div style="margin-top: 18px;">
+          <p class="mock-kicker">Accessories</p>
+          <div class="amazon-saved-list">
+            ${state.cart.items
+              .filter((item) => item.accessory)
+              .map(
+                (item) => `
+                  <article class="amazon-cart-card">
+                    <div><strong>${escapeHtml(item.title)}</strong></div>
+                    <div class="amazon-actions">
+                      <button class="mock-btn-danger" data-action="remove-accessory" data-item-id="${item.itemId}" data-accessory-id="${item.accessoryId}">Remove</button>
+                    </div>
+                  </article>
+                `,
+              )
+              .join("") || '<div class="mock-subtle">No accessory items.</div>'}
+          </div>
+        </div>
+        <div class="amazon-actions" style="margin-top: 18px;">
+          <button class="mock-btn" data-action="start-checkout">Proceed to checkout</button>
+        </div>
+      </section>
+    `;
+  }
+
+  function renderCheckout(state) {
+    const selectedAddress = ADDRESSES.find((address) => address.id === state.checkout.addressId);
+    const shippingOptions = selectedAddress?.id === "address-office-loft"
+      ? [
+          { id: "shipping-locker-next-day", label: "Next-day locker delivery" },
+          { id: "shipping-standard-office", label: "Standard office delivery" },
+        ]
+      : [
+          { id: "shipping-dock-two-day", label: "Two-day dock delivery" },
+          { id: "shipping-ground-warehouse", label: "Ground warehouse delivery" },
+        ];
+
+    return `
+      <section class="amazon-checkout mock-card">
+        <p class="mock-kicker">Checkout</p>
+        <h2 class="mock-title">Select address, shipping, and payment</h2>
+        <div class="amazon-checkout-grid">
+          <div class="amazon-step">
+            <div class="mock-kicker">Address</div>
+            ${ADDRESSES.map((address) => `
+              <button class="mock-btn-secondary amazon-address-button ${state.checkout.addressId === address.id ? "active" : ""}" style="width: 100%; margin-top: 10px;" data-action="select-address" data-address-id="${address.id}">
+                ${escapeHtml(address.label)}
+              </button>
+            `).join("")}
+          </div>
+          <div class="amazon-step">
+            <div class="mock-kicker">Shipping</div>
+            ${shippingOptions.map((option) => `
+              <button class="mock-btn-secondary amazon-shipping-button ${state.checkout.shippingOptionId === option.id ? "active" : ""}" style="width: 100%; margin-top: 10px;" data-action="select-shipping" data-shipping-id="${option.id}">
+                ${escapeHtml(option.label)}
+              </button>
+            `).join("")}
+          </div>
+          <div class="amazon-step">
+            <div class="mock-kicker">Payment</div>
+            ${PAYMENTS.map((payment) => `
+              <button class="mock-btn-secondary amazon-payment-button ${state.checkout.paymentId === payment.id ? "active" : ""}" style="width: 100%; margin-top: 10px;" data-action="select-payment" data-payment-id="${payment.id}">
+                ${escapeHtml(payment.label)}
+              </button>
+            `).join("")}
+          </div>
+        </div>
+        <div class="amazon-actions" style="margin-top: 18px;">
+          <button class="mock-btn" data-action="place-order">Place order</button>
+        </div>
+      </section>
+    `;
+  }
+
+  function renderConfirmation(state) {
+    return `
+      <section class="amazon-confirmation mock-card">
+        <p class="mock-kicker">Order placed</p>
+        <h2 class="mock-title">${escapeHtml(state.confirmation?.title || "")}</h2>
+        <div class="mock-subtle">Address: ${escapeHtml(state.confirmation?.addressId || "")}</div>
+        <div class="mock-subtle">Shipping: ${escapeHtml(state.confirmation?.shippingOptionId || "")}</div>
+        <div class="mock-subtle">Payment: ${escapeHtml(state.confirmation?.paymentId || "")}</div>
+      </section>
+    `;
+  }
+
+  function render() {
+    const state = store.getState();
+    let content = "";
+    if (state.ui.surface === "home") {
+      content = renderHome(state);
+    } else if (state.ui.surface === "results") {
+      content = renderResults(state);
+    } else if (state.ui.surface === "product") {
+      content = renderProduct(state);
+    } else if (state.ui.surface === "cart") {
+      content = renderCart(state);
+    } else if (state.ui.surface === "checkout") {
+      content = renderCheckout(state);
+    } else {
+      content = renderConfirmation(state);
+    }
+
+    app.innerHTML = `
+      <div class="mock-page">
+        ${renderTopbar(state)}
+        <main class="amazon-shell">
+          ${content}
+        </main>
+      </div>
+    `;
+  }
+
+  function searchSubmit() {
+    const state = store.getState();
+    tracker.track("amazon_search_execute", {
+      query: state.ui.searchQuery,
+    });
+    store.update((draft) => {
+      draft.ui.surface = "results";
+    });
+    render();
+  }
+
+  function openProduct(productId) {
+    const product = getProduct(store.getState(), productId);
+    if (!product) {
+      return;
+    }
+    store.update((state) => {
+      state.selectedProductId = product.id;
+      state.selectedOfferId = "";
+      state.selectedVariant = {};
+      state.offersOpen = false;
+      state.ui.surface = "product";
+    });
+    tracker.track("product_open", {
+      productId: product.id,
+    });
+    render();
+  }
+
+  function selectVariant(key, value) {
+    const state = store.getState();
+    const product = getCurrentProduct(state);
+    if (!product) {
+      return;
+    }
+    store.update((draft) => {
+      draft.selectedVariant[key] = value;
+    });
+    tracker.track("variant_select", {
+      productId: product.id,
+      variantKey: key,
+      variantValue: value,
+    });
+    render();
+  }
+
+  function openOffers() {
+    const state = store.getState();
+    const product = getCurrentProduct(state);
+    if (!product) {
+      return;
+    }
+    store.update((draft) => {
+      draft.offersOpen = !draft.offersOpen;
+    });
+    tracker.track("offer_open", {
+      productId: product.id,
+    });
+    render();
+  }
+
+  function selectOffer(offerId) {
+    const state = store.getState();
+    const product = getCurrentProduct(state);
+    if (!product) {
+      return;
+    }
+    store.update((draft) => {
+      draft.selectedOfferId = offerId;
+    });
+    tracker.track("offer_select", {
+      productId: product.id,
+      offerId,
+    });
+    render();
+  }
+
+  function addToCart(path) {
+    const state = store.getState();
+    const product = getCurrentProduct(state);
+    if (!product) {
+      return;
+    }
+
+    const variantId = getSelectedVariantId(state, product) || "default";
+    const offerId = state.selectedOfferId || product.offers[0]?.id || "";
+    const itemId = `cart-${product.id}`;
+    store.update((draft) => {
+      draft.cart.items = draft.cart.items.filter((item) => item.itemId !== itemId && item.productId !== product.id);
+      draft.cart.items.push({
+        itemId,
+        productId: product.id,
+        title: product.title,
+        variantId,
+        offerId,
+        quantity: 1,
+      });
+      if (product.autoAccessoryId) {
+        draft.cart.items.push({
+          itemId: `accessory-${product.autoAccessoryId}`,
+          accessory: true,
+          accessoryId: product.autoAccessoryId,
+          title: ACCESSORIES[product.autoAccessoryId],
+        });
+      }
+      draft.checkout.checkoutPath = path;
+      draft.ui.surface = path === "buy_now" ? "checkout" : "cart";
+    });
+
+    tracker.track("cart_add", {
+      productId: product.id,
+      variantId,
+      offerId,
+      checkoutPath: path,
+    });
+    render();
+  }
+
+  function changeQuantity(itemId, quantity) {
+    if (quantity < 1) {
+      return;
+    }
+    const state = store.getState();
+    const item = state.cart.items.find((entry) => entry.itemId === itemId && !entry.accessory);
+    if (!item) {
+      return;
+    }
+    store.update((draft) => {
+      const target = draft.cart.items.find((entry) => entry.itemId === itemId);
+      if (target) {
+        target.quantity = quantity;
+      }
+    });
+    tracker.track("cart_qty_change", {
+      productId: item.productId,
+      quantity,
+    });
+    render();
+  }
+
+  function saveForLater(itemId) {
+    const state = store.getState();
+    const item = state.cart.items.find((entry) => entry.itemId === itemId);
+    if (!item) {
+      return;
+    }
+    store.update((draft) => {
+      draft.cart.items = draft.cart.items.filter((entry) => entry.itemId !== itemId);
+      draft.cart.saved.push(item);
+    });
+    tracker.track("save_for_later", {
+      productId: item.productId,
+    });
+    render();
+  }
+
+  function restoreItem(itemId) {
+    const state = store.getState();
+    const item = state.cart.saved.find((entry) => entry.itemId === itemId);
+    if (!item) {
+      return;
+    }
+    store.update((draft) => {
+      draft.cart.saved = draft.cart.saved.filter((entry) => entry.itemId !== itemId);
+      draft.cart.items.push(item);
+      draft.ui.surface = "cart";
+    });
+    tracker.track("restore_from_saved", {
+      productId: item.productId,
+    });
+    render();
+  }
+
+  function removeAccessory(itemId, accessoryId) {
+    store.update((draft) => {
+      draft.cart.items = draft.cart.items.filter((entry) => entry.itemId !== itemId);
+      if (!draft.cart.removedAccessoryIds.includes(accessoryId)) {
+        draft.cart.removedAccessoryIds.push(accessoryId);
+      }
+    });
+    render();
+  }
+
+  function selectAddress(addressId) {
+    store.update((draft) => {
+      draft.checkout.addressId = addressId;
+      draft.checkout.shippingOptionId = "";
+    });
+    tracker.track("address_select", {
+      addressId,
+    });
+    render();
+  }
+
+  function selectShipping(shippingId) {
+    store.update((draft) => {
+      draft.checkout.shippingOptionId = shippingId;
+    });
+    tracker.track("shipping_option_select", {
+      shippingOptionId: shippingId,
+    });
+    render();
+  }
+
+  function selectPayment(paymentId) {
+    store.update((draft) => {
+      draft.checkout.paymentId = paymentId;
+    });
+    tracker.track("payment_select", {
+      paymentId,
+    });
+    render();
+  }
+
+  function placeOrder() {
+    const state = store.getState();
+    const mainItem = state.cart.items.find((item) => !item.accessory);
+    if (!mainItem) {
+      return;
+    }
+
+    tracker.track("place_order_click", {
+      productId: mainItem.productId,
+      variantId: mainItem.variantId,
+      offerId: mainItem.offerId,
+      quantity: mainItem.quantity,
+      removedAccessoryIds: state.cart.removedAccessoryIds.slice(),
+      addressId: state.checkout.addressId,
+      shippingOptionId: state.checkout.shippingOptionId,
+      paymentId: state.checkout.paymentId,
+      checkoutPath: state.checkout.checkoutPath || "cart",
+    });
+
+    store.update((draft) => {
+      draft.confirmation = {
+        title: mainItem.title,
+        addressId: draft.checkout.addressId,
+        shippingOptionId: draft.checkout.shippingOptionId,
+        paymentId: draft.checkout.paymentId,
+      };
+      draft.ui.surface = "confirmation";
+    });
+    render();
+  }
+
+  app.addEventListener("click", (event) => {
+    const target = event.target.closest("[data-action]");
+    if (!target) {
+      return;
+    }
+
+    const action = target.dataset.action;
+
+    if (action === "set-search-query") {
+      store.update((state) => {
+        state.ui.searchQuery = target.dataset.query;
+      });
+      render();
+      return;
+    }
+
+    if (action === "search-submit") {
+      searchSubmit();
+      return;
+    }
+
+    if (action === "open-product") {
+      openProduct(target.dataset.productId);
+      return;
+    }
+
+    if (action === "select-variant") {
+      selectVariant(target.dataset.variantKey, target.dataset.variantValue);
+      return;
+    }
+
+    if (action === "open-offers") {
+      openOffers();
+      return;
+    }
+
+    if (action === "select-offer") {
+      selectOffer(target.dataset.offerId);
+      return;
+    }
+
+    if (action === "add-to-cart") {
+      addToCart("cart");
+      return;
+    }
+
+    if (action === "buy-now") {
+      addToCart("buy_now");
+      return;
+    }
+
+    if (action === "open-cart") {
+      store.update((state) => {
+        state.ui.surface = "cart";
+      });
+      render();
+      return;
+    }
+
+    if (action === "qty-change") {
+      changeQuantity(target.dataset.itemId, Number(target.dataset.qty));
+      return;
+    }
+
+    if (action === "save-for-later") {
+      saveForLater(target.dataset.itemId);
+      return;
+    }
+
+    if (action === "restore-item") {
+      restoreItem(target.dataset.itemId);
+      return;
+    }
+
+    if (action === "remove-accessory") {
+      removeAccessory(target.dataset.itemId, target.dataset.accessoryId);
+      return;
+    }
+
+    if (action === "start-checkout") {
+      store.update((state) => {
+        state.ui.surface = "checkout";
+        if (!state.checkout.checkoutPath) {
+          state.checkout.checkoutPath = "cart";
+        }
+      });
+      render();
+      return;
+    }
+
+    if (action === "select-address") {
+      selectAddress(target.dataset.addressId);
+      return;
+    }
+
+    if (action === "select-shipping") {
+      selectShipping(target.dataset.shippingId);
+      return;
+    }
+
+    if (action === "select-payment") {
+      selectPayment(target.dataset.paymentId);
+      return;
+    }
+
+    if (action === "place-order") {
+      placeOrder();
+      return;
+    }
+
+    if (action === "go-home") {
+      store.update((state) => {
+        state.ui.surface = "home";
+      });
+      render();
+    }
+  });
+
+  app.addEventListener("input", (event) => {
+    if (event.target.id === "amazon-search-input") {
+      store.update((state) => {
+        state.ui.searchQuery = event.target.value;
+      });
+    }
+  });
+
+  app.addEventListener("change", (event) => {
+    if (event.target.id === "amazon-brand-filter") {
+      store.update((state) => {
+        state.filters.brand = event.target.value;
+      });
+      tracker.track("facet_select", {
+        facet: "brand",
+        value: event.target.value,
+      });
+      render();
+      return;
+    }
+
+    if (event.target.id === "amazon-sponsored-filter") {
+      store.update((state) => {
+        state.filters.sponsoredOnly = event.target.checked;
+      });
+      tracker.track("facet_select", {
+        facet: "sponsored",
+        value: String(event.target.checked),
+      });
+      render();
+      return;
+    }
+
+    if (event.target.id === "amazon-sort") {
+      store.update((state) => {
+        state.sort = event.target.value;
+      });
+      tracker.track("results_sort_apply", {
+        value: event.target.value,
+      });
+      render();
+    }
+  });
+
+  render();
+})();

--- a/eval/booking/css/booking.css
+++ b/eval/booking/css/booking.css
@@ -1,0 +1,246 @@
+.booking-body {
+  --mock-accent: #006ce4;
+  --mock-accent-soft: rgba(0, 108, 228, 0.12);
+  background:
+    radial-gradient(circle at top right, rgba(226, 238, 255, 0.95), transparent 30%),
+    linear-gradient(180deg, #f7faff, #eef4fb 42%, #edf2f8 100%);
+}
+
+.booking-topbar {
+  display: grid;
+  grid-template-columns: 240px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 18px;
+  padding: 16px 24px;
+}
+
+.booking-brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-weight: 800;
+}
+
+.booking-brand-mark {
+  display: grid;
+  place-items: center;
+  width: 42px;
+  height: 42px;
+  border-radius: 14px;
+  background: linear-gradient(135deg, #dfeaff, #ffffff);
+  color: var(--mock-accent);
+  border: 1px solid rgba(0, 108, 228, 0.12);
+}
+
+.booking-shell {
+  padding: 22px 24px 30px;
+}
+
+.booking-hero {
+  padding: 26px;
+  display: grid;
+  gap: 18px;
+}
+
+.booking-search-grid {
+  display: grid;
+  grid-template-columns: minmax(220px, 1.2fr) repeat(3, minmax(180px, 0.7fr)) auto;
+  gap: 12px;
+  align-items: end;
+}
+
+.booking-layout {
+  display: grid;
+  grid-template-columns: 300px minmax(0, 1fr);
+  gap: 18px;
+  align-items: start;
+}
+
+.booking-filters {
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.booking-results,
+.booking-property,
+.booking-checkout,
+.booking-compare,
+.booking-confirmation {
+  padding: 18px;
+}
+
+.booking-results-list,
+.booking-room-list {
+  display: grid;
+  gap: 14px;
+}
+
+.booking-property-card,
+.booking-room-card,
+.booking-compare-card {
+  padding: 16px;
+  border-radius: 20px;
+  border: 1px solid var(--mock-border);
+  background: rgba(255, 255, 255, 0.94);
+  display: grid;
+  gap: 10px;
+}
+
+.booking-property-top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 14px;
+}
+
+.booking-property-name {
+  font-size: 21px;
+  font-weight: 800;
+  line-height: 1.18;
+}
+
+.booking-score {
+  display: grid;
+  justify-items: end;
+  gap: 4px;
+}
+
+.booking-score-box {
+  padding: 8px 12px;
+  border-radius: 14px;
+  background: var(--mock-accent);
+  color: #fff;
+  font-weight: 800;
+}
+
+.booking-property-meta,
+.booking-room-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.booking-property-meta .mock-badge,
+.booking-room-meta .mock-badge {
+  background: rgba(0, 108, 228, 0.08);
+  color: var(--mock-accent);
+}
+
+.booking-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.booking-room-grid {
+  display: grid;
+  grid-template-columns: 1.1fr 0.9fr auto;
+  gap: 16px;
+  align-items: start;
+}
+
+.booking-room-slot {
+  padding: 10px 12px;
+  border-radius: 12px;
+  background: rgba(0, 108, 228, 0.06);
+  color: var(--mock-accent);
+  font-weight: 700;
+}
+
+.booking-property-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 320px;
+  gap: 18px;
+}
+
+.booking-summary-side {
+  padding: 16px;
+  display: grid;
+  gap: 12px;
+}
+
+.booking-form-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.booking-modal-calendar {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.booking-month {
+  border: 1px solid var(--mock-border);
+  border-radius: 18px;
+  padding: 14px;
+}
+
+.booking-day-grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 6px;
+}
+
+.booking-day {
+  display: grid;
+  place-items: center;
+  min-height: 40px;
+  border-radius: 12px;
+  border: 1px solid transparent;
+  background: rgba(15, 23, 34, 0.03);
+}
+
+.booking-day.active {
+  background: rgba(0, 108, 228, 0.12);
+  border-color: rgba(0, 108, 228, 0.22);
+  color: var(--mock-accent);
+  font-weight: 800;
+}
+
+.booking-counter-row {
+  display: grid;
+  grid-template-columns: 1fr auto auto auto;
+  gap: 12px;
+  align-items: center;
+  padding: 12px 0;
+  border-bottom: 1px solid var(--mock-border);
+}
+
+.booking-compare-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.booking-confirmation {
+  display: grid;
+  gap: 14px;
+}
+
+@media (max-width: 1200px) {
+  .booking-search-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .booking-property-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 940px) {
+  .booking-topbar {
+    grid-template-columns: 1fr;
+  }
+
+  .booking-layout,
+  .booking-compare-grid,
+  .booking-modal-calendar,
+  .booking-form-grid,
+  .booking-room-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/eval/booking/index.html
+++ b/eval/booking/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Booking Mock</title>
+  <link rel="stylesheet" href="/css/hard-mock-base.css">
+  <link rel="stylesheet" href="/booking/css/booking.css">
+</head>
+<body class="booking-body">
+  <div id="app"></div>
+  <script src="/js/tracker.js"></script>
+  <script src="/js/hard-mock-core.js"></script>
+  <script src="/booking/js/booking.js"></script>
+</body>
+</html>

--- a/eval/booking/js/booking.js
+++ b/eval/booking/js/booking.js
@@ -1,0 +1,1119 @@
+window.tracker = new AgentTracker("booking.com", "hard");
+
+(function () {
+  const { createSeededStore, escapeHtml, formatCurrency, uniqueSorted } = window.HardMockSite;
+
+  function createPlan(config) {
+    return {
+      id: config.id,
+      name: config.name,
+      breakfast: Boolean(config.breakfast),
+      freeCancellation: Boolean(config.freeCancellation),
+      occupancy: config.occupancy,
+      roomType: config.roomType,
+      price: config.price,
+      payment: config.payment || "Pay at property",
+      notes: config.notes || [],
+    };
+  }
+
+  function createProperty(config) {
+    return {
+      id: config.id,
+      name: config.name,
+      neighborhood: config.neighborhood,
+      reviewScore: config.reviewScore,
+      reviewText: config.reviewText,
+      description: config.description,
+      roomPlans: config.roomPlans || [],
+      badges: config.badges || [],
+    };
+  }
+
+  function buildSeedProperties() {
+    const properties = [
+      createProperty({
+        id: "property-castelo-river-house",
+        name: "Castelo River House",
+        neighborhood: "Baixa",
+        reviewScore: 9.1,
+        reviewText: "Exceptional",
+        description: "Quiet townhouse off the riverfront with breakfast slots and flexible cancellations on premium rooms.",
+        badges: ["River access", "Breakfast bar"],
+        roomPlans: [
+          createPlan({
+            id: "plan-castelo-deluxe-breakfast-flex",
+            name: "Deluxe Queen Balcony",
+            breakfast: true,
+            freeCancellation: true,
+            occupancy: 2,
+            roomType: "Queen",
+            price: 244,
+            notes: ["Breakfast included", "Free cancellation until Jun 12"],
+          }),
+          createPlan({
+            id: "plan-castelo-deluxe-breakfast-prepay",
+            name: "Deluxe Queen Balcony",
+            breakfast: true,
+            freeCancellation: false,
+            occupancy: 2,
+            roomType: "Queen",
+            price: 212,
+            notes: ["Breakfast included", "Non-refundable"],
+          }),
+        ],
+      }),
+      createProperty({
+        id: "property-castelo-river-houses",
+        name: "Castelo River Houses",
+        neighborhood: "Baixa",
+        reviewScore: 8.9,
+        reviewText: "Fabulous",
+        description: "Very similar branding, but only breakfast on prepaid rooms.",
+        badges: ["Flexible late check-in"],
+        roomPlans: [
+          createPlan({
+            id: "plan-castelo-houses-flex-no-breakfast",
+            name: "Superior Double",
+            breakfast: false,
+            freeCancellation: true,
+            occupancy: 2,
+            roomType: "Double",
+            price: 228,
+            notes: ["Free cancellation", "Breakfast not included"],
+          }),
+        ],
+      }),
+      createProperty({
+        id: "property-harborline-residence-chiado",
+        name: "Harborline Residence Chiado",
+        neighborhood: "Chiado",
+        reviewScore: 9.0,
+        reviewText: "Wonderful",
+        description: "Modern business-facing residence with strong breakfast and cancellation combinations.",
+        badges: ["Business lounge", "Walkable center"],
+        roomPlans: [
+          createPlan({
+            id: "plan-harborline-chiado-premium-flex-breakfast",
+            name: "Premium King with Courtyard View",
+            breakfast: true,
+            freeCancellation: true,
+            occupancy: 2,
+            roomType: "King",
+            price: 276,
+            notes: ["Breakfast included", "Free cancellation", "Pay at property"],
+          }),
+          createPlan({
+            id: "plan-harborline-chiado-studio-prepay",
+            name: "Compact Studio",
+            breakfast: true,
+            freeCancellation: false,
+            occupancy: 2,
+            roomType: "Studio",
+            price: 219,
+            notes: ["Breakfast included", "Prepay only"],
+          }),
+        ],
+      }),
+      createProperty({
+        id: "property-harborline-residences-chiado",
+        name: "Harborline Residences Chiado",
+        neighborhood: "Chiado",
+        reviewScore: 8.8,
+        reviewText: "Fabulous",
+        description: "Nearly identical name, but its flexible room lacks breakfast.",
+        badges: ["Shared lounge"],
+        roomPlans: [
+          createPlan({
+            id: "plan-harborline-residences-flex",
+            name: "Executive Double",
+            breakfast: false,
+            freeCancellation: true,
+            occupancy: 2,
+            roomType: "Double",
+            price: 241,
+            notes: ["Free cancellation", "Breakfast not included"],
+          }),
+        ],
+      }),
+      createProperty({
+        id: "property-miradouro-lane-hotel",
+        name: "Miradouro Lane Hotel",
+        neighborhood: "Alfama",
+        reviewScore: 9.2,
+        reviewText: "Exceptional",
+        description: "Family-friendly hilltop hotel with multi-room combinations and breakfast on the target offers.",
+        badges: ["Family stay", "Breakfast included"],
+        roomPlans: [
+          createPlan({
+            id: "plan-miradouro-family-loft-flex-breakfast",
+            name: "Family Loft with Terrace",
+            breakfast: true,
+            freeCancellation: true,
+            occupancy: 4,
+            roomType: "Family Loft",
+            price: 328,
+            notes: ["Breakfast included", "Free cancellation", "Best for 2 adults + 2 children"],
+          }),
+          createPlan({
+            id: "plan-miradouro-standard-twin-flex-breakfast",
+            name: "Standard Twin City View",
+            breakfast: true,
+            freeCancellation: true,
+            occupancy: 2,
+            roomType: "Twin",
+            price: 214,
+            notes: ["Breakfast included", "Free cancellation"],
+          }),
+          createPlan({
+            id: "plan-miradouro-family-loft-no-breakfast",
+            name: "Family Loft with Terrace",
+            breakfast: false,
+            freeCancellation: true,
+            occupancy: 4,
+            roomType: "Family Loft",
+            price: 299,
+            notes: ["Free cancellation", "Breakfast not included"],
+          }),
+        ],
+      }),
+      createProperty({
+        id: "property-miradouro-lane-house",
+        name: "Miradouro Lane House",
+        neighborhood: "Alfama",
+        reviewScore: 9.0,
+        reviewText: "Wonderful",
+        description: "Similar neighborhood and branding but fewer room combinations.",
+        badges: ["Adults preferred"],
+        roomPlans: [
+          createPlan({
+            id: "plan-miradouro-house-double",
+            name: "Double Room",
+            breakfast: true,
+            freeCancellation: true,
+            occupancy: 2,
+            roomType: "Double",
+            price: 221,
+            notes: ["Breakfast included", "Free cancellation"],
+          }),
+        ],
+      }),
+    ];
+
+    const fillerNeighborhoods = ["Chiado", "Baixa", "Alfama", "Avenida", "Bairro Alto"];
+    for (let index = 1; index <= 14; index += 1) {
+      properties.push(
+        createProperty({
+          id: `property-filler-${index}`,
+          name: `Lisbon Stayhouse ${index}`,
+          neighborhood: fillerNeighborhoods[index % fillerNeighborhoods.length],
+          reviewScore: 8.1 + (index % 8) * 0.1,
+          reviewText: "Very good",
+          description: "Seeded hotel used for dense result pages and decoy availability.",
+          badges: index % 2 === 0 ? ["Late check-in"] : ["Breakfast optional"],
+          roomPlans: [
+            createPlan({
+              id: `plan-filler-${index}-1`,
+              name: "Standard Room",
+              breakfast: index % 2 === 0,
+              freeCancellation: index % 3 !== 0,
+              occupancy: 2,
+              roomType: "Standard",
+              price: 165 + index,
+              notes: ["Seeded room plan"],
+            }),
+          ],
+        }),
+      );
+    }
+
+    return properties;
+  }
+
+  function buildSeedState() {
+    return {
+      properties: buildSeedProperties(),
+      ui: {
+        surface: "search",
+        modal: null,
+      },
+      search: {
+        destinationId: null,
+        destinationLabel: "",
+        checkIn: "",
+        checkOut: "",
+        guests: {
+          adults: 2,
+          children: 0,
+          rooms: 1,
+        },
+        filters: {
+          minReview: "",
+          freeCancellation: false,
+          neighborhood: "",
+          meal: "",
+        },
+        sort: "recommended",
+      },
+      shortlist: [],
+      selectedPropertyId: null,
+      selectedRoomPlanIds: [],
+      checkout: {
+        guestNames: ["", ""],
+        email: "",
+        specialRequest: "",
+      },
+      confirmation: null,
+    };
+  }
+
+  const store = createSeededStore({
+    storageKey: "openbrowser.eval.booking",
+    seedState: buildSeedState(),
+  });
+
+  const DESTINATIONS = [
+    { id: "lisbon-portugal", label: "Lisbon, Portugal" },
+    { id: "lisbon-old-town", label: "Lisbon Old Town, Portugal" },
+    { id: "porto-portugal", label: "Porto, Portugal" },
+  ];
+
+  const CALENDAR_MONTHS = [
+    { id: "2026-06", label: "June 2026", days: [14, 15, 16, 17, 18, 19, 20, 21] },
+    { id: "2026-07", label: "July 2026", days: [4, 5, 6, 7, 8, 9, 10, 11] },
+  ];
+
+  const app = document.getElementById("app");
+
+  function getPropertyById(state, propertyId) {
+    return state.properties.find((property) => property.id === propertyId) || null;
+  }
+
+  function getSelectedProperty(state) {
+    return getPropertyById(state, state.selectedPropertyId);
+  }
+
+  function getFilteredProperties(state) {
+    const { minReview, freeCancellation, neighborhood, meal } = state.search.filters;
+    return state.properties
+      .filter((property) => {
+        if (state.search.destinationId && state.search.destinationId.indexOf("lisbon") === -1) {
+          return false;
+        }
+        if (minReview && property.reviewScore < Number(minReview)) {
+          return false;
+        }
+        if (neighborhood && property.neighborhood !== neighborhood) {
+          return false;
+        }
+        if (freeCancellation && !property.roomPlans.some((plan) => plan.freeCancellation)) {
+          return false;
+        }
+        if (meal === "breakfast" && !property.roomPlans.some((plan) => plan.breakfast)) {
+          return false;
+        }
+        return true;
+      })
+      .sort((left, right) => {
+        if (state.search.sort === "score-desc") {
+          return right.reviewScore - left.reviewScore;
+        }
+        if (state.search.sort === "price-asc") {
+          return Math.min(...left.roomPlans.map((plan) => plan.price)) - Math.min(...right.roomPlans.map((plan) => plan.price));
+        }
+        return right.reviewScore - left.reviewScore;
+      });
+  }
+
+  function renderTopbar() {
+    return `
+      <header class="mock-topbar">
+        <div class="booking-topbar">
+          <div class="booking-brand">
+            <div class="booking-brand-mark">B</div>
+            <div>
+              <div>Booking Mock</div>
+              <div class="mock-subtle">Hotels, filters, compare, room plans, checkout</div>
+            </div>
+          </div>
+          <div class="mock-subtle">Dense decision-making with near-duplicate hotels and repeated room actions.</div>
+          <div style="display: flex; gap: 10px;">
+            <span class="mock-pill">18+ properties</span>
+            <span class="mock-pill">Multi-room edge cases</span>
+          </div>
+        </div>
+      </header>
+    `;
+  }
+
+  function renderSearchSurface(state) {
+    return `
+      <section class="booking-hero mock-card">
+        <div>
+          <p class="mock-kicker">Search stays</p>
+          <h1 class="mock-title">Search through dense Lisbon listings with repeated names and subtle policy differences.</h1>
+        </div>
+        <div class="booking-search-grid">
+          <div>
+            <label class="mock-kicker" for="destination-input">Destination</label>
+            <input id="destination-input" class="mock-input" value="${escapeHtml(state.search.destinationLabel)}" placeholder="Where are you going?">
+          </div>
+          <div>
+            <label class="mock-kicker">Dates</label>
+            <button class="mock-btn-secondary" data-action="open-dates">${state.search.checkIn && state.search.checkOut ? `${state.search.checkIn} → ${state.search.checkOut}` : "Choose dates"}</button>
+          </div>
+          <div>
+            <label class="mock-kicker">Guests</label>
+            <button class="mock-btn-secondary" data-action="open-guests">${state.search.guests.adults} adults · ${state.search.guests.children} children · ${state.search.guests.rooms} room(s)</button>
+          </div>
+          <div>
+            <label class="mock-kicker">Hints</label>
+            <div class="mock-pill">Use the autocomplete choice, not free text only</div>
+          </div>
+          <button class="mock-btn" data-action="search-submit">Search stays</button>
+        </div>
+      </section>
+    `;
+  }
+
+  function renderPropertyCard(state, property) {
+    return `
+      <article class="booking-property-card">
+        <div class="booking-property-top">
+          <div>
+            <div class="booking-property-name">${escapeHtml(property.name)}</div>
+            <div class="mock-subtle">${escapeHtml(property.neighborhood)} · ${escapeHtml(property.description)}</div>
+          </div>
+          <div class="booking-score">
+            <span class="booking-score-box">${property.reviewScore.toFixed(1)}</span>
+            <span class="mock-subtle">${escapeHtml(property.reviewText)}</span>
+          </div>
+        </div>
+        <div class="booking-property-meta">
+          ${property.badges.map((badge) => `<span class="mock-badge">${escapeHtml(badge)}</span>`).join("")}
+          <span class="mock-badge">${property.roomPlans.length} room plans</span>
+        </div>
+        <div class="booking-actions">
+          <button class="mock-btn-secondary" data-action="toggle-shortlist" data-property-id="${property.id}">
+            ${state.shortlist.includes(property.id) ? "Shortlisted" : "Save"}
+          </button>
+          <button class="mock-btn" data-action="open-property" data-property-id="${property.id}">See availability</button>
+        </div>
+      </article>
+    `;
+  }
+
+  function renderResultsSurface(state) {
+    const results = getFilteredProperties(state);
+    return `
+      <div class="booking-layout">
+        <aside class="booking-filters mock-card mock-sticky-panel">
+          <div>
+            <p class="mock-kicker">Refine search</p>
+            <h2 class="mock-title">Filters</h2>
+          </div>
+          <div>
+            <label class="mock-kicker" for="filter-review">Review score</label>
+            <select id="filter-review" class="mock-select" data-filter-key="minReview">
+              <option value="">Any</option>
+              <option value="8.8" ${state.search.filters.minReview === "8.8" ? "selected" : ""}>8.8+</option>
+              <option value="9.0" ${state.search.filters.minReview === "9.0" ? "selected" : ""}>9.0+</option>
+            </select>
+          </div>
+          <div>
+            <label class="mock-kicker" for="filter-neighborhood">Neighborhood</label>
+            <select id="filter-neighborhood" class="mock-select" data-filter-key="neighborhood">
+              <option value="">Any</option>
+              <option value="Baixa" ${state.search.filters.neighborhood === "Baixa" ? "selected" : ""}>Baixa</option>
+              <option value="Chiado" ${state.search.filters.neighborhood === "Chiado" ? "selected" : ""}>Chiado</option>
+              <option value="Alfama" ${state.search.filters.neighborhood === "Alfama" ? "selected" : ""}>Alfama</option>
+            </select>
+          </div>
+          <div>
+            <label class="mock-kicker" for="filter-meal">Meals</label>
+            <select id="filter-meal" class="mock-select" data-filter-key="meal">
+              <option value="">Any</option>
+              <option value="breakfast" ${state.search.filters.meal === "breakfast" ? "selected" : ""}>Breakfast included</option>
+            </select>
+          </div>
+          <label class="mock-pill" style="justify-content: flex-start;">
+            <input type="checkbox" data-filter-key="freeCancellation" ${state.search.filters.freeCancellation ? "checked" : ""}>
+            Free cancellation
+          </label>
+        </aside>
+        <section class="booking-results mock-card">
+          <div class="booking-actions" style="justify-content: space-between; margin-bottom: 14px;">
+            <div>
+              <p class="mock-kicker">Results</p>
+              <h2 class="mock-title">${results.length} Lisbon stays</h2>
+            </div>
+            <div class="booking-actions">
+              <select class="mock-select" id="booking-sort" style="min-width: 180px;">
+                <option value="recommended" ${state.search.sort === "recommended" ? "selected" : ""}>Recommended</option>
+                <option value="score-desc" ${state.search.sort === "score-desc" ? "selected" : ""}>Top reviewed</option>
+                <option value="price-asc" ${state.search.sort === "price-asc" ? "selected" : ""}>Lowest price</option>
+              </select>
+              <button class="mock-btn-secondary" data-action="open-compare" ${state.shortlist.length === 2 ? "" : "disabled"}>Compare saved stays</button>
+            </div>
+          </div>
+          <div class="booking-results-list">
+            ${results.map((property) => renderPropertyCard(state, property)).join("")}
+          </div>
+        </section>
+      </div>
+    `;
+  }
+
+  function renderPropertySurface(state) {
+    const property = getSelectedProperty(state);
+    if (!property) {
+      return renderResultsSurface(state);
+    }
+
+    const selectedPlans = state.selectedRoomPlanIds;
+    const nextRoomSlot = selectedPlans.length + 1;
+
+    return `
+      <section class="booking-property mock-card">
+        <div class="booking-property-layout">
+          <div>
+            <div class="booking-actions" style="justify-content: space-between; margin-bottom: 14px;">
+              <div>
+                <p class="mock-kicker">Property detail</p>
+                <h2 class="mock-title">${escapeHtml(property.name)}</h2>
+                <p class="mock-subtle">${escapeHtml(property.neighborhood)} · ${escapeHtml(property.description)}</p>
+              </div>
+              <button class="mock-btn-secondary" data-action="back-to-results">Back to results</button>
+            </div>
+            <div class="booking-room-list">
+              ${property.roomPlans
+                .map(
+                  (plan) => `
+                    <article class="booking-room-card">
+                      <div class="booking-room-grid">
+                        <div>
+                          <div class="booking-property-name" style="font-size: 18px;">${escapeHtml(plan.name)}</div>
+                          <div class="booking-room-meta">
+                            <span class="mock-badge">${escapeHtml(plan.roomType)}</span>
+                            <span class="mock-badge">${plan.breakfast ? "Breakfast included" : "No breakfast"}</span>
+                            <span class="mock-badge">${plan.freeCancellation ? "Free cancellation" : "Non-refundable"}</span>
+                            <span class="mock-badge">Fits ${plan.occupancy}</span>
+                          </div>
+                          <div class="mock-subtle">${escapeHtml(plan.notes.join(" · "))}</div>
+                        </div>
+                        <div>
+                          <div class="mock-kicker">Price</div>
+                          <div class="mock-title">${formatCurrency(plan.price, "$")}</div>
+                          <div class="mock-subtle">${escapeHtml(plan.payment)}</div>
+                        </div>
+                        <div>
+                          <div class="booking-room-slot">Room slot ${Math.min(nextRoomSlot, state.search.guests.rooms)}</div>
+                          <button class="mock-btn" data-action="select-plan" data-plan-id="${plan.id}">Select</button>
+                        </div>
+                      </div>
+                    </article>
+                  `,
+                )
+                .join("")}
+            </div>
+          </div>
+          <aside class="booking-summary-side mock-card">
+            <div>
+              <p class="mock-kicker">Selection summary</p>
+              <h3 class="mock-title">Guests and room rules</h3>
+            </div>
+            <div class="mock-subtle">${state.search.guests.adults} adults · ${state.search.guests.children} children · ${state.search.guests.rooms} room(s)</div>
+            <div class="mock-subtle">Selected room plans: ${selectedPlans.length || 0}</div>
+            <div class="booking-property-meta">
+              ${selectedPlans.map((planId) => `<span class="mock-badge">${escapeHtml(planId)}</span>`).join("") || '<span class="mock-subtle">Nothing selected yet.</span>'}
+            </div>
+            <button class="mock-btn" data-action="continue-checkout" ${selectedPlans.length === state.search.guests.rooms ? "" : "disabled"}>Continue to traveler details</button>
+          </aside>
+        </div>
+      </section>
+    `;
+  }
+
+  function renderCheckoutSurface(state) {
+    const property = getSelectedProperty(state);
+    return `
+      <section class="booking-checkout mock-card">
+        <div class="booking-actions" style="justify-content: space-between; margin-bottom: 14px;">
+          <div>
+            <p class="mock-kicker">Traveler details</p>
+            <h2 class="mock-title">${escapeHtml(property ? property.name : "")}</h2>
+          </div>
+          <button class="mock-btn-secondary" data-action="back-to-property">Back to rooms</button>
+        </div>
+        <div class="booking-form-grid">
+          <div>
+            <label class="mock-kicker" for="guest-name-1">Primary traveler</label>
+            <input id="guest-name-1" class="mock-input" data-checkout-field="guest-0" value="${escapeHtml(state.checkout.guestNames[0] || "")}">
+          </div>
+          <div>
+            <label class="mock-kicker" for="guest-name-2">Second traveler / room lead</label>
+            <input id="guest-name-2" class="mock-input" data-checkout-field="guest-1" value="${escapeHtml(state.checkout.guestNames[1] || "")}">
+          </div>
+          <div>
+            <label class="mock-kicker" for="checkout-email">Email</label>
+            <input id="checkout-email" class="mock-input" data-checkout-field="email" value="${escapeHtml(state.checkout.email)}">
+          </div>
+          <div>
+            <label class="mock-kicker" for="special-request">Special request</label>
+            <textarea id="special-request" class="mock-textarea" rows="4" data-checkout-field="specialRequest">${escapeHtml(state.checkout.specialRequest)}</textarea>
+          </div>
+        </div>
+        <div class="booking-actions" style="margin-top: 16px;">
+          <button class="mock-btn-secondary" data-action="submit-traveler-form">Save traveler details</button>
+          <button class="mock-btn" data-action="submit-reservation">Confirm reservation</button>
+        </div>
+      </section>
+    `;
+  }
+
+  function renderCompareSurface(state) {
+    const properties = state.shortlist.map((propertyId) => getPropertyById(state, propertyId)).filter(Boolean);
+    return `
+      <section class="booking-compare mock-card">
+        <div class="booking-actions" style="justify-content: space-between; margin-bottom: 14px;">
+          <div>
+            <p class="mock-kicker">Compare</p>
+            <h2 class="mock-title">Saved stays</h2>
+          </div>
+          <button class="mock-btn-secondary" data-action="back-to-results">Back to results</button>
+        </div>
+        <div class="booking-compare-grid">
+          ${properties
+            .map(
+              (property) => `
+                <article class="booking-compare-card">
+                  <div class="booking-property-name">${escapeHtml(property.name)}</div>
+                  <div class="mock-subtle">${escapeHtml(property.neighborhood)} · Score ${property.reviewScore.toFixed(1)}</div>
+                  <div class="booking-property-meta">
+                    ${property.badges.map((badge) => `<span class="mock-badge">${escapeHtml(badge)}</span>`).join("")}
+                  </div>
+                  <button class="mock-btn" data-action="open-property" data-property-id="${property.id}">Reopen property</button>
+                </article>
+              `,
+            )
+            .join("")}
+        </div>
+      </section>
+    `;
+  }
+
+  function renderConfirmationSurface(state) {
+    const confirmation = state.confirmation;
+    if (!confirmation) {
+      return renderResultsSurface(state);
+    }
+
+    return `
+      <section class="booking-confirmation mock-card">
+        <p class="mock-kicker">Reservation complete</p>
+        <h2 class="mock-title">${escapeHtml(confirmation.propertyName)}</h2>
+        <div class="mock-subtle">Reservation path: ${escapeHtml(confirmation.roomPlanIds.join(", "))}</div>
+        <div class="booking-property-meta">
+          <span class="mock-badge">${escapeHtml(confirmation.email)}</span>
+          ${confirmation.guestNames.filter(Boolean).map((name) => `<span class="mock-badge">${escapeHtml(name)}</span>`).join("")}
+        </div>
+        ${confirmation.specialRequest ? `<div class="mock-subtle">Special request: ${escapeHtml(confirmation.specialRequest)}</div>` : ""}
+        <button class="mock-btn-secondary" data-action="back-to-results">Book another stay</button>
+      </section>
+    `;
+  }
+
+  function renderModal(state) {
+    const modal = state.ui.modal;
+    if (!modal) {
+      return "";
+    }
+
+    if (modal.type === "destination") {
+      return `
+        <div class="mock-modal-backdrop">
+          <div class="mock-modal">
+            <div class="mock-modal-header">
+              <div>
+                <p class="mock-kicker">Destination autocomplete</p>
+                <h3 class="mock-title">Choose the destination</h3>
+              </div>
+              <button class="mock-btn-ghost" data-action="close-modal">Close</button>
+            </div>
+            <div class="mock-modal-body">
+              ${DESTINATIONS.map((destination) => `
+                <button class="drive-upload-option" data-action="choose-destination" data-destination-id="${destination.id}">
+                  <span>${escapeHtml(destination.label)}</span>
+                  <span class="mock-subtle">${destination.id.includes("lisbon") ? "Portugal" : "Alternative city"}</span>
+                </button>
+              `).join("")}
+            </div>
+          </div>
+        </div>
+      `;
+    }
+
+    if (modal.type === "dates") {
+      return `
+        <div class="mock-modal-backdrop">
+          <div class="mock-modal">
+            <div class="mock-modal-header">
+              <div>
+                <p class="mock-kicker">Dual-month picker</p>
+                <h3 class="mock-title">Select check-in and check-out</h3>
+              </div>
+              <button class="mock-btn-ghost" data-action="close-modal">Close</button>
+            </div>
+            <div class="mock-modal-body">
+              <div class="booking-modal-calendar">
+                ${CALENDAR_MONTHS.map((month) => `
+                  <section class="booking-month">
+                    <p class="mock-kicker">${escapeHtml(month.label)}</p>
+                    <div class="booking-day-grid">
+                      ${month.days
+                        .map((day) => {
+                          const value = `${month.id}-${String(day).padStart(2, "0")}`;
+                          const active = [state.search.checkIn, state.search.checkOut].includes(value);
+                          return `<button class="booking-day ${active ? "active" : ""}" data-action="pick-date" data-date="${value}">${day}</button>`;
+                        })
+                        .join("")}
+                    </div>
+                  </section>
+                `).join("")}
+              </div>
+            </div>
+          </div>
+        </div>
+      `;
+    }
+
+    if (modal.type === "guests") {
+      const guests = state.search.guests;
+      return `
+        <div class="mock-modal-backdrop">
+          <div class="mock-modal">
+            <div class="mock-modal-header">
+              <div>
+                <p class="mock-kicker">Guest picker</p>
+                <h3 class="mock-title">Adjust guests and rooms</h3>
+              </div>
+              <button class="mock-btn-ghost" data-action="close-modal">Close</button>
+            </div>
+            <div class="mock-modal-body">
+              ${[
+                ["adults", "Adults"],
+                ["children", "Children"],
+                ["rooms", "Rooms"],
+              ]
+                .map(
+                  ([key, label]) => `
+                    <div class="booking-counter-row">
+                      <span>${label}</span>
+                      <button class="mock-btn-secondary" data-action="guest-adjust" data-key="${key}" data-delta="-1">-</button>
+                      <span>${guests[key]}</span>
+                      <button class="mock-btn-secondary" data-action="guest-adjust" data-key="${key}" data-delta="1">+</button>
+                    </div>
+                  `,
+                )
+                .join("")}
+            </div>
+            <div class="mock-modal-footer">
+              <span class="mock-subtle">Traveler validation later depends on this room allocation.</span>
+              <button class="mock-btn" data-action="close-modal">Done</button>
+            </div>
+          </div>
+        </div>
+      `;
+    }
+
+    return "";
+  }
+
+  function render() {
+    const state = store.getState();
+    let content = "";
+    if (state.ui.surface === "search") {
+      content = renderSearchSurface(state);
+    } else if (state.ui.surface === "results") {
+      content = renderResultsSurface(state);
+    } else if (state.ui.surface === "property") {
+      content = renderPropertySurface(state);
+    } else if (state.ui.surface === "checkout") {
+      content = renderCheckoutSurface(state);
+    } else if (state.ui.surface === "compare") {
+      content = renderCompareSurface(state);
+    } else {
+      content = renderConfirmationSurface(state);
+    }
+
+    app.innerHTML = `
+      <div class="mock-page">
+        ${renderTopbar()}
+        <main class="booking-shell">
+          ${content}
+        </main>
+        ${renderModal(state)}
+      </div>
+    `;
+  }
+
+  function setDestination(destinationId) {
+    const destination = DESTINATIONS.find((item) => item.id === destinationId);
+    if (!destination) {
+      return;
+    }
+
+    store.update((state) => {
+      state.search.destinationId = destination.id;
+      state.search.destinationLabel = destination.label;
+      state.ui.modal = null;
+    });
+    tracker.track("destination_select", {
+      destinationId: destination.id,
+      destinationLabel: destination.label,
+    });
+    render();
+  }
+
+  function pickDate(value) {
+    const nextState = store.update((state) => {
+      if (!state.search.checkIn || (state.search.checkIn && state.search.checkOut)) {
+        state.search.checkIn = value;
+        state.search.checkOut = "";
+      } else {
+        state.search.checkOut = value;
+        if (state.search.checkOut < state.search.checkIn) {
+          const temp = state.search.checkIn;
+          state.search.checkIn = state.search.checkOut;
+          state.search.checkOut = temp;
+        }
+      }
+    });
+
+    if (nextState.search.checkIn && nextState.search.checkOut) {
+      tracker.track("date_range_select", {
+        checkIn: nextState.search.checkIn,
+        checkOut: nextState.search.checkOut,
+      });
+    }
+    render();
+  }
+
+  function adjustGuest(key, delta) {
+    const nextState = store.update((state) => {
+      const minValues = { adults: 1, children: 0, rooms: 1 };
+      state.search.guests[key] = Math.max(minValues[key], state.search.guests[key] + delta);
+    });
+    tracker.track("guest_count_change", {
+      adults: nextState.search.guests.adults,
+      children: nextState.search.guests.children,
+      rooms: nextState.search.guests.rooms,
+    });
+    render();
+  }
+
+  function submitSearch() {
+    const state = store.getState();
+    store.update((draft) => {
+      draft.ui.surface = "results";
+      draft.selectedPropertyId = null;
+      draft.selectedRoomPlanIds = [];
+    });
+    tracker.track("search_submit", {
+      destinationId: state.search.destinationId,
+      checkIn: state.search.checkIn,
+      checkOut: state.search.checkOut,
+      adults: state.search.guests.adults,
+      children: state.search.guests.children,
+      rooms: state.search.guests.rooms,
+    });
+    render();
+  }
+
+  function applyFilter(key, value) {
+    const normalizedValue = key === "freeCancellation" ? value : value;
+    const nextState = store.update((state) => {
+      state.search.filters[key] = normalizedValue;
+    });
+    tracker.track("filter_apply", {
+      filterKey: key,
+      value: String(nextState.search.filters[key]),
+    });
+    render();
+  }
+
+  function applySort(value) {
+    store.update((state) => {
+      state.search.sort = value;
+    });
+    tracker.track("sort_apply", {
+      value,
+    });
+    render();
+  }
+
+  function toggleShortlist(propertyId) {
+    const nextState = store.update((state) => {
+      const shortlist = new Set(state.shortlist);
+      if (shortlist.has(propertyId)) {
+        shortlist.delete(propertyId);
+      } else if (shortlist.size < 2) {
+        shortlist.add(propertyId);
+      }
+      state.shortlist = Array.from(shortlist);
+    });
+    tracker.track("shortlist_toggle", {
+      propertyId,
+      shortlisted: nextState.shortlist.includes(propertyId),
+    });
+    render();
+  }
+
+  function openProperty(propertyId) {
+    const property = getPropertyById(store.getState(), propertyId);
+    if (!property) {
+      return;
+    }
+
+    store.update((state) => {
+      state.selectedPropertyId = property.id;
+      state.selectedRoomPlanIds = [];
+      state.ui.surface = "property";
+    });
+    tracker.track("property_open", {
+      propertyId: property.id,
+    });
+    render();
+  }
+
+  function selectPlan(planId) {
+    const state = store.getState();
+    const property = getSelectedProperty(state);
+    if (!property) {
+      return;
+    }
+
+    const plan = property.roomPlans.find((item) => item.id === planId);
+    if (!plan) {
+      return;
+    }
+
+    const roomSlot = Math.min(state.selectedRoomPlanIds.length + 1, state.search.guests.rooms);
+    store.update((draft) => {
+      if (draft.selectedRoomPlanIds.length < draft.search.guests.rooms) {
+        draft.selectedRoomPlanIds.push(planId);
+      }
+    });
+    tracker.track("rate_plan_select", {
+      propertyId: property.id,
+      roomPlanId: plan.id,
+      roomSlot,
+    });
+    render();
+  }
+
+  function continueCheckout() {
+    const state = store.getState();
+    store.update((state) => {
+      state.ui.surface = "checkout";
+    });
+    tracker.track("booking_continue", {
+      propertyId: state.selectedPropertyId,
+      roomPlanIds: state.selectedRoomPlanIds.slice(),
+      stage: "traveler_details",
+    });
+    render();
+  }
+
+  function submitTravelerForm() {
+    const state = store.getState();
+    tracker.track("traveler_form_submit", {
+      propertyId: state.selectedPropertyId,
+      guestNames: state.checkout.guestNames.filter(Boolean),
+      email: state.checkout.email,
+    });
+  }
+
+  function submitReservation() {
+    const state = store.getState();
+    const property = getSelectedProperty(state);
+    if (!property) {
+      return;
+    }
+
+    const payload = {
+      propertyId: property.id,
+      roomPlanIds: state.selectedRoomPlanIds.slice(),
+      guestNames: state.checkout.guestNames.filter(Boolean),
+      email: state.checkout.email,
+      specialRequest: state.checkout.specialRequest,
+    };
+
+    tracker.track("reservation_submit", payload);
+    store.update((draft) => {
+      draft.confirmation = {
+        propertyName: property.name,
+        roomPlanIds: draft.selectedRoomPlanIds.slice(),
+        guestNames: draft.checkout.guestNames.filter(Boolean),
+        email: draft.checkout.email,
+        specialRequest: draft.checkout.specialRequest,
+      };
+      draft.ui.surface = "confirmation";
+    });
+    render();
+  }
+
+  app.addEventListener("click", (event) => {
+    const target = event.target.closest("[data-action]");
+    if (!target) {
+      return;
+    }
+
+    const action = target.dataset.action;
+
+    if (action === "open-dates") {
+      store.update((state) => {
+        state.ui.modal = { type: "dates" };
+      });
+      render();
+      return;
+    }
+
+    if (action === "open-guests") {
+      store.update((state) => {
+        state.ui.modal = { type: "guests" };
+      });
+      render();
+      return;
+    }
+
+    if (action === "search-submit") {
+      submitSearch();
+      return;
+    }
+
+    if (action === "choose-destination") {
+      setDestination(target.dataset.destinationId);
+      return;
+    }
+
+    if (action === "pick-date") {
+      pickDate(target.dataset.date);
+      return;
+    }
+
+    if (action === "guest-adjust") {
+      adjustGuest(target.dataset.key, Number(target.dataset.delta));
+      return;
+    }
+
+    if (action === "toggle-shortlist") {
+      toggleShortlist(target.dataset.propertyId);
+      return;
+    }
+
+    if (action === "open-property") {
+      openProperty(target.dataset.propertyId);
+      return;
+    }
+
+    if (action === "back-to-results") {
+      store.update((state) => {
+        state.ui.surface = "results";
+      });
+      render();
+      return;
+    }
+
+    if (action === "select-plan") {
+      selectPlan(target.dataset.planId);
+      return;
+    }
+
+    if (action === "continue-checkout") {
+      continueCheckout();
+      return;
+    }
+
+    if (action === "submit-traveler-form") {
+      submitTravelerForm();
+      return;
+    }
+
+    if (action === "submit-reservation") {
+      submitReservation();
+      return;
+    }
+
+    if (action === "back-to-property") {
+      store.update((state) => {
+        state.ui.surface = "property";
+      });
+      render();
+      return;
+    }
+
+    if (action === "open-compare") {
+      const state = store.getState();
+      store.update((state) => {
+        state.ui.surface = "compare";
+      });
+      tracker.track("compare_open", {
+        propertyIds: state.shortlist.slice(),
+      });
+      render();
+      return;
+    }
+
+    if (action === "close-modal") {
+      store.update((state) => {
+        state.ui.modal = null;
+      });
+      render();
+    }
+  });
+
+  app.addEventListener("change", (event) => {
+    if (event.target.id === "booking-sort") {
+      applySort(event.target.value);
+      return;
+    }
+
+    const filterKey = event.target.dataset.filterKey;
+    if (filterKey) {
+      const value = event.target.type === "checkbox" ? event.target.checked : event.target.value;
+      applyFilter(filterKey, value);
+    }
+  });
+
+  app.addEventListener("input", (event) => {
+    if (event.target.id === "destination-input") {
+      const value = event.target.value;
+      store.update((state) => {
+        state.search.destinationLabel = value;
+      });
+
+      if (value.trim()) {
+        store.update((state) => {
+          state.ui.modal = { type: "destination" };
+        });
+        render();
+      }
+      return;
+    }
+
+    const checkoutField = event.target.dataset.checkoutField;
+    if (checkoutField) {
+      store.update((state) => {
+        if (checkoutField.startsWith("guest-")) {
+          const index = Number(checkoutField.split("-")[1]);
+          state.checkout.guestNames[index] = event.target.value;
+        } else {
+          state.checkout[checkoutField] = event.target.value;
+        }
+      });
+    }
+  });
+
+  render();
+})();

--- a/eval/css/hard-mock-base.css
+++ b/eval/css/hard-mock-base.css
@@ -1,0 +1,314 @@
+:root {
+  color-scheme: light;
+  --mock-font-sans: "Instrument Sans", "Avenir Next", "Segoe UI", sans-serif;
+  --mock-font-serif: "Iowan Old Style", "Palatino Linotype", serif;
+  --mock-font-mono: "IBM Plex Mono", "SFMono-Regular", monospace;
+  --mock-surface: #ffffff;
+  --mock-surface-muted: #f4f5f7;
+  --mock-surface-raised: #fbfbfc;
+  --mock-border: rgba(14, 23, 38, 0.12);
+  --mock-border-strong: rgba(14, 23, 38, 0.22);
+  --mock-text: #0f1722;
+  --mock-text-muted: #566173;
+  --mock-text-faint: #7a8798;
+  --mock-accent: #1865f2;
+  --mock-accent-soft: rgba(24, 101, 242, 0.12);
+  --mock-danger: #c0362c;
+  --mock-success: #237650;
+  --mock-warning: #b86506;
+  --mock-shadow: 0 16px 44px rgba(15, 23, 34, 0.12);
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  min-height: 100%;
+}
+
+body {
+  font-family: var(--mock-font-sans);
+  color: var(--mock-text);
+  background:
+    radial-gradient(circle at top left, rgba(255, 255, 255, 0.9), transparent 42%),
+    linear-gradient(180deg, #f5f8ff, #eef2f8 28%, #edf1f6 100%);
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+}
+
+button {
+  cursor: pointer;
+}
+
+button:disabled {
+  cursor: not-allowed;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.mock-page {
+  min-height: 100vh;
+}
+
+.mock-topbar {
+  position: sticky;
+  top: 0;
+  z-index: 30;
+  backdrop-filter: blur(12px);
+  background: rgba(255, 255, 255, 0.84);
+  border-bottom: 1px solid var(--mock-border);
+}
+
+.mock-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: var(--mock-surface-muted);
+  color: var(--mock-text-muted);
+  font-size: 12px;
+  line-height: 1;
+}
+
+.mock-btn,
+.mock-btn-secondary,
+.mock-btn-danger,
+.mock-btn-ghost {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  border-radius: 12px;
+  padding: 10px 14px;
+  border: 1px solid transparent;
+  transition: transform 120ms ease, box-shadow 120ms ease, background 120ms ease;
+}
+
+.mock-btn:hover,
+.mock-btn-secondary:hover,
+.mock-btn-danger:hover,
+.mock-btn-ghost:hover {
+  transform: translateY(-1px);
+}
+
+.mock-btn:disabled,
+.mock-btn-secondary:disabled,
+.mock-btn-danger:disabled,
+.mock-btn-ghost:disabled {
+  opacity: 0.42;
+  box-shadow: none;
+  transform: none;
+}
+
+.mock-btn:disabled:hover,
+.mock-btn-secondary:disabled:hover,
+.mock-btn-danger:disabled:hover,
+.mock-btn-ghost:disabled:hover {
+  transform: none;
+}
+
+.mock-btn {
+  background: var(--mock-accent);
+  color: #ffffff;
+  box-shadow: 0 10px 24px rgba(24, 101, 242, 0.22);
+}
+
+.mock-btn-secondary {
+  background: var(--mock-surface);
+  color: var(--mock-text);
+  border-color: var(--mock-border);
+}
+
+.mock-btn-danger {
+  background: rgba(192, 54, 44, 0.08);
+  border-color: rgba(192, 54, 44, 0.16);
+  color: var(--mock-danger);
+}
+
+.mock-btn-ghost {
+  background: transparent;
+  color: var(--mock-text-muted);
+  border-color: var(--mock-border);
+}
+
+.mock-input,
+.mock-select,
+.mock-textarea {
+  width: 100%;
+  border-radius: 14px;
+  border: 1px solid var(--mock-border);
+  background: rgba(255, 255, 255, 0.96);
+  color: var(--mock-text);
+  padding: 12px 14px;
+}
+
+.mock-input:focus,
+.mock-select:focus,
+.mock-textarea:focus {
+  outline: 2px solid rgba(24, 101, 242, 0.18);
+  border-color: rgba(24, 101, 242, 0.42);
+}
+
+.mock-card {
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid var(--mock-border);
+  border-radius: 22px;
+  box-shadow: var(--mock-shadow);
+}
+
+.mock-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 10px;
+  border-radius: 999px;
+  background: rgba(15, 23, 34, 0.06);
+  color: var(--mock-text-muted);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.mock-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 34, 0.42);
+  backdrop-filter: blur(4px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  z-index: 80;
+}
+
+.mock-modal {
+  width: min(760px, 100%);
+  max-height: min(88vh, 980px);
+  overflow: hidden;
+  background: var(--mock-surface);
+  border-radius: 24px;
+  border: 1px solid rgba(255, 255, 255, 0.46);
+  box-shadow: 0 24px 70px rgba(15, 23, 34, 0.24);
+}
+
+.mock-modal-header,
+.mock-modal-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 18px 24px;
+  border-bottom: 1px solid var(--mock-border);
+}
+
+.mock-modal-footer {
+  border-top: 1px solid var(--mock-border);
+  border-bottom: 0;
+}
+
+.mock-modal-body {
+  padding: 24px;
+  overflow: auto;
+  max-height: calc(88vh - 140px);
+}
+
+.mock-split {
+  display: grid;
+  gap: 20px;
+}
+
+.mock-empty {
+  padding: 28px;
+  text-align: center;
+  color: var(--mock-text-muted);
+}
+
+.mock-kicker {
+  margin: 0 0 6px;
+  color: var(--mock-text-faint);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.mock-title {
+  margin: 0;
+  font-size: 24px;
+  line-height: 1.15;
+}
+
+.mock-subtle {
+  color: var(--mock-text-muted);
+}
+
+.mock-list-reset {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.mock-scroll {
+  overflow: auto;
+  scrollbar-width: thin;
+}
+
+.mock-divider {
+  height: 1px;
+  background: var(--mock-border);
+}
+
+.mock-sticky-panel {
+  position: sticky;
+  top: 96px;
+}
+
+.mock-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.mock-table th,
+.mock-table td {
+  padding: 12px 10px;
+  text-align: left;
+  border-bottom: 1px solid var(--mock-border);
+  vertical-align: top;
+}
+
+.mock-table th {
+  color: var(--mock-text-faint);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.mock-highlight {
+  color: var(--mock-accent);
+}
+
+@media (max-width: 1100px) {
+  .mock-modal-backdrop {
+    padding: 12px;
+  }
+
+  .mock-sticky-panel {
+    position: static;
+  }
+}

--- a/eval/dataset/amazon_offer_disambiguation.yaml
+++ b/eval/dataset/amazon_offer_disambiguation.yaml
@@ -1,0 +1,73 @@
+id: amazon_offer_disambiguation
+name: "Amazon Offer Disambiguation"
+difficulty: very hard
+description: "Search and open the correct product, open the offers surface, choose the exact seller and condition, verify the delivery promise via address selection, add the correct offer to cart, and complete checkout without using Buy Now."
+start_url: "http://localhost:16605/amazon/?reset=1"
+instruction: "In the Amazon mock, search for portable monitor and open North Lake Portable Monitor 16. Open the offers surface and choose the new Harbor Tech offer. Add that exact offer to cart without using Buy Now. Then complete checkout using address Office Loft, shipping Next-day locker delivery, payment Visa ending 4242, and place the order."
+time_limit: 1020.0
+cost_limit: 2.3
+
+criteria:
+  - type: search
+    description: "Search for the product"
+    points: 1.0
+    expected:
+      event_type: amazon_search_execute
+      page: "/amazon/"
+      query: "portable monitor"
+
+  - type: open_product
+    description: "Open the correct monitor"
+    points: 1.2
+    expected:
+      event_type: product_open
+      page: "/amazon/"
+      productId: "product-north-lake-monitor-16"
+
+  - type: open_offers
+    description: "Open the offers surface"
+    points: 1.0
+    expected:
+      event_type: offer_open
+      page: "/amazon/"
+      productId: "product-north-lake-monitor-16"
+
+  - type: choose_offer
+    description: "Choose the exact seller offer"
+    points: 1.6
+    expected:
+      event_type: offer_select
+      page: "/amazon/"
+      productId: "product-north-lake-monitor-16"
+      offerId: "offer-monitor-harbor-tech-new"
+
+  - type: add_to_cart
+    description: "Add the selected offer to cart"
+    points: 1.4
+    expected:
+      event_type: cart_add
+      page: "/amazon/"
+      productId: "product-north-lake-monitor-16"
+      offerId: "offer-monitor-harbor-tech-new"
+      checkoutPath: "cart"
+
+  - type: address
+    description: "Select the Office Loft address"
+    points: 0.8
+    expected:
+      event_type: address_select
+      page: "/amazon/"
+      addressId: "address-office-loft"
+
+  - type: final_order
+    description: "Place the correct offer order through the cart path"
+    points: 3.0
+    expected:
+      event_type: place_order_click
+      page: "/amazon/"
+      productId: "product-north-lake-monitor-16"
+      offerId: "offer-monitor-harbor-tech-new"
+      addressId: "address-office-loft"
+      shippingOptionId: "shipping-locker-next-day"
+      paymentId: "payment-visa-4242"
+      checkoutPath: "cart"

--- a/eval/dataset/amazon_variant_checkout.yaml
+++ b/eval/dataset/amazon_variant_checkout.yaml
@@ -1,0 +1,94 @@
+id: amazon_variant_checkout
+name: "Amazon Variant Checkout"
+difficulty: hard
+description: "Search through noisy results, open the correct PDP, select the exact color and size, add to cart, remove the auto-added accessory, and complete checkout."
+start_url: "http://localhost:16605/amazon/?reset=1"
+instruction: "In the Amazon mock, search for trail shell and open Aurora Trail Shell Jacket. Select color Canyon Red and size M. Add it to cart, remove the auto-added Rain Care Kit accessory, then complete checkout using address Office Loft, shipping Next-day locker delivery, payment Visa ending 4242, and place the order."
+time_limit: 700.0
+cost_limit: 1.6
+
+criteria:
+  - type: search
+    description: "Search for the target product"
+    points: 1.0
+    expected:
+      event_type: amazon_search_execute
+      page: "/amazon/"
+      query: "trail shell"
+
+  - type: open_product
+    description: "Open the correct PDP"
+    points: 1.2
+    expected:
+      event_type: product_open
+      page: "/amazon/"
+      productId: "product-aurora-trail-shell"
+
+  - type: select_color
+    description: "Select the Canyon Red color"
+    points: 0.8
+    expected:
+      event_type: variant_select
+      page: "/amazon/"
+      productId: "product-aurora-trail-shell"
+      variantKey: "color"
+      variantValue: "Canyon Red"
+
+  - type: select_size
+    description: "Select size M"
+    points: 0.8
+    expected:
+      event_type: variant_select
+      page: "/amazon/"
+      productId: "product-aurora-trail-shell"
+      variantKey: "size"
+      variantValue: "M"
+
+  - type: add_cart
+    description: "Add the selected variant to cart"
+    points: 1.2
+    expected:
+      event_type: cart_add
+      page: "/amazon/"
+      productId: "product-aurora-trail-shell"
+      variantId: "canyon-red__m"
+      checkoutPath: "cart"
+
+  - type: address
+    description: "Select the address"
+    points: 0.8
+    expected:
+      event_type: address_select
+      page: "/amazon/"
+      addressId: "address-office-loft"
+
+  - type: shipping
+    description: "Select the shipping option"
+    points: 0.8
+    expected:
+      event_type: shipping_option_select
+      page: "/amazon/"
+      shippingOptionId: "shipping-locker-next-day"
+
+  - type: payment
+    description: "Select the payment method"
+    points: 0.8
+    expected:
+      event_type: payment_select
+      page: "/amazon/"
+      paymentId: "payment-visa-4242"
+
+  - type: order
+    description: "Place the final order with the correct cart state"
+    points: 2.8
+    expected:
+      event_type: place_order_click
+      page: "/amazon/"
+      productId: "product-aurora-trail-shell"
+      variantId: "canyon-red__m"
+      removedAccessoryIds:
+        - "acc-rain-care-kit"
+      addressId: "address-office-loft"
+      shippingOptionId: "shipping-locker-next-day"
+      paymentId: "payment-visa-4242"
+      checkoutPath: "cart"

--- a/eval/dataset/booking_compare_and_book.yaml
+++ b/eval/dataset/booking_compare_and_book.yaml
@@ -1,0 +1,68 @@
+id: booking_compare_and_book
+name: "Booking Compare And Book"
+difficulty: hard
+description: "Shortlist two similar hotels, compare them, reopen the correct property, select the valid offer, fill traveler details, and confirm the reservation."
+start_url: "http://localhost:16605/booking/?reset=1"
+instruction: "In the Booking mock, search Lisbon, Portugal for 2026-06-14 to 2026-06-17 for 2 adults in 1 room. Shortlist Harborline Residence Chiado and Harborline Residences Chiado, open the compare view, then reopen Harborline Residence Chiado. Choose the Premium King with Courtyard View plan that includes breakfast and free cancellation. Enter Sofia Grant as the primary traveler, leave the second traveler blank, use sofiagrant@example.com, and confirm the reservation."
+time_limit: 720.0
+cost_limit: 1.7
+
+criteria:
+  - type: shortlist_first
+    description: "Shortlist the first Harborline hotel"
+    points: 1.0
+    expected:
+      event_type: shortlist_toggle
+      page: "/booking/"
+      propertyId: "property-harborline-residence-chiado"
+      shortlisted: true
+
+  - type: shortlist_second
+    description: "Shortlist the second Harborline hotel"
+    points: 1.0
+    expected:
+      event_type: shortlist_toggle
+      page: "/booking/"
+      propertyId: "property-harborline-residences-chiado"
+      shortlisted: true
+
+  - type: open_compare
+    description: "Open the compare view with both shortlisted hotels"
+    points: 1.0
+    expected:
+      event_type: compare_open
+      page: "/booking/"
+      propertyIds:
+        - "property-harborline-residence-chiado"
+        - "property-harborline-residences-chiado"
+
+  - type: open_target_property
+    description: "Reopen the correct Harborline hotel"
+    points: 1.4
+    expected:
+      event_type: property_open
+      page: "/booking/"
+      propertyId: "property-harborline-residence-chiado"
+
+  - type: choose_target_plan
+    description: "Choose the valid room offer"
+    points: 1.6
+    expected:
+      event_type: rate_plan_select
+      page: "/booking/"
+      propertyId: "property-harborline-residence-chiado"
+      roomPlanId: "plan-harborline-chiado-premium-flex-breakfast"
+      roomSlot: 1
+
+  - type: submit_reservation
+    description: "Confirm the reservation"
+    points: 4.0
+    expected:
+      event_type: reservation_submit
+      page: "/booking/"
+      propertyId: "property-harborline-residence-chiado"
+      roomPlanIds:
+        - "plan-harborline-chiado-premium-flex-breakfast"
+      guestNames:
+        - "Sofia Grant"
+      email: "sofiagrant@example.com"

--- a/eval/dataset/booking_family_trip_edgecase.yaml
+++ b/eval/dataset/booking_family_trip_edgecase.yaml
@@ -1,0 +1,82 @@
+id: booking_family_trip_edgecase
+name: "Booking Family Trip Edge Case"
+difficulty: very hard
+description: "Configure a multi-room family trip, apply neighborhood and meal filters, avoid decoys, choose two exact room plans, fill traveler details, add a special request, and complete booking."
+start_url: "http://localhost:16605/booking/?reset=1"
+instruction: 'In the Booking mock, choose Lisbon, Portugal for 2026-06-14 to 2026-06-17. Set the guests to 4 adults, 2 children, and 2 rooms. Filter to the Alfama neighborhood and breakfast included. Open Miradouro Lane Hotel. Select exactly these two room plans in order: Family Loft with Terrace that includes breakfast and free cancellation, then Standard Twin City View that includes breakfast and free cancellation. In checkout, use Elena Ward for the first room lead, Marcus Ward for the second room lead, email wardfamily@example.com, add the special request "Need adjoining rooms near a quiet elevator bank.", and confirm the reservation.'
+time_limit: 1040.0
+cost_limit: 2.4
+
+criteria:
+  - type: search_family
+    description: "Submit the family search with the correct room configuration"
+    points: 1.4
+    expected:
+      event_type: search_submit
+      page: "/booking/"
+      destinationId: "lisbon-portugal"
+      adults: 4
+      children: 2
+      rooms: 2
+
+  - type: filter_neighborhood
+    description: "Apply the Alfama filter"
+    points: 0.8
+    expected:
+      event_type: filter_apply
+      page: "/booking/"
+      filterKey: "neighborhood"
+      value: "Alfama"
+
+  - type: filter_meal
+    description: "Apply the breakfast filter"
+    points: 0.8
+    expected:
+      event_type: filter_apply
+      page: "/booking/"
+      filterKey: "meal"
+      value: "breakfast"
+
+  - type: open_property
+    description: "Open the correct family hotel"
+    points: 1.2
+    expected:
+      event_type: property_open
+      page: "/booking/"
+      propertyId: "property-miradouro-lane-hotel"
+
+  - type: select_first_room
+    description: "Select the family loft first"
+    points: 1.2
+    expected:
+      event_type: rate_plan_select
+      page: "/booking/"
+      propertyId: "property-miradouro-lane-hotel"
+      roomPlanId: "plan-miradouro-family-loft-flex-breakfast"
+      roomSlot: 1
+
+  - type: select_second_room
+    description: "Select the standard twin second"
+    points: 1.2
+    expected:
+      event_type: rate_plan_select
+      page: "/booking/"
+      propertyId: "property-miradouro-lane-hotel"
+      roomPlanId: "plan-miradouro-standard-twin-flex-breakfast"
+      roomSlot: 2
+
+  - type: reservation
+    description: "Confirm the final reservation with the special request"
+    points: 4.4
+    expected:
+      event_type: reservation_submit
+      page: "/booking/"
+      propertyId: "property-miradouro-lane-hotel"
+      roomPlanIds:
+        - "plan-miradouro-family-loft-flex-breakfast"
+        - "plan-miradouro-standard-twin-flex-breakfast"
+      guestNames:
+        - "Elena Ward"
+        - "Marcus Ward"
+      email: "wardfamily@example.com"
+      specialRequest: "Need adjoining rooms near a quiet elevator bank."

--- a/eval/dataset/booking_room_selection.yaml
+++ b/eval/dataset/booking_room_selection.yaml
@@ -1,0 +1,84 @@
+id: booking_room_selection
+name: "Booking Room Selection"
+difficulty: hard
+description: "Choose the destination, date range, and guests; filter results by review score and cancellation; open the correct hotel; select the only room plan that matches breakfast and free-cancellation constraints; and continue to traveler details."
+start_url: "http://localhost:16605/booking/?reset=1"
+instruction: "In the Booking mock, choose Lisbon, Portugal. Set the stay for 2026-06-14 to 2026-06-17 for 2 adults in 1 room. Filter results to review score 8.8+ and free cancellation. Open Castelo River House, choose the Deluxe Queen Balcony plan that includes breakfast and free cancellation, then continue to traveler details."
+time_limit: 660.0
+cost_limit: 1.5
+
+criteria:
+  - type: destination
+    description: "Choose Lisbon"
+    points: 1.0
+    expected:
+      event_type: destination_select
+      page: "/booking/"
+      destinationId: "lisbon-portugal"
+
+  - type: dates
+    description: "Select the date range"
+    points: 1.0
+    expected:
+      event_type: date_range_select
+      page: "/booking/"
+      checkIn: "2026-06-14"
+      checkOut: "2026-06-17"
+
+  - type: search
+    description: "Submit the search with the correct guest count"
+    points: 1.2
+    expected:
+      event_type: search_submit
+      page: "/booking/"
+      destinationId: "lisbon-portugal"
+      adults: 2
+      children: 0
+      rooms: 1
+
+  - type: filter_review
+    description: "Apply the review filter"
+    points: 0.8
+    expected:
+      event_type: filter_apply
+      page: "/booking/"
+      filterKey: "minReview"
+      value: "8.8"
+
+  - type: filter_cancellation
+    description: "Apply the free-cancellation filter"
+    points: 0.8
+    expected:
+      event_type: filter_apply
+      page: "/booking/"
+      filterKey: "freeCancellation"
+      value: "true"
+
+  - type: open_property
+    description: "Open the correct hotel"
+    points: 1.4
+    expected:
+      event_type: property_open
+      page: "/booking/"
+      propertyId: "property-castelo-river-house"
+
+  - type: select_room
+    description: "Select the correct room plan"
+    points: 1.6
+    expected:
+      event_type: rate_plan_select
+      page: "/booking/"
+      propertyId: "property-castelo-river-house"
+      roomPlanId: "plan-castelo-deluxe-breakfast-flex"
+      roomSlot: 1
+
+  - type: continue_checkout
+    description: "Continue to traveler details"
+    points: 1.2
+    expected:
+      event_type: booking_continue
+      page: "/booking/"
+      propertyId: "property-castelo-river-house"
+      roomPlanIds:
+        - "plan-castelo-deluxe-breakfast-flex"
+      stage: "traveler_details"

--- a/eval/dataset/drive_bulk_release_assets.yaml
+++ b/eval/dataset/drive_bulk_release_assets.yaml
@@ -1,0 +1,81 @@
+id: drive_bulk_release_assets
+name: "Drive Bulk Release Assets"
+difficulty: very hard
+description: "Switch to list view, multi-select several similarly named assets, move them together, upload a replacement asset, and delete one obsolete duplicate."
+start_url: "http://localhost:16605/drive/?reset=1"
+instruction: "In the Drive mock, switch to list view and work inside Release Assets / Social / Scratch. Select exactly these three files together: Launch Keyvisual Final.png, Launch Keyvisual Final@2x.png, and Launch Keyvisual Final Print.png. Move them in one action to Release Assets / Social / Release Ready Social. Upload the mock replacement asset Launch-Keyvisual-Final-retouched.png into that same Release Ready Social folder. Then delete the obsolete duplicate file Launch Keyvisual Final copy.png. Do not touch the shortcut."
+time_limit: 980.0
+cost_limit: 2.1
+
+criteria:
+  - type: switch_list_view
+    description: "Switch Drive to list view"
+    points: 1.0
+    expected:
+      event_type: view_mode_change
+      page: "/drive/"
+      viewMode: "list"
+
+  - type: select_asset_one
+    description: "Select the first asset"
+    points: 0.8
+    expected:
+      event_type: item_select
+      page: "/drive/"
+      itemId: "asset-keyvisual-final"
+
+  - type: select_asset_two
+    description: "Select the second asset"
+    points: 0.8
+    expected:
+      event_type: item_select
+      page: "/drive/"
+      itemId: "asset-keyvisual-final-2x"
+
+  - type: select_asset_three
+    description: "Select the third asset"
+    points: 0.8
+    expected:
+      event_type: item_select
+      page: "/drive/"
+      itemId: "asset-keyvisual-final-print"
+
+  - type: commit_multi_select
+    description: "Commit the exact three-item bulk selection"
+    points: 1.4
+    expected:
+      event_type: multi_select_commit
+      page: "/drive/"
+      itemIds:
+        - "asset-keyvisual-final"
+        - "asset-keyvisual-final-2x"
+        - "asset-keyvisual-final-print"
+
+  - type: move_assets
+    description: "Move the selected assets to the release-ready folder"
+    points: 2.2
+    expected:
+      event_type: item_move
+      page: "/drive/"
+      itemIds:
+        - "asset-keyvisual-final"
+        - "asset-keyvisual-final-2x"
+        - "asset-keyvisual-final-print"
+      destinationId: "folder-release-ready-social"
+
+  - type: upload_replacement
+    description: "Upload the replacement asset"
+    points: 1.4
+    expected:
+      event_type: mock_upload_complete
+      page: "/drive/"
+      itemId: "upload-launch-keyvisual-retouched"
+      destinationId: "folder-release-ready-social"
+
+  - type: delete_duplicate
+    description: "Delete the obsolete duplicate"
+    points: 1.6
+    expected:
+      event_type: item_delete
+      page: "/drive/"
+      itemId: "asset-keyvisual-final-copy"

--- a/eval/dataset/drive_permission_cleanup.yaml
+++ b/eval/dataset/drive_permission_cleanup.yaml
@@ -1,0 +1,47 @@
+id: drive_permission_cleanup
+name: "Drive Permission Cleanup"
+difficulty: hard
+description: "Open a shared folder, add collaborators with different roles, and downgrade an existing editor."
+start_url: "http://localhost:16605/drive/?reset=1"
+instruction: "In the Drive mock, locate the shared folder Northstar Launch Shared. Open its share dialog. Add mila.procurement@northstar.com as a commenter. Add ceo.office@northstar.com as a viewer. Then downgrade alex@northstar.com from editor to commenter."
+time_limit: 620.0
+cost_limit: 1.3
+
+criteria:
+  - type: open_share_dialog
+    description: "Open the correct share dialog"
+    points: 1.2
+    expected:
+      event_type: share_dialog_open
+      page: "/drive/"
+      itemId: "folder-shared-northstar-launch"
+
+  - type: add_first_collaborator
+    description: "Add the procurement collaborator"
+    points: 1.6
+    expected:
+      event_type: permission_add
+      page: "/drive/"
+      itemId: "folder-shared-northstar-launch"
+      email: "mila.procurement@northstar.com"
+      role: "commenter"
+
+  - type: add_second_collaborator
+    description: "Add the executive office collaborator"
+    points: 1.6
+    expected:
+      event_type: permission_add
+      page: "/drive/"
+      itemId: "folder-shared-northstar-launch"
+      email: "ceo.office@northstar.com"
+      role: "viewer"
+
+  - type: downgrade_existing_editor
+    description: "Downgrade the existing editor"
+    points: 2.2
+    expected:
+      event_type: permission_change
+      page: "/drive/"
+      itemId: "folder-shared-northstar-launch"
+      email: "alex@northstar.com"
+      role: "commenter"

--- a/eval/dataset/drive_project_reorg.yaml
+++ b/eval/dataset/drive_project_reorg.yaml
@@ -1,0 +1,54 @@
+id: drive_project_reorg
+name: "Drive Project Reorg"
+difficulty: hard
+description: "Search for a specific launch brief, move it into the correct nested approval folder, rename it, and create a shortcut in a second destination."
+start_url: "http://localhost:16605/drive/?reset=1"
+instruction: "In the Drive mock, search for the file named Launch Brief v5. Move that exact file into Projects / Launch / Final / Board Approvals. Rename it to Launch Brief Board Final. Then create a shortcut to that same file inside Projects / Launch / Final / Shared Launch Handoff."
+time_limit: 660.0
+cost_limit: 1.5
+
+criteria:
+  - type: search_file
+    description: "Search Drive for the target file"
+    points: 1.0
+    expected:
+      event_type: drive_search_execute
+      page: "/drive/"
+      query: "Launch Brief v5"
+
+  - type: select_target
+    description: "Select the exact launch brief file"
+    points: 1.0
+    expected:
+      event_type: item_select
+      page: "/drive/"
+      itemId: "file-launch-brief-v5"
+
+  - type: move_target
+    description: "Move the file to the correct approval folder"
+    points: 2.0
+    expected:
+      event_type: item_move
+      page: "/drive/"
+      itemId: "file-launch-brief-v5"
+      itemIds:
+        - "file-launch-brief-v5"
+      destinationId: "folder-launch-board-approvals"
+
+  - type: rename_target
+    description: "Rename the file"
+    points: 1.5
+    expected:
+      event_type: item_rename
+      page: "/drive/"
+      itemId: "file-launch-brief-v5"
+      newName: "Launch Brief Board Final"
+
+  - type: create_shortcut
+    description: "Create the shortcut in the correct folder"
+    points: 2.0
+    expected:
+      event_type: shortcut_create
+      page: "/drive/"
+      sourceId: "file-launch-brief-v5"
+      destinationId: "folder-shared-launch-handoff"

--- a/eval/dataset/github_issue_triage_deep.yaml
+++ b/eval/dataset/github_issue_triage_deep.yaml
@@ -1,0 +1,62 @@
+id: github_issue_triage_deep
+name: "GitHub Issue Triage Deep"
+difficulty: hard
+description: "Filter issues with qualifiers, open the correct issue, add the right label, assign the right owner, set the milestone, and leave an exact triage comment."
+start_url: "http://localhost:16605/github/?reset=1"
+instruction: 'In the GitHub mock, go to Issues and filter with this exact query: "is:open label:release-blocker billing webhook retry". Open issue #118, add the label triage-needs-pm, assign it to mila-ops, set the milestone to May Launch, and leave this exact comment: "Need PM sign-off before we clear the release blocker. Please confirm retry cap behavior in staging."'
+time_limit: 680.0
+cost_limit: 1.5
+
+criteria:
+  - type: filter_issues
+    description: "Apply the exact issue filter"
+    points: 1.2
+    expected:
+      event_type: issue_filter_apply
+      page: "/github/"
+      query: "is:open label:release-blocker billing webhook retry"
+
+  - type: open_issue
+    description: "Open the correct issue"
+    points: 1.2
+    expected:
+      event_type: issue_open
+      page: "/github/"
+      issueNumber: 118
+
+  - type: add_label
+    description: "Add the right issue label"
+    points: 1.2
+    expected:
+      event_type: label_add
+      page: "/github/"
+      targetType: "issue"
+      issueNumber: 118
+      labelId: "triage-needs-pm"
+
+  - type: set_assignee
+    description: "Assign the correct owner"
+    points: 1.2
+    expected:
+      event_type: assignee_set
+      page: "/github/"
+      issueNumber: 118
+      assignee: "mila-ops"
+
+  - type: set_milestone
+    description: "Set the May Launch milestone"
+    points: 1.2
+    expected:
+      event_type: milestone_set
+      page: "/github/"
+      issueNumber: 118
+      milestoneId: "May Launch"
+
+  - type: add_comment
+    description: "Leave the exact triage comment"
+    points: 2.5
+    expected:
+      event_type: issue_comment_add
+      page: "/github/"
+      issueNumber: 118
+      commentBody: "Need PM sign-off before we clear the release blocker. Please confirm retry cap behavior in staging."

--- a/eval/dataset/github_pr_review.yaml
+++ b/eval/dataset/github_pr_review.yaml
@@ -1,0 +1,64 @@
+id: github_pr_review
+name: "GitHub PR Review"
+difficulty: hard
+description: "Open the target PR, switch to Files changed, filter the correct file path, add an inline diff comment on the correct hunk, mark another file viewed, and submit Request changes."
+start_url: "http://localhost:16605/github/?reset=1"
+instruction: 'In the GitHub mock, open pull request #42. Switch to Files changed. Filter the file list to server/billing/retry_policy.py. Add this exact inline diff comment on the retry-cap-guard hunk: "This still emits a duplicate invoice after the retry cap. We should stop before emit_duplicate_invoice." Then mark web/dashboard/release_gate.ts as viewed and submit a review with the state Request changes.'
+time_limit: 720.0
+cost_limit: 1.7
+
+criteria:
+  - type: open_pr
+    description: "Open the target PR"
+    points: 1.2
+    expected:
+      event_type: pr_open
+      page: "/github/"
+      prNumber: 42
+
+  - type: switch_files_changed
+    description: "Switch to Files changed"
+    points: 0.9
+    expected:
+      event_type: pr_tab_change
+      page: "/github/"
+      prNumber: 42
+      tab: "files"
+
+  - type: filter_file
+    description: "Filter to the exact file path"
+    points: 1.1
+    expected:
+      event_type: files_changed_filter_apply
+      page: "/github/"
+      prNumber: 42
+      query: "server/billing/retry_policy.py"
+
+  - type: add_inline_comment
+    description: "Leave the exact inline diff comment"
+    points: 2.4
+    expected:
+      event_type: diff_comment_add
+      page: "/github/"
+      prNumber: 42
+      filePath: "server/billing/retry_policy.py"
+      hunkId: "retry-cap-guard"
+      commentBody: "This still emits a duplicate invoice after the retry cap. We should stop before emit_duplicate_invoice."
+
+  - type: mark_other_file_viewed
+    description: "Mark the dashboard file viewed"
+    points: 1.2
+    expected:
+      event_type: file_mark_viewed
+      page: "/github/"
+      prNumber: 42
+      filePath: "web/dashboard/release_gate.ts"
+
+  - type: submit_review
+    description: "Submit Request changes"
+    points: 2.2
+    expected:
+      event_type: review_submit
+      page: "/github/"
+      prNumber: 42
+      state: "request_changes"

--- a/eval/dataset/gmail_exec_followup.yaml
+++ b/eval/dataset/gmail_exec_followup.yaml
@@ -1,0 +1,62 @@
+id: gmail_exec_followup
+name: "Gmail Finance Follow-up"
+difficulty: hard
+description: "Use Gmail-style search operators to find the exact finance board-packet thread, label it correctly, reply with exact text, attach the correct PDF, and send."
+start_url: "http://localhost:16605/gmail/?reset=1"
+instruction: 'In the Gmail mock, use search operators to find the correct finance board-packet thread from Mira Lin at aldercap.com. Open that exact thread, add it to the Finance/Board-Prep label, reply with this exact sentence: "Approved for Friday board prep. Please route the signed PDF back before 4 PM." Attach the mock PDF named Board-Pack-Revision-C.pdf and send the reply.'
+time_limit: 660.0
+cost_limit: 1.4
+
+criteria:
+  - type: search_operators
+    description: "Execute a mail search with operators"
+    points: 1.0
+    expected:
+      event_type: mail_search_execute
+      page: "/gmail/"
+
+  - type: open_correct_thread
+    description: "Open the correct finance thread"
+    points: 1.5
+    expected:
+      event_type: thread_open
+      page: "/gmail/"
+      threadId: "thr-fin-board-pack"
+
+  - type: create_label
+    description: "Create the requested nested label"
+    points: 1.0
+    expected:
+      event_type: label_create
+      page: "/gmail/"
+      labelName: "Finance/Board-Prep"
+
+  - type: apply_label
+    description: "Apply the label to the correct thread"
+    points: 1.0
+    expected:
+      event_type: label_apply
+      page: "/gmail/"
+      threadId: "thr-fin-board-pack"
+      labelName: "Finance/Board-Prep"
+
+  - type: attach_pdf
+    description: "Attach the correct PDF upload"
+    points: 1.0
+    expected:
+      event_type: attachment_add
+      page: "/gmail/"
+      attachmentId: "pdf-board-pack-revision-c"
+      source: "upload"
+
+  - type: send_reply
+    description: "Send the exact reply with the correct attachment"
+    points: 2.5
+    expected:
+      event_type: mail_send
+      page: "/gmail/"
+      threadId: "thr-fin-board-pack"
+      mode: "reply"
+      body: "Approved for Friday board prep. Please route the signed PDF back before 4 PM."
+      attachmentIds:
+        - "pdf-board-pack-revision-c"

--- a/eval/dataset/gmail_inbox_cleanup.yaml
+++ b/eval/dataset/gmail_inbox_cleanup.yaml
@@ -1,0 +1,52 @@
+id: gmail_inbox_cleanup
+name: "Gmail Inbox Cleanup"
+difficulty: hard
+description: "Navigate categories, bulk archive the correct campaign threads, star one urgent message, and mark another thread unread without touching a decoy."
+start_url: "http://localhost:16605/gmail/?reset=1"
+instruction: "In the Gmail mock, go through the inbox categories and clean up the mailbox. In Promotions, bulk-select and archive the two campaign threads for April Pulse relaunch. In Primary, star the urgent payroll exception thread. In Updates, mark the vendor renewal redline summary thread unread. Do not archive the analytics metrics snapshot."
+time_limit: 600.0
+cost_limit: 1.2
+
+criteria:
+  - type: select_first_campaign
+    description: "Select the first campaign thread"
+    points: 1.0
+    expected:
+      event_type: thread_select
+      page: "/gmail/"
+      threadId: "thr-campaign-april-pulse"
+
+  - type: select_second_campaign
+    description: "Select the second campaign thread"
+    points: 1.0
+    expected:
+      event_type: thread_select
+      page: "/gmail/"
+      threadId: "thr-campaign-april-pulse-followup"
+
+  - type: archive_campaign_threads
+    description: "Archive exactly the two campaign threads"
+    points: 2.0
+    expected:
+      event_type: thread_archive
+      page: "/gmail/"
+      threadIds:
+        - "thr-campaign-april-pulse"
+        - "thr-campaign-april-pulse-followup"
+
+  - type: star_urgent_thread
+    description: "Star the urgent payroll thread"
+    points: 1.5
+    expected:
+      event_type: thread_star_toggle
+      page: "/gmail/"
+      threadId: "thr-urgent-payroll"
+      starred: true
+
+  - type: mark_redline_unread
+    description: "Mark the legal redline thread unread"
+    points: 1.5
+    expected:
+      event_type: thread_mark_unread
+      page: "/gmail/"
+      threadId: "thr-renewal-redline"

--- a/eval/dataset/gmail_vendor_escalation.yaml
+++ b/eval/dataset/gmail_vendor_escalation.yaml
@@ -1,0 +1,74 @@
+id: gmail_vendor_escalation
+name: "Gmail Vendor Escalation"
+difficulty: very hard
+description: "Find a buried vendor customs-hold thread, expand the conversation history, draft the escalation with exact recipients and CC, reopen it from Drafts, add the correct Drive link, and send."
+start_url: "http://localhost:16605/gmail/?reset=1"
+instruction: 'In the Gmail mock, search for the Delta Components customs-hold conversation, open the exact vendor thread, expand the collapsed history, and inspect the newest message. Forward the escalation using TO mila.ops@northstar.com and CC arun.procurement@northstar.com. Use this exact body: "Escalating the Delta Components shipment blocker. Mila and Arun are looped in for a decision today." Save it as a draft, reopen that draft from Drafts, add the Drive attachment named Vendor SLA Summary, and send it.'
+time_limit: 900.0
+cost_limit: 2.2
+
+criteria:
+  - type: search_vendor_thread
+    description: "Execute the search"
+    points: 0.8
+    expected:
+      event_type: mail_search_execute
+      page: "/gmail/"
+
+  - type: open_vendor_thread
+    description: "Open the correct vendor thread"
+    points: 1.2
+    expected:
+      event_type: thread_open
+      page: "/gmail/"
+      threadId: "thr-vendor-delta-blocker"
+
+  - type: expand_history
+    description: "Expand the collapsed conversation history"
+    points: 1.0
+    expected:
+      event_type: thread_expand
+      page: "/gmail/"
+      threadId: "thr-vendor-delta-blocker"
+
+  - type: open_forward_draft
+    description: "Open a forward compose draft for the vendor thread"
+    points: 1.0
+    expected:
+      event_type: compose_open
+      page: "/gmail/"
+      threadId: "thr-vendor-delta-blocker"
+      mode: "forward"
+
+  - type: autosave_draft
+    description: "Save or autosave the draft"
+    points: 1.0
+    expected:
+      event_type: draft_autosave
+      page: "/gmail/"
+      threadId: "thr-vendor-delta-blocker"
+
+  - type: attach_drive_link
+    description: "Attach the correct Drive link"
+    points: 1.0
+    expected:
+      event_type: attachment_add
+      page: "/gmail/"
+      attachmentId: "drive-vendor-sla-summary"
+      source: "drive"
+
+  - type: send_escalation
+    description: "Send the exact escalation to the correct recipients"
+    points: 3.0
+    expected:
+      event_type: mail_send
+      page: "/gmail/"
+      threadId: "thr-vendor-delta-blocker"
+      mode: "forward"
+      to:
+        - "mila.ops@northstar.com"
+      cc:
+        - "arun.procurement@northstar.com"
+      body: "Escalating the Delta Components shipment blocker. Mila and Arun are looped in for a decision today."
+      attachmentIds:
+        - "drive-vendor-sla-summary"

--- a/eval/dataset/mapquest_navigate.yaml
+++ b/eval/dataset/mapquest_navigate.yaml
@@ -1,0 +1,65 @@
+id: mapquest_navigate
+name: "MapQuest Navigate — Autocomplete, Directions & Collapse"
+difficulty: hard
+description: "Search Pike Place Market via autocomplete, get walking directions from Space Needle, select shortest route, collapse the panel."
+start_url: "http://localhost:16605/mapquest/"
+instruction: "Search for \"Pike Place Market\" and select it from the autocomplete dropdown (do NOT just press Enter — wait for suggestions). From the place detail panel, click \"Directions\". Set the origin to \"Space Needle\" (again selecting from autocomplete). Switch to the walking mode (the pedestrian icon — there are no text labels, only icons). From the route results, select the shortest route. Then collapse the left panel using the arrow on its right edge."
+time_limit: 540.0
+cost_limit: 1.5
+
+criteria:
+  - type: autocomplete_select_pike
+    description: "Select 'Pike Place Market' from autocomplete (not Enter)"
+    points: 1.5
+    expected:
+      event_type: autocomplete_select
+      itemText: "Pike Place Market"
+
+  - type: click_directions
+    description: "Click Directions in place panel"
+    points: 0.5
+    expected:
+      event_type: click
+      element_id: "directions-btn"
+
+  - type: panel_directions_state
+    description: "Panel transitions to directions state"
+    points: 0.5
+    expected:
+      event_type: panel_state_change
+      state: "directions"
+
+  - type: autocomplete_origin_space_needle
+    description: "Enter and select 'Space Needle' as origin"
+    points: 1.5
+    expected:
+      event_type: autocomplete_select
+      field: "origin"
+      itemText: "Space Needle"
+
+  - type: select_walk_mode
+    description: "Select walking mode (icon-only, no text)"
+    points: 2.0
+    expected:
+      event_type: transport_mode_select
+      mode: "walk"
+
+  - type: select_shortest_route
+    description: "Select the shortest route from results"
+    points: 1.5
+    expected:
+      event_type: route_select
+      routeIndex: 0
+
+  - type: collapse_panel
+    description: "Collapse the left panel via edge arrow"
+    points: 1.5
+    expected:
+      event_type: panel_collapse
+
+  - type: map_viewport_change
+    description: "Map viewport changes after collapse"
+    points: 0.5
+    optional: true
+    expected:
+      event_type: map_viewport_change

--- a/eval/dataset/mapquest_nearby_pins.yaml
+++ b/eval/dataset/mapquest_nearby_pins.yaml
@@ -1,0 +1,74 @@
+id: mapquest_nearby_pins
+name: "MapQuest Nearby Pins — Scroll Chips, Ambiguous Pins & Directions"
+difficulty: very_hard
+description: "Search Pike Place Market, scroll chip bar to find Parking, click correct pin among close neighbors, get driving directions."
+start_url: "http://localhost:16605/mapquest/"
+instruction: "Search for \"Pike Place Market\" and select it from the autocomplete dropdown. Then scroll the Nearby category bar to the right until you find the \"Parking\" chip (it is off-screen initially) and click it. Multiple parking pins will appear on the map. Two pins are very close together — click specifically on \"Pike Place Market Parking Garage\" (NOT \"Pacific Place Parking\" which is the adjacent pin). Once the correct detail panel opens, click \"Directions\" and set the origin to \"Pike Place Market\" (already searched). Choose the driving mode."
+time_limit: 600.0
+cost_limit: 2.0
+
+criteria:
+  - type: autocomplete_select_pike
+    description: "Select 'Pike Place Market' from autocomplete"
+    points: 1.0
+    expected:
+      event_type: autocomplete_select
+      itemText: "Pike Place Market"
+
+  - type: scroll_chip_bar
+    description: "Scroll the Nearby chip bar to reveal 'Parking'"
+    points: 1.5
+    expected:
+      event_type: chip_bar_scroll
+      direction: "right"
+
+  - type: click_parking_chip
+    description: "Click the 'Parking' chip"
+    points: 1.0
+    expected:
+      event_type: nearby_chip_select
+      category: "parking"
+
+  - type: click_correct_pin
+    description: "Click the correct parking pin (not the distractor)"
+    points: 3.0
+    expected:
+      event_type: pin_click
+      pinId: "pike-place-parking-garage"
+
+  - type: verify_panel_content
+    description: "Verify correct panel content"
+    points: 1.0
+    expected:
+      event_type: panel_state_change
+      state: "place-detail"
+      placeId: "pike-place-parking-garage"
+
+  - type: click_directions_parking
+    description: "Click Directions from parking detail"
+    points: 0.5
+    expected:
+      event_type: click
+      element_id: "directions-btn"
+
+  - type: set_origin_pike
+    description: "Set origin to Pike Place Market"
+    points: 1.5
+    expected:
+      event_type: autocomplete_select
+      field: "origin"
+      itemText: "Pike Place Market"
+
+  - type: choose_drive_mode
+    description: "Choose driving mode (car icon)"
+    points: 1.5
+    expected:
+      event_type: transport_mode_select
+      mode: "drive"
+
+  - type: route_results_display
+    description: "Route results display"
+    points: 1.0
+    optional: true
+    expected:
+      event_type: route_results_render

--- a/eval/dataset/staybnb_book.yaml
+++ b/eval/dataset/staybnb_book.yaml
@@ -1,0 +1,98 @@
+id: staybnb_book
+name: "StayBnB Book — Filters, Gallery & Two-Step Booking"
+difficulty: very_hard
+description: "Open filter modal, drag price slider, check amenities, toggle instant book, find listing, view photos, reserve, and confirm."
+start_url: "http://localhost:16605/staybnb/#results"
+instruction: "On the StayBnB search results page (pre-loaded with Tokyo listings), open the \"Filters\" modal. Drag the price slider to set a range of approximately $50–$150/night (the slider has two handles — drag both). Check the \"Wifi\" and \"Kitchen\" amenity checkboxes. Toggle on \"Instant Book\". Click the \"Show N stays\" button at the bottom of the modal to apply the filters. From the filtered results, open the listing \"Shibuya Loft with Skyline View\". Click \"Show all photos\" to open the fullscreen gallery and scroll through at least 5 photos. Close the gallery, then click \"Reserve\" and complete the booking by clicking \"Confirm and pay\" on the confirmation panel."
+time_limit: 600.0
+cost_limit: 2.0
+
+criteria:
+  - type: open_filter_modal
+    description: "Open filter modal"
+    points: 0.5
+    expected:
+      event_type: filter_modal_open
+
+  - type: drag_price_min
+    description: "Drag price min handle to ~$50"
+    points: 2.0
+    expected:
+      event_type: price_slider_change
+      handle: "min"
+
+  - type: drag_price_max
+    description: "Drag price max handle to ~$150"
+    points: 2.0
+    expected:
+      event_type: price_slider_change
+      handle: "max"
+
+  - type: check_wifi
+    description: "Check 'Wifi' amenity"
+    points: 0.5
+    expected:
+      event_type: amenity_toggle
+      amenity: "wifi"
+      checked: true
+
+  - type: check_kitchen
+    description: "Check 'Kitchen' amenity"
+    points: 0.5
+    expected:
+      event_type: amenity_toggle
+      amenity: "kitchen"
+      checked: true
+
+  - type: toggle_instant_book
+    description: "Toggle 'Instant Book' on"
+    points: 0.5
+    expected:
+      event_type: instant_book_toggle
+      checked: true
+
+  - type: apply_filters
+    description: "Click 'Show N stays' to apply filters"
+    points: 0.5
+    expected:
+      event_type: filter_apply
+
+  - type: open_shibuya_loft
+    description: "Open 'Shibuya Loft' listing"
+    points: 1.0
+    expected:
+      event_type: listing_open
+      listingId: "shibuya-loft"
+
+  - type: show_all_photos
+    description: "Click 'Show all photos'"
+    points: 1.0
+    expected:
+      event_type: gallery_open
+      listingId: "shibuya-loft"
+
+  - type: scroll_gallery
+    description: "Scroll through gallery (5+ photos viewed)"
+    points: 1.5
+    expected:
+      event_type: gallery_scroll
+
+  - type: close_gallery
+    description: "Close gallery"
+    points: 0.5
+    expected:
+      event_type: gallery_close
+
+  - type: click_reserve
+    description: "Click Reserve"
+    points: 1.5
+    expected:
+      event_type: reserve_click
+      listingId: "shibuya-loft"
+
+  - type: confirm_booking
+    description: "Click Confirm and pay"
+    points: 3.0
+    expected:
+      event_type: booking_confirm
+      listingId: "shibuya-loft"

--- a/eval/dataset/staybnb_search.yaml
+++ b/eval/dataset/staybnb_search.yaml
@@ -1,0 +1,83 @@
+id: staybnb_search
+name: "StayBnB Search — Segmented Pill, Calendar & Guest Stepper"
+difficulty: hard
+description: "Use the segmented search bar to search Tokyo, pick dates in June 2026 calendar, set guest counts, and submit search."
+start_url: "http://localhost:16605/staybnb/"
+instruction: "On the StayBnB homepage, search for stays in \"Tokyo\" using the segmented search bar. Click the \"When\" section, navigate forward to June 2026 in the calendar (the default view shows the current month), and select June 10 as check-in and June 17 as check-out. Note: some dates in the calendar are grayed out and unclickable — make sure to pick available dates. Then click the \"Who\" section and set 3 adults, 1 child, and 1 infant. Click \"Search\"."
+time_limit: 540.0
+cost_limit: 1.5
+
+criteria:
+  - type: select_tokyo
+    description: "Click 'Where' and select 'Tokyo' from autocomplete"
+    points: 1.0
+    expected:
+      event_type: autocomplete_select
+      value: "Tokyo, Japan"
+
+  - type: click_when
+    description: "Click 'When' to open date picker"
+    points: 0.5
+    expected:
+      event_type: search_section_click
+      section: "when"
+
+  - type: navigate_to_june
+    description: "Navigate calendar forward to June"
+    points: 1.0
+    expected:
+      event_type: calendar_month_nav
+      direction: "forward"
+
+  - type: select_checkin
+    description: "Select check-in June 10 (avoid disabled dates)"
+    points: 1.5
+    expected:
+      event_type: date_select
+      role: "checkin"
+      date: "2026-06-10"
+
+  - type: select_checkout
+    description: "Select check-out June 17"
+    points: 1.5
+    expected:
+      event_type: date_select
+      role: "checkout"
+      date: "2026-06-17"
+
+  - type: click_who
+    description: "Click 'Who' to open guest stepper"
+    points: 0.5
+    expected:
+      event_type: search_section_click
+      section: "who"
+
+  - type: set_adults_3
+    description: "Increment adults to 3 (click + twice)"
+    points: 1.0
+    expected:
+      event_type: guest_stepper_click
+      guestType: "adults"
+      finalCount: 3
+
+  - type: set_children_1
+    description: "Increment children to 1"
+    points: 1.0
+    expected:
+      event_type: guest_stepper_click
+      guestType: "children"
+      finalCount: 1
+
+  - type: set_infants_1
+    description: "Increment infants to 1"
+    points: 1.0
+    expected:
+      event_type: guest_stepper_click
+      guestType: "infants"
+      finalCount: 1
+
+  - type: click_search
+    description: "Click Search"
+    points: 1.5
+    expected:
+      event_type: search_submit

--- a/eval/dataset/taskflow_drag_and_edit.yaml
+++ b/eval/dataset/taskflow_drag_and_edit.yaml
@@ -1,0 +1,73 @@
+id: taskflow_drag_and_edit
+name: "TaskFlow Drag & Edit — DnD, Checklist & Hover Quick-Edit"
+difficulty: hard
+description: "Drag a card between columns, interact with card-back modal checklists, and use hover-reveal pencil to rename a card."
+start_url: "http://localhost:16605/taskflow/"
+instruction: "On the TaskFlow board, drag the card \"Write unit tests\" from \"To Do\" and drop it into the \"In Progress\" column. Then open the card \"Design API schema\" (in \"In Progress\") by clicking it. In the card-back modal, check off the checklist item \"Define endpoints\" and add a new checklist item \"Add rate limiting\". Then close the modal. Finally, hover over the card \"Deploy staging build\" in the \"Review\" column to reveal the pencil quick-edit icon, and click it to rename the card to \"Deploy production build\"."
+time_limit: 540.0
+cost_limit: 1.5
+
+criteria:
+  - type: drag_start
+    description: "Drag 'Write unit tests'"
+    points: 1.0
+    expected:
+      event_type: card_drag_start
+      cardTitle: "Write unit tests"
+      fromColumn: "To Do"
+
+  - type: drop_in_progress
+    description: "Drop in 'In Progress'"
+    points: 2.5
+    expected:
+      event_type: card_drop
+      cardTitle: "Write unit tests"
+      toColumn: "In Progress"
+
+  - type: open_design_api
+    description: "Open 'Design API schema' card-back"
+    points: 0.5
+    expected:
+      event_type: card_modal_open
+      cardTitle: "Design API schema"
+
+  - type: check_define_endpoints
+    description: "Check 'Define endpoints'"
+    points: 1.5
+    expected:
+      event_type: checklist_check
+      itemText: "Define endpoints"
+      checked: true
+
+  - type: add_rate_limiting
+    description: "Add 'Add rate limiting' checklist item"
+    points: 1.5
+    expected:
+      event_type: checklist_add_submit
+
+  - type: close_modal
+    description: "Close card-back modal"
+    points: 0.5
+    expected:
+      event_type: card_modal_close
+
+  - type: hover_deploy_reveal
+    description: "Hover 'Deploy staging build' to reveal pencil"
+    points: 1.5
+    expected:
+      event_type: card_hover_edit_reveal
+      cardTitle: "Deploy staging build"
+
+  - type: click_pencil
+    description: "Click pencil to enter quick-edit"
+    points: 1.0
+    expected:
+      event_type: card_quick_edit_open
+      cardTitle: "Deploy staging build"
+
+  - type: rename_card
+    description: "Rename to 'Deploy production build'"
+    points: 1.5
+    expected:
+      event_type: card_quick_edit_save
+      newTitle: "Deploy production build"

--- a/eval/dataset/taskflow_full_workflow.yaml
+++ b/eval/dataset/taskflow_full_workflow.yaml
@@ -1,0 +1,107 @@
+id: taskflow_full_workflow
+name: "TaskFlow Full Workflow — Create, Label, Drag & Filter"
+difficulty: very_hard
+description: "Create a card, assign color-only label, manage checklist, drag card, open board menu, and filter by label color."
+start_url: "http://localhost:16605/taskflow/"
+instruction: "Create a new card in the \"Review\" column titled \"Security audit\". Open the card-back, assign the red label (fourth color swatch from left — there are no text names, only colors), add a new checklist item \"Run OWASP scan\" and check it off. Close the card-back. Then drag \"Security audit\" from \"Review\" to \"Done\". After dropping it, open the board menu (the \"...\" button in the board header) — note that this slides in a panel from the right that shrinks the board. Use the filter in the board menu to filter by the red label, confirming that only red-labeled cards remain fully visible (others should be dimmed)."
+time_limit: 600.0
+cost_limit: 2.0
+
+criteria:
+  - type: click_add_card
+    description: "Click 'Add a card' in Review"
+    points: 0.5
+    expected:
+      event_type: add_card_click
+      column: "Review"
+
+  - type: create_card
+    description: "Type and submit 'Security audit'"
+    points: 1.0
+    expected:
+      event_type: card_create_submit
+      cardTitle: "Security audit"
+      column: "Review"
+
+  - type: open_card_back
+    description: "Open card-back"
+    points: 0.5
+    expected:
+      event_type: card_modal_open
+      cardTitle: "Security audit"
+
+  - type: open_label_picker
+    description: "Open label picker"
+    points: 0.5
+    expected:
+      event_type: label_picker_open
+
+  - type: assign_red_label
+    description: "Assign red label (4th swatch, color-only)"
+    points: 1.5
+    expected:
+      event_type: label_assign
+      color: "red"
+
+  - type: add_owasp_item
+    description: "Add checklist item 'Run OWASP scan'"
+    points: 1.0
+    expected:
+      event_type: checklist_add_submit
+
+  - type: check_owasp_item
+    description: "Check off the item"
+    points: 1.0
+    expected:
+      event_type: checklist_check
+      checked: true
+
+  - type: close_card_back
+    description: "Close card-back"
+    points: 0.5
+    expected:
+      event_type: card_modal_close
+
+  - type: drag_security_audit
+    description: "Drag 'Security audit' from Review"
+    points: 1.0
+    expected:
+      event_type: card_drag_start
+      cardTitle: "Security audit"
+      fromColumn: "Review"
+
+  - type: drop_in_done
+    description: "Drop in Done"
+    points: 2.0
+    expected:
+      event_type: card_drop
+      cardTitle: "Security audit"
+      toColumn: "Done"
+
+  - type: open_board_menu
+    description: "Open board menu ('...')"
+    points: 0.5
+    expected:
+      event_type: board_menu_open
+
+  - type: board_layout_shift
+    description: "Board menu steals horizontal space"
+    points: 0.5
+    optional: true
+    expected:
+      event_type: board_layout_shift
+
+  - type: filter_by_red
+    description: "Apply filter by red label"
+    points: 2.0
+    expected:
+      event_type: board_filter_apply
+      filterType: "label"
+      color: "red"
+
+  - type: filter_active
+    description: "Non-matching cards are dimmed"
+    points: 0.5
+    optional: true
+    expected:
+      event_type: board_filter_active

--- a/eval/dataset/vidhub_comment.yaml
+++ b/eval/dataset/vidhub_comment.yaml
@@ -1,0 +1,100 @@
+id: vidhub_comment
+name: "VidHub Comment — Description, Nested Replies & Volume Slider"
+difficulty: very_hard
+description: "Expand description, scroll to comments, sort, find specific comment, expand replies, reply with specific text, adjust volume via hover-reveal slider."
+start_url: "http://localhost:16605/vidhub/"
+instruction: "Navigate to the video \"Understanding Transformers — Visual Guide\" from the homepage feed. First, expand the video description by clicking \"...more\" below the title. Then scroll down past the description to the comments section. Change the comment sort to \"Newest first\" using the dropdown. Find the comment by \"Dr. Sarah Chen\" (you may need to scroll within the comments). Expand her reply thread by clicking \"4 replies\". Reply to her comment with a message that includes the phrase \"attention mechanism\". After submitting the reply, scroll back up and hover over the player to reveal controls, then hover over the volume icon to reveal the volume slider and adjust it to approximately 50%."
+time_limit: 600.0
+cost_limit: 2.0
+
+criteria:
+  - type: open_video
+    description: "Open target video from feed"
+    points: 0.5
+    expected:
+      event_type: video_open
+      videoId: "transformers-visual-guide"
+
+  - type: expand_description
+    description: "Expand description ('...more')"
+    points: 1.0
+    expected:
+      event_type: description_expand
+
+  - type: scroll_to_comments
+    description: "Scroll to comments section"
+    points: 0.5
+    expected:
+      event_type: comments_section_visible
+
+  - type: open_sort
+    description: "Open sort dropdown"
+    points: 0.5
+    expected:
+      event_type: comment_sort_open
+
+  - type: sort_newest
+    description: "Select 'Newest first'"
+    points: 1.0
+    expected:
+      event_type: comment_sort_change
+      sort: "newest"
+
+  - type: find_sarah_chen
+    description: "Locate Dr. Sarah Chen's comment"
+    points: 1.0
+    expected:
+      event_type: comment_visible
+      authorName: "Dr. Sarah Chen"
+
+  - type: expand_replies
+    description: "Expand '4 replies' thread"
+    points: 1.5
+    expected:
+      event_type: reply_thread_expand
+      parentCommentAuthor: "Dr. Sarah Chen"
+
+  - type: click_reply
+    description: "Click Reply on her comment"
+    points: 1.0
+    expected:
+      event_type: reply_click
+      parentCommentAuthor: "Dr. Sarah Chen"
+
+  - type: type_reply
+    description: "Type reply with 'attention mechanism'"
+    points: 1.5
+    expected:
+      event_type: reply_input
+      value_contains: "attention mechanism"
+
+  - type: submit_reply
+    description: "Submit reply"
+    points: 2.0
+    expected:
+      event_type: reply_submit
+      parentCommentAuthor: "Dr. Sarah Chen"
+
+  - type: scroll_up_to_player
+    description: "Scroll back up to player area"
+    points: 0.5
+    expected:
+      event_type: player_area_visible
+
+  - type: hover_player_controls
+    description: "Hover player to reveal controls"
+    points: 0.5
+    expected:
+      event_type: player_controls_show
+
+  - type: hover_volume_slider
+    description: "Hover volume icon to reveal slider"
+    points: 1.5
+    expected:
+      event_type: volume_slider_reveal
+
+  - type: adjust_volume
+    description: "Adjust volume to ~50%"
+    points: 2.0
+    expected:
+      event_type: volume_change

--- a/eval/dataset/vidhub_player.yaml
+++ b/eval/dataset/vidhub_player.yaml
@@ -1,0 +1,72 @@
+id: vidhub_player
+name: "VidHub Player — Search, Auto-Hide Controls & Nested Settings"
+difficulty: hard
+description: "Search for a video, use auto-hide player controls, seek timeline, navigate nested settings to change speed, like and subscribe."
+start_url: "http://localhost:16605/vidhub/"
+instruction: "On the VidHub homepage, search for \"machine learning tutorial\" and open the first result. On the video page, hover over the player area to reveal the control bar (it auto-hides after 3 seconds), then click play. Seek to approximately the 75% mark on the timeline by clicking the progress bar. Then open the Settings menu (gear icon) and navigate into the \"Playback speed\" submenu to select \"1.5x\". Finally, like the video and subscribe to the channel."
+time_limit: 540.0
+cost_limit: 1.5
+
+criteria:
+  - type: search_submit
+    description: "Search and submit query"
+    points: 0.5
+    expected:
+      event_type: search_submit
+
+  - type: open_first_result
+    description: "Open first result"
+    points: 0.5
+    expected:
+      event_type: video_open
+      videoId: "ml-tutorial"
+
+  - type: hover_reveal_controls
+    description: "Hover player to reveal controls"
+    points: 1.0
+    expected:
+      event_type: player_controls_show
+
+  - type: click_play
+    description: "Click play (icon-only)"
+    points: 1.0
+    expected:
+      event_type: player_play
+
+  - type: seek_75
+    description: "Seek to ~75% on thin progress bar"
+    points: 2.0
+    expected:
+      event_type: player_seek
+
+  - type: open_settings
+    description: "Open Settings (gear icon, icon-only)"
+    points: 1.0
+    expected:
+      event_type: settings_open
+
+  - type: open_speed_submenu
+    description: "Navigate to Playback speed submenu"
+    points: 1.5
+    expected:
+      event_type: settings_submenu_open
+      submenu: "playback-speed"
+
+  - type: select_1_5x
+    description: "Select 1.5x speed"
+    points: 1.5
+    expected:
+      event_type: playback_speed_change
+      speed: 1.5
+
+  - type: like_video
+    description: "Like the video (icon-only)"
+    points: 1.5
+    expected:
+      event_type: video_like
+
+  - type: subscribe_channel
+    description: "Subscribe to channel"
+    points: 1.5
+    expected:
+      event_type: channel_subscribe

--- a/eval/drive/css/drive.css
+++ b/eval/drive/css/drive.css
@@ -1,0 +1,258 @@
+.drive-body {
+  --mock-accent: #0f9d58;
+  --mock-accent-soft: rgba(15, 157, 88, 0.12);
+  background:
+    radial-gradient(circle at top left, rgba(216, 244, 228, 0.9), transparent 34%),
+    linear-gradient(180deg, #f4fbf8, #eef7f1 44%, #edf3ef 100%);
+}
+
+.drive-topbar {
+  display: grid;
+  grid-template-columns: 240px minmax(0, 1fr) auto;
+  gap: 18px;
+  align-items: center;
+  padding: 16px 24px;
+}
+
+.drive-brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.drive-brand-mark {
+  display: grid;
+  place-items: center;
+  width: 42px;
+  height: 42px;
+  border-radius: 14px;
+  background: linear-gradient(135deg, #e2fff0, #ffffff);
+  border: 1px solid rgba(15, 157, 88, 0.14);
+  color: var(--mock-accent);
+  font-weight: 800;
+}
+
+.drive-search-form {
+  position: relative;
+}
+
+.drive-search-submit {
+  position: absolute;
+  right: 6px;
+  top: 6px;
+  bottom: 6px;
+  min-width: 104px;
+}
+
+.drive-search-form .mock-input {
+  padding-right: 126px;
+  border-radius: 18px;
+}
+
+.drive-layout {
+  display: grid;
+  grid-template-columns: 270px minmax(420px, 1fr) 300px;
+  gap: 18px;
+  padding: 22px 24px 26px;
+}
+
+.drive-sidebar,
+.drive-main,
+.drive-detail {
+  min-height: calc(100vh - 126px);
+}
+
+.drive-sidebar {
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.drive-section-list,
+.drive-tree {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.drive-section-item,
+.drive-tree-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 10px 12px;
+  border-radius: 14px;
+  color: var(--mock-text-muted);
+}
+
+.drive-section-item.active,
+.drive-tree-item.active {
+  background: rgba(15, 157, 88, 0.11);
+  color: var(--mock-accent);
+  font-weight: 700;
+}
+
+.drive-main {
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.drive-main-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 18px 20px 16px;
+  border-bottom: 1px solid var(--mock-border);
+}
+
+.drive-toolbar-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.drive-breadcrumb {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+  color: var(--mock-text-muted);
+}
+
+.drive-content {
+  padding: 16px;
+  overflow: auto;
+}
+
+.drive-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 14px;
+}
+
+.drive-item {
+  padding: 14px;
+  border-radius: 18px;
+  border: 1px solid var(--mock-border);
+  background: rgba(255, 255, 255, 0.92);
+  display: grid;
+  gap: 8px;
+}
+
+.drive-item.selected {
+  border-color: rgba(15, 157, 88, 0.24);
+  background: rgba(15, 157, 88, 0.08);
+}
+
+.drive-item-topline {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.drive-item-name {
+  font-weight: 700;
+  line-height: 1.4;
+}
+
+.drive-item-meta {
+  color: var(--mock-text-muted);
+  font-size: 13px;
+}
+
+.drive-list-table tbody tr.selected {
+  background: rgba(15, 157, 88, 0.08);
+}
+
+.drive-detail {
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.drive-detail-block {
+  padding: 14px;
+  border-radius: 18px;
+  background: rgba(15, 23, 34, 0.03);
+}
+
+.drive-permission-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 10px;
+  align-items: center;
+  padding: 12px 0;
+  border-bottom: 1px solid var(--mock-border);
+}
+
+.drive-permission-row:last-child {
+  border-bottom: 0;
+}
+
+.drive-destination-picker {
+  max-height: 320px;
+  overflow: auto;
+  border: 1px solid var(--mock-border);
+  border-radius: 18px;
+  padding: 12px;
+  background: rgba(15, 23, 34, 0.03);
+}
+
+.drive-destination-item {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  width: 100%;
+  padding: 10px 12px;
+  border-radius: 12px;
+  background: transparent;
+  border: 1px solid transparent;
+  color: var(--mock-text);
+}
+
+.drive-destination-item.active {
+  border-color: rgba(15, 157, 88, 0.24);
+  background: rgba(15, 157, 88, 0.08);
+}
+
+.drive-upload-option {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 14px;
+  border-radius: 14px;
+  border: 1px solid var(--mock-border);
+}
+
+@media (max-width: 1220px) {
+  .drive-layout {
+    grid-template-columns: 240px 1fr;
+  }
+
+  .drive-detail {
+    grid-column: 1 / -1;
+    min-height: auto;
+  }
+}
+
+@media (max-width: 900px) {
+  .drive-topbar {
+    grid-template-columns: 1fr;
+  }
+
+  .drive-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .drive-sidebar,
+  .drive-main,
+  .drive-detail {
+    min-height: auto;
+  }
+}

--- a/eval/drive/index.html
+++ b/eval/drive/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Drive Mock Workspace</title>
+  <link rel="stylesheet" href="/css/hard-mock-base.css">
+  <link rel="stylesheet" href="/drive/css/drive.css">
+</head>
+<body class="drive-body">
+  <div id="app"></div>
+  <script src="/js/tracker.js"></script>
+  <script src="/js/hard-mock-core.js"></script>
+  <script src="/drive/js/drive.js"></script>
+</body>
+</html>

--- a/eval/drive/js/drive.js
+++ b/eval/drive/js/drive.js
@@ -683,13 +683,21 @@ window.tracker = new AgentTracker("drive.google.com", "hard");
       return;
     }
 
+    const selectedIds = uniqueSorted(state.ui.selectedIds);
+
     store.update((draft) => {
       draft.ui.modal = {
         type,
-        itemIds: uniqueSorted(draft.ui.selectedIds),
+        itemIds: selectedIds,
         destinationId: draft.ui.currentFolderId,
       };
     });
+
+    if (type === "move" && selectedIds.length > 1) {
+      tracker.track("multi_select_commit", {
+        itemIds: selectedIds,
+      });
+    }
     render();
   }
 
@@ -712,11 +720,6 @@ window.tracker = new AgentTracker("drive.google.com", "hard");
       draft.ui.detailItemId = modal.destinationId;
     });
 
-    if (itemIds.length > 1) {
-      tracker.track("multi_select_commit", {
-        itemIds,
-      });
-    }
     tracker.track("item_move", {
       itemIds,
       itemId: itemIds[0],

--- a/eval/drive/js/drive.js
+++ b/eval/drive/js/drive.js
@@ -1,0 +1,1076 @@
+window.tracker = new AgentTracker("drive.google.com", "hard");
+
+(function () {
+  const { createSeededStore, escapeHtml, uniqueSorted, normalize, formatLongDate } = window.HardMockSite;
+
+  function createItem(config) {
+    return {
+      id: config.id,
+      type: config.type,
+      name: config.name,
+      parentId: config.parentId ?? null,
+      section: config.section || "my-drive",
+      owner: config.owner || "You",
+      modifiedAt: config.modifiedAt || "2026-04-10",
+      shortcutTo: config.shortcutTo || null,
+      permissions: config.permissions || [],
+    };
+  }
+
+  function buildSeedState() {
+    const items = [
+      createItem({ id: "folder-projects", type: "folder", name: "Projects", parentId: null, section: "my-drive" }),
+      createItem({ id: "folder-design-archive", type: "folder", name: "Design Archive", parentId: null, section: "my-drive" }),
+      createItem({ id: "folder-operations", type: "folder", name: "Operations", parentId: null, section: "my-drive" }),
+      createItem({ id: "folder-release-assets", type: "folder", name: "Release Assets", parentId: null, section: "my-drive" }),
+      createItem({ id: "folder-launch", type: "folder", name: "Launch", parentId: "folder-projects", section: "my-drive" }),
+      createItem({ id: "folder-launch-working", type: "folder", name: "Working", parentId: "folder-launch", section: "my-drive" }),
+      createItem({ id: "folder-launch-final", type: "folder", name: "Final", parentId: "folder-launch", section: "my-drive" }),
+      createItem({ id: "folder-launch-board-approvals", type: "folder", name: "Board Approvals", parentId: "folder-launch-final", section: "my-drive" }),
+      createItem({ id: "folder-shared-launch-handoff", type: "folder", name: "Shared Launch Handoff", parentId: "folder-launch-final", section: "my-drive" }),
+      createItem({ id: "folder-release-social", type: "folder", name: "Social", parentId: "folder-release-assets", section: "my-drive" }),
+      createItem({ id: "folder-release-ready-social", type: "folder", name: "Release Ready Social", parentId: "folder-release-social", section: "my-drive" }),
+      createItem({ id: "folder-release-scratch", type: "folder", name: "Scratch", parentId: "folder-release-social", section: "my-drive" }),
+      createItem({ id: "folder-shared-northstar-launch", type: "folder", name: "Northstar Launch Shared", parentId: null, section: "shared", owner: "Maya Perez",
+        permissions: [
+          { email: "alex@northstar.com", role: "editor" },
+          { email: "finance.pm@northstar.com", role: "viewer" },
+        ],
+      }),
+      createItem({ id: "folder-shared-quarterly-assets", type: "folder", name: "Quarterly Assets", parentId: null, section: "shared", owner: "Rina Cho" }),
+      createItem({ id: "file-launch-brief-v5", type: "file", name: "Launch Brief v5", parentId: "folder-launch-working", section: "my-drive", modifiedAt: "2026-04-08" }),
+      createItem({ id: "file-launch-brief-final", type: "file", name: "Launch Brief Final", parentId: "folder-launch-working", section: "my-drive", modifiedAt: "2026-04-07" }),
+      createItem({ id: "file-launch-brief", type: "file", name: "Launch Brief", parentId: "folder-design-archive", section: "my-drive", modifiedAt: "2026-03-29" }),
+      createItem({ id: "shortcut-launch-brief", type: "shortcut", name: "Launch Brief Shortcut", parentId: "folder-shared-launch-handoff", section: "my-drive", shortcutTo: "file-launch-brief-final" }),
+      createItem({ id: "asset-keyvisual-final", type: "file", name: "Launch Keyvisual Final.png", parentId: "folder-release-scratch", section: "my-drive", modifiedAt: "2026-04-06" }),
+      createItem({ id: "asset-keyvisual-final-2x", type: "file", name: "Launch Keyvisual Final@2x.png", parentId: "folder-release-scratch", section: "my-drive", modifiedAt: "2026-04-06" }),
+      createItem({ id: "asset-keyvisual-final-print", type: "file", name: "Launch Keyvisual Final Print.png", parentId: "folder-release-scratch", section: "my-drive", modifiedAt: "2026-04-05" }),
+      createItem({ id: "asset-keyvisual-final-copy", type: "file", name: "Launch Keyvisual Final copy.png", parentId: "folder-release-scratch", section: "my-drive", modifiedAt: "2026-04-04" }),
+      createItem({ id: "shortcut-keyvisual-final", type: "shortcut", name: "Launch Keyvisual Final shortcut", parentId: "folder-release-scratch", section: "my-drive", shortcutTo: "asset-keyvisual-final" }),
+    ];
+
+    const fillerFolders = [
+      "folder-projects",
+      "folder-launch-working",
+      "folder-launch-final",
+      "folder-design-archive",
+      "folder-operations",
+      "folder-release-social",
+      "folder-shared-quarterly-assets",
+      "folder-shared-northstar-launch",
+    ];
+
+    fillerFolders.forEach((folderId, folderIndex) => {
+      for (let index = 1; index <= 6; index += 1) {
+        items.push(
+          createItem({
+            id: `${folderId}-file-${index}`,
+            type: "file",
+            name: `Seeded Asset ${folderIndex + 1}.${index}`,
+            parentId: folderId,
+            section: folderId.startsWith("folder-shared") ? "shared" : "my-drive",
+            owner: folderId.startsWith("folder-shared") ? "Shared owner" : "You",
+            modifiedAt: `2026-04-${String((index % 8) + 1).padStart(2, "0")}`,
+          }),
+        );
+      }
+    });
+
+    return {
+      items,
+      ui: {
+        section: "my-drive",
+        currentFolderId: null,
+        searchQuery: "",
+        viewMode: "grid",
+        selectedIds: [],
+        detailItemId: "file-launch-brief-v5",
+        modal: null,
+      },
+      counters: {
+        shortcut: 1,
+        upload: 1,
+      },
+    };
+  }
+
+  const store = createSeededStore({
+    storageKey: "openbrowser.eval.drive",
+    seedState: buildSeedState(),
+  });
+
+  const UPLOAD_CHOICES = [
+    { id: "upload-launch-keyvisual-retouched", name: "Launch-Keyvisual-Final-retouched.png", destinationId: "folder-release-ready-social" },
+    { id: "upload-board-brief-pdf", name: "Board-Brief.pdf", destinationId: "folder-launch-board-approvals" },
+    { id: "upload-mini-logo-lockup", name: "Logo-Lockup-Mini.svg", destinationId: "folder-release-social" },
+  ];
+
+  const app = document.getElementById("app");
+
+  function getItemById(state, itemId) {
+    return state.items.find((item) => item.id === itemId) || null;
+  }
+
+  function getChildren(state, parentId, section) {
+    return state.items.filter((item) => item.parentId === parentId && item.section === section);
+  }
+
+  function getFolderPath(state, folderId) {
+    const path = [];
+    let current = folderId ? getItemById(state, folderId) : null;
+    while (current) {
+      path.unshift(current);
+      current = current.parentId ? getItemById(state, current.parentId) : null;
+    }
+    return path;
+  }
+
+  function getVisibleItems(state) {
+    const query = state.ui.searchQuery.trim();
+    if (query) {
+      return state.items.filter((item) => {
+        const parentPath = getFolderPath(state, item.parentId)
+          .map((folder) => folder.name)
+          .join(" / ");
+        return normalize(`${item.name} ${item.owner} ${parentPath}`).includes(normalize(query));
+      });
+    }
+
+    return state.items.filter(
+      (item) => item.section === state.ui.section && item.parentId === state.ui.currentFolderId,
+    );
+  }
+
+  function setDetail(itemId) {
+    store.update((state) => {
+      state.ui.detailItemId = itemId;
+    });
+  }
+
+  function renderSidebar(state) {
+    const sections = [
+      { id: "my-drive", label: "My Drive" },
+      { id: "shared", label: "Shared with me" },
+      { id: "recent", label: "Recent" },
+    ];
+
+    const visibleFolders = state.items.filter(
+      (item) =>
+        item.type === "folder" &&
+        item.section === (state.ui.section === "recent" ? "my-drive" : state.ui.section) &&
+        (item.parentId === null || ["folder-projects", "folder-release-assets", "folder-shared-northstar-launch"].includes(item.parentId)),
+    );
+
+    return `
+      <aside class="drive-sidebar mock-card">
+        <div>
+          <p class="mock-kicker">Workspace</p>
+          <div class="drive-section-list">
+            ${sections
+              .map(
+                (section) => `
+                  <button class="drive-section-item ${state.ui.section === section.id ? "active" : ""}" data-action="set-section" data-section="${section.id}">
+                    <span>${section.label}</span>
+                    <span>${state.items.filter((item) => item.section === (section.id === "recent" ? "my-drive" : section.id)).length}</span>
+                  </button>
+                `,
+              )
+              .join("")}
+          </div>
+        </div>
+        <div>
+          <p class="mock-kicker">Folder Tree</p>
+          <div class="drive-tree">
+            ${visibleFolders
+              .map(
+                (folder) => `
+                  <button class="drive-tree-item ${state.ui.currentFolderId === folder.id ? "active" : ""}" data-action="open-folder" data-folder-id="${folder.id}">
+                    <span>${escapeHtml(folder.name)}</span>
+                    <span>${getChildren(state, folder.id, folder.section).length}</span>
+                  </button>
+                `,
+              )
+              .join("")}
+          </div>
+        </div>
+      </aside>
+    `;
+  }
+
+  function renderItemCard(state, item) {
+    const selected = state.ui.selectedIds.includes(item.id);
+    const path = getFolderPath(state, item.parentId).map((folder) => folder.name).join(" / ");
+    return `
+      <article class="drive-item ${selected ? "selected" : ""}">
+        <div class="drive-item-topline">
+          <div>
+            <div class="drive-item-name">${escapeHtml(item.name)}</div>
+            <div class="drive-item-meta">${escapeHtml(item.type)} · ${escapeHtml(item.owner)}</div>
+          </div>
+          <input type="checkbox" data-action="toggle-select" data-item-id="${item.id}" ${selected ? "checked" : ""}>
+        </div>
+        <div class="drive-item-meta">${path ? escapeHtml(path) : "Top level"}</div>
+        <div class="drive-item-meta">${formatLongDate(item.modifiedAt)}</div>
+        <div class="drive-toolbar-actions">
+          ${item.type === "folder"
+            ? `<button class="mock-btn-secondary" data-action="open-folder" data-folder-id="${item.id}">Open</button>`
+            : `<button class="mock-btn-secondary" data-action="focus-item" data-item-id="${item.id}">Details</button>`}
+        </div>
+      </article>
+    `;
+  }
+
+  function renderListTable(state, items) {
+    return `
+      <table class="mock-table drive-list-table">
+        <thead>
+          <tr>
+            <th>Select</th>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Owner</th>
+            <th>Location</th>
+          </tr>
+        </thead>
+        <tbody>
+          ${items
+            .map((item) => {
+              const selected = state.ui.selectedIds.includes(item.id);
+              const path = getFolderPath(state, item.parentId).map((folder) => folder.name).join(" / ");
+              return `
+                <tr class="${selected ? "selected" : ""}">
+                  <td><input type="checkbox" data-action="toggle-select" data-item-id="${item.id}" ${selected ? "checked" : ""}></td>
+                  <td>
+                    <button class="mock-btn-ghost" data-action="${item.type === "folder" ? "open-folder" : "focus-item"}" ${
+                      item.type === "folder" ? `data-folder-id="${item.id}"` : `data-item-id="${item.id}"`
+                    }>
+                      ${escapeHtml(item.name)}
+                    </button>
+                  </td>
+                  <td>${escapeHtml(item.type)}</td>
+                  <td>${escapeHtml(item.owner)}</td>
+                  <td>${escapeHtml(path || "Top level")}</td>
+                </tr>
+              `;
+            })
+            .join("")}
+        </tbody>
+      </table>
+    `;
+  }
+
+  function renderMain(state) {
+    const visibleItems = state.ui.section === "recent"
+      ? state.items.slice().sort((a, b) => b.modifiedAt.localeCompare(a.modifiedAt)).slice(0, 12)
+      : getVisibleItems(state);
+    const path = getFolderPath(state, state.ui.currentFolderId);
+    const surfaceItem = getItemById(state, state.ui.currentFolderId);
+    const singleTargetSelected = state.ui.selectedIds.length === 1;
+    const surfaceActionTarget = singleTargetSelected
+      ? getItemById(state, state.ui.selectedIds[0])
+      : surfaceItem;
+    const shareActionEnabled = Boolean(surfaceActionTarget);
+    const selectionText = state.ui.selectedIds.length
+      ? `${state.ui.selectedIds.length} selected`
+      : state.ui.searchQuery
+        ? `Search: ${escapeHtml(state.ui.searchQuery)}`
+        : path.length
+          ? path.map((folder) => folder.name).join(" / ")
+          : state.ui.section === "shared"
+            ? "Shared with me"
+            : "My Drive";
+
+    return `
+      <section class="drive-main mock-card">
+        <div class="drive-main-toolbar">
+          <div>
+            <p class="mock-kicker">Surface</p>
+            <h2 class="mock-title">${selectionText}</h2>
+            <div class="drive-breadcrumb">
+              <button class="mock-btn-ghost" data-action="go-root">Root</button>
+              ${path.map((folder) => `<span>${escapeHtml(folder.name)}</span>`).join("<span>/</span>")}
+            </div>
+          </div>
+          <div class="drive-toolbar-actions">
+            <button class="mock-btn-secondary" data-action="set-view" data-view-mode="grid">Grid</button>
+            <button class="mock-btn-secondary" data-action="set-view" data-view-mode="list">List</button>
+            <button class="mock-btn-secondary" data-action="open-rename" ${state.ui.selectedIds.length === 1 ? "" : "disabled"}>Rename</button>
+            <button class="mock-btn-secondary" data-action="open-move" ${state.ui.selectedIds.length ? "" : "disabled"}>Move</button>
+            <button class="mock-btn-secondary" data-action="open-shortcut" ${state.ui.selectedIds.length === 1 ? "" : "disabled"}>Create shortcut</button>
+            <button class="mock-btn-secondary" data-action="open-share" ${shareActionEnabled ? "" : "disabled"}>Share</button>
+            <button class="mock-btn-secondary" data-action="open-upload">Mock upload</button>
+            <button class="mock-btn-danger" data-action="delete-selected" ${state.ui.selectedIds.length === 1 ? "" : "disabled"}>Delete</button>
+          </div>
+        </div>
+        <div class="drive-content">
+          ${
+            visibleItems.length
+              ? state.ui.viewMode === "grid"
+                ? `<div class="drive-grid">${visibleItems.map((item) => renderItemCard(state, item)).join("")}</div>`
+                : renderListTable(state, visibleItems)
+              : '<div class="mock-empty">No items in this folder or search view.</div>'
+          }
+        </div>
+      </section>
+    `;
+  }
+
+  function renderDetail(state) {
+    const detailItem = getItemById(state, state.ui.detailItemId) || getItemById(state, state.ui.selectedIds[0]) || null;
+
+    if (!detailItem) {
+      return `
+        <aside class="drive-detail mock-card">
+          <div class="mock-empty">Select a file or folder to inspect metadata, permissions, and move targets.</div>
+        </aside>
+      `;
+    }
+
+    const folderPath = getFolderPath(state, detailItem.parentId).map((folder) => folder.name).join(" / ");
+    return `
+      <aside class="drive-detail mock-card">
+        <div>
+          <p class="mock-kicker">Details</p>
+          <h3 class="mock-title">${escapeHtml(detailItem.name)}</h3>
+          <p class="mock-subtle">${escapeHtml(detailItem.type)} · ${escapeHtml(detailItem.owner)}</p>
+        </div>
+        <div class="drive-detail-block">
+          <div class="mock-kicker">Location</div>
+          <div>${escapeHtml(folderPath || "Top level")}</div>
+        </div>
+        <div class="drive-detail-block">
+          <div class="mock-kicker">Modified</div>
+          <div>${formatLongDate(detailItem.modifiedAt)}</div>
+        </div>
+        ${
+          detailItem.permissions.length
+            ? `
+              <div class="drive-detail-block">
+                <div class="mock-kicker">Permissions</div>
+                ${detailItem.permissions
+                  .map(
+                    (permission) => `
+                      <div class="drive-permission-row">
+                        <span>${escapeHtml(permission.email)}</span>
+                        <span class="mock-badge">${escapeHtml(permission.role)}</span>
+                      </div>
+                    `,
+                  )
+                  .join("")}
+              </div>
+            `
+            : `
+              <div class="drive-detail-block">
+                <div class="mock-kicker">Permissions</div>
+                <div class="mock-subtle">No custom collaborators on this item.</div>
+              </div>
+            `
+        }
+      </aside>
+    `;
+  }
+
+  function getAllDestinationFolders(state) {
+    return state.items.filter((item) => item.type === "folder");
+  }
+
+  function renderDestinationPicker(state, activeDestinationId) {
+    return `
+      <div class="drive-destination-picker">
+        ${getAllDestinationFolders(state)
+          .map((folder) => {
+            const path = getFolderPath(state, folder.parentId).map((item) => item.name).join(" / ");
+            return `
+              <button class="drive-destination-item ${activeDestinationId === folder.id ? "active" : ""}" data-action="set-modal-destination" data-destination-id="${folder.id}">
+                <span>${escapeHtml(folder.name)}</span>
+                <span class="mock-subtle">${escapeHtml(path || folder.section)}</span>
+              </button>
+            `;
+          })
+          .join("")}
+      </div>
+    `;
+  }
+
+  function renderModal(state) {
+    const modal = state.ui.modal;
+    if (!modal) {
+      return "";
+    }
+
+    if (modal.type === "rename") {
+      return `
+        <div class="mock-modal-backdrop">
+          <div class="mock-modal">
+            <div class="mock-modal-header">
+              <div>
+                <p class="mock-kicker">Rename item</p>
+                <h3 class="mock-title">${escapeHtml(modal.itemId)}</h3>
+              </div>
+              <button class="mock-btn-ghost" data-action="close-modal">Close</button>
+            </div>
+            <div class="mock-modal-body">
+              <label class="mock-kicker" for="drive-rename-input">New name</label>
+              <input id="drive-rename-input" class="mock-input" data-modal-field="newName" value="${escapeHtml(modal.newName || "")}">
+            </div>
+            <div class="mock-modal-footer">
+              <span class="mock-subtle">Rename preserves stable item IDs; scoring uses the same seeded object.</span>
+              <button class="mock-btn" data-action="commit-rename">Save</button>
+            </div>
+          </div>
+        </div>
+      `;
+    }
+
+    if (modal.type === "move" || modal.type === "shortcut") {
+      const title = modal.type === "move" ? "Move items" : "Create shortcut";
+      return `
+        <div class="mock-modal-backdrop">
+          <div class="mock-modal">
+            <div class="mock-modal-header">
+              <div>
+                <p class="mock-kicker">${modal.type}</p>
+                <h3 class="mock-title">${title}</h3>
+              </div>
+              <button class="mock-btn-ghost" data-action="close-modal">Close</button>
+            </div>
+            <div class="mock-modal-body">
+              <p class="mock-subtle">Selected: ${escapeHtml((modal.itemIds || []).join(", "))}</p>
+              ${renderDestinationPicker(state, modal.destinationId || null)}
+            </div>
+            <div class="mock-modal-footer">
+              <span class="mock-subtle">The destination picker is intentionally scrollable and nested.</span>
+              <button class="mock-btn" data-action="${modal.type === "move" ? "commit-move" : "commit-shortcut"}">
+                ${modal.type === "move" ? "Move items" : "Create shortcut"}
+              </button>
+            </div>
+          </div>
+        </div>
+      `;
+    }
+
+    if (modal.type === "share") {
+      const item = getItemById(state, modal.itemId);
+      return `
+        <div class="mock-modal-backdrop">
+          <div class="mock-modal">
+            <div class="mock-modal-header">
+              <div>
+                <p class="mock-kicker">Share dialog</p>
+                <h3 class="mock-title">${escapeHtml(item ? item.name : modal.itemId)}</h3>
+              </div>
+              <button class="mock-btn-ghost" data-action="close-modal">Close</button>
+            </div>
+            <div class="mock-modal-body">
+              ${(item?.permissions || [])
+                .map(
+                  (permission) => `
+                    <div class="drive-permission-row">
+                      <span>${escapeHtml(permission.email)}</span>
+                      <select class="mock-select" data-action="change-permission-role" data-email="${permission.email}">
+                        ${["viewer", "commenter", "editor"]
+                          .map(
+                            (role) => `<option value="${role}" ${permission.role === role ? "selected" : ""}>${role}</option>`,
+                          )
+                          .join("")}
+                      </select>
+                    </div>
+                  `,
+                )
+                .join("")}
+              <div class="mock-divider" style="margin: 14px 0;"></div>
+              <div class="mock-split">
+                <div>
+                  <label class="mock-kicker" for="share-email">Add collaborator</label>
+                  <input id="share-email" class="mock-input" data-modal-field="email" value="${escapeHtml(modal.email || "")}" placeholder="name@example.com">
+                </div>
+                <div>
+                  <label class="mock-kicker" for="share-role">Role</label>
+                  <select id="share-role" class="mock-select" data-modal-field="role">
+                    ${["viewer", "commenter", "editor"]
+                      .map((role) => `<option value="${role}" ${modal.role === role ? "selected" : ""}>${role}</option>`)
+                      .join("")}
+                  </select>
+                </div>
+              </div>
+            </div>
+            <div class="mock-modal-footer">
+              <span class="mock-subtle">Add or downgrade collaborators from this modal.</span>
+              <button class="mock-btn" data-action="add-permission">Add collaborator</button>
+            </div>
+          </div>
+        </div>
+      `;
+    }
+
+    if (modal.type === "upload") {
+      return `
+        <div class="mock-modal-backdrop">
+          <div class="mock-modal">
+            <div class="mock-modal-header">
+              <div>
+                <p class="mock-kicker">Frontend upload picker</p>
+                <h3 class="mock-title">Choose a replacement asset</h3>
+              </div>
+              <button class="mock-btn-ghost" data-action="close-modal">Close</button>
+            </div>
+            <div class="mock-modal-body">
+              <div class="mock-split">
+                ${UPLOAD_CHOICES.map((choice) => `
+                  <button class="drive-upload-option" data-action="select-upload-choice" data-upload-id="${choice.id}">
+                    <span>${escapeHtml(choice.name)}</span>
+                    <span class="mock-subtle">${escapeHtml(choice.destinationId)}</span>
+                  </button>
+                `).join("")}
+              </div>
+              <div style="margin-top: 16px;">
+                <p class="mock-kicker">Destination</p>
+                ${renderDestinationPicker(state, modal.destinationId || null)}
+              </div>
+            </div>
+            <div class="mock-modal-footer">
+              <span class="mock-subtle">This replaces native upload with deterministic in-page assets.</span>
+              <button class="mock-btn" data-action="commit-upload" ${modal.uploadId ? "" : "disabled"}>Upload selected asset</button>
+            </div>
+          </div>
+        </div>
+      `;
+    }
+
+    return "";
+  }
+
+  function render() {
+    const state = store.getState();
+    app.innerHTML = `
+      <div class="mock-page">
+        <header class="mock-topbar">
+          <div class="drive-topbar">
+            <div class="drive-brand">
+              <div class="drive-brand-mark">D</div>
+              <div>
+                <div style="font-weight: 800;">Drive Workspace</div>
+                <div class="mock-subtle">Nested folders, sharing, shortcuts, uploads</div>
+              </div>
+            </div>
+            <form id="drive-search-form" class="drive-search-form">
+              <input id="drive-search-input" class="mock-input" value="${escapeHtml(state.ui.searchQuery)}" placeholder="Search in Drive">
+              <button class="mock-btn drive-search-submit" type="submit">Search</button>
+            </form>
+            <div style="display: flex; gap: 10px;">
+              <span class="mock-pill">50+ seeded objects</span>
+              <span class="mock-pill">Bulk toolbar is selection-based</span>
+            </div>
+          </div>
+        </header>
+        <main class="drive-layout">
+          ${renderSidebar(state)}
+          ${renderMain(state)}
+          ${renderDetail(state)}
+        </main>
+        ${renderModal(state)}
+      </div>
+    `;
+  }
+
+  function openFolder(folderId) {
+    const state = store.getState();
+    const folder = getItemById(state, folderId);
+    if (!folder) {
+      return;
+    }
+
+    store.update((draft) => {
+      draft.ui.section = folder.section;
+      draft.ui.currentFolderId = folder.id;
+      draft.ui.searchQuery = "";
+      draft.ui.selectedIds = [];
+      draft.ui.detailItemId = folder.id;
+    });
+
+    tracker.track("folder_open", {
+      folderId: folder.id,
+      section: folder.section,
+    });
+    render();
+  }
+
+  function setSection(section) {
+    store.update((state) => {
+      state.ui.section = section;
+      state.ui.currentFolderId = null;
+      state.ui.searchQuery = "";
+      state.ui.selectedIds = [];
+    });
+    render();
+  }
+
+  function setView(viewMode) {
+    store.update((state) => {
+      state.ui.viewMode = viewMode;
+    });
+    tracker.track("view_mode_change", {
+      viewMode,
+    });
+    render();
+  }
+
+  function toggleSelect(itemId) {
+    const nextState = store.update((state) => {
+      const selected = new Set(state.ui.selectedIds);
+      if (selected.has(itemId)) {
+        selected.delete(itemId);
+      } else {
+        selected.add(itemId);
+      }
+      state.ui.selectedIds = Array.from(selected);
+      state.ui.detailItemId = itemId;
+    });
+
+    tracker.track("item_select", {
+      itemId,
+      itemIds: uniqueSorted(nextState.ui.selectedIds),
+    });
+    render();
+  }
+
+  function openRenameModal() {
+    const state = store.getState();
+    if (state.ui.selectedIds.length !== 1) {
+      return;
+    }
+
+    const item = getItemById(state, state.ui.selectedIds[0]);
+    if (!item) {
+      return;
+    }
+
+    store.update((draft) => {
+      draft.ui.modal = {
+        type: "rename",
+        itemId: item.id,
+        newName: item.name,
+      };
+    });
+    render();
+  }
+
+  function commitRename() {
+    const state = store.getState();
+    const modal = state.ui.modal;
+    if (!modal || modal.type !== "rename") {
+      return;
+    }
+
+    store.update((draft) => {
+      const item = getItemById(draft, modal.itemId);
+      if (item) {
+        item.name = modal.newName.trim();
+      }
+      draft.ui.modal = null;
+    });
+
+    tracker.track("item_rename", {
+      itemId: modal.itemId,
+      newName: modal.newName.trim(),
+    });
+    render();
+  }
+
+  function openDestinationModal(type) {
+    const state = store.getState();
+    if (!state.ui.selectedIds.length) {
+      return;
+    }
+
+    store.update((draft) => {
+      draft.ui.modal = {
+        type,
+        itemIds: uniqueSorted(draft.ui.selectedIds),
+        destinationId: draft.ui.currentFolderId,
+      };
+    });
+    render();
+  }
+
+  function commitMove() {
+    const state = store.getState();
+    const modal = state.ui.modal;
+    if (!modal || modal.type !== "move" || !modal.destinationId) {
+      return;
+    }
+
+    const itemIds = uniqueSorted(modal.itemIds || []);
+    store.update((draft) => {
+      draft.items.forEach((item) => {
+        if (itemIds.includes(item.id)) {
+          item.parentId = modal.destinationId;
+        }
+      });
+      draft.ui.modal = null;
+      draft.ui.selectedIds = [];
+      draft.ui.detailItemId = modal.destinationId;
+    });
+
+    if (itemIds.length > 1) {
+      tracker.track("multi_select_commit", {
+        itemIds,
+      });
+    }
+    tracker.track("item_move", {
+      itemIds,
+      itemId: itemIds[0],
+      destinationId: modal.destinationId,
+    });
+    render();
+  }
+
+  function commitShortcut() {
+    const state = store.getState();
+    const modal = state.ui.modal;
+    if (!modal || modal.type !== "shortcut" || !modal.destinationId || modal.itemIds.length !== 1) {
+      return;
+    }
+
+    const sourceItem = getItemById(state, modal.itemIds[0]);
+    const shortcutId = `shortcut-generated-${state.counters.shortcut}`;
+    if (!sourceItem) {
+      return;
+    }
+
+    store.update((draft) => {
+      draft.items.push(
+        createItem({
+          id: shortcutId,
+          type: "shortcut",
+          name: `${sourceItem.name} shortcut`,
+          parentId: modal.destinationId,
+          section: getItemById(draft, modal.destinationId)?.section || "my-drive",
+          owner: "You",
+          shortcutTo: sourceItem.id,
+        }),
+      );
+      draft.counters.shortcut += 1;
+      draft.ui.modal = null;
+      draft.ui.selectedIds = [];
+    });
+
+    tracker.track("shortcut_create", {
+      sourceId: sourceItem.id,
+      shortcutId,
+      destinationId: modal.destinationId,
+    });
+    render();
+  }
+
+  function openShareDialog() {
+    const state = store.getState();
+    const itemId = state.ui.selectedIds.length === 1
+      ? state.ui.selectedIds[0]
+      : state.ui.currentFolderId;
+    const item = itemId ? getItemById(state, itemId) : null;
+    if (!item) {
+      return;
+    }
+
+    store.update((draft) => {
+      draft.ui.modal = {
+        type: "share",
+        itemId: item.id,
+        email: "",
+        role: "viewer",
+      };
+    });
+
+    tracker.track("share_dialog_open", {
+      itemId: item.id,
+    });
+    render();
+  }
+
+  function addPermission() {
+    const state = store.getState();
+    const modal = state.ui.modal;
+    if (!modal || modal.type !== "share" || !modal.email.trim()) {
+      return;
+    }
+
+    store.update((draft) => {
+      const item = getItemById(draft, modal.itemId);
+      if (!item) {
+        return;
+      }
+      item.permissions.push({
+        email: modal.email.trim(),
+        role: modal.role,
+      });
+      draft.ui.modal.email = "";
+      draft.ui.modal.role = "viewer";
+    });
+
+    tracker.track("permission_add", {
+      itemId: modal.itemId,
+      email: modal.email.trim(),
+      role: modal.role,
+    });
+    render();
+  }
+
+  function changePermission(email, role) {
+    const state = store.getState();
+    const modal = state.ui.modal;
+    if (!modal || modal.type !== "share") {
+      return;
+    }
+
+    store.update((draft) => {
+      const item = getItemById(draft, modal.itemId);
+      const permission = item?.permissions.find((entry) => entry.email === email);
+      if (permission) {
+        permission.role = role;
+      }
+    });
+
+    tracker.track("permission_change", {
+      itemId: modal.itemId,
+      email,
+      role,
+    });
+    render();
+  }
+
+  function openUploadModal() {
+    store.update((state) => {
+      state.ui.modal = {
+        type: "upload",
+        uploadId: "",
+        destinationId: state.ui.currentFolderId || "folder-release-ready-social",
+      };
+    });
+    render();
+  }
+
+  function commitUpload() {
+    const state = store.getState();
+    const modal = state.ui.modal;
+    if (!modal || modal.type !== "upload" || !modal.uploadId || !modal.destinationId) {
+      return;
+    }
+
+    const choice = UPLOAD_CHOICES.find((item) => item.id === modal.uploadId);
+    if (!choice) {
+      return;
+    }
+
+    const itemId = choice.id;
+    store.update((draft) => {
+      draft.items.push(
+        createItem({
+          id: itemId,
+          type: "file",
+          name: choice.name,
+          parentId: modal.destinationId,
+          section: getItemById(draft, modal.destinationId)?.section || "my-drive",
+          modifiedAt: "2026-04-10",
+        }),
+      );
+      draft.ui.modal = null;
+      draft.ui.detailItemId = itemId;
+    });
+
+    tracker.track("mock_upload_complete", {
+      itemId,
+      destinationId: modal.destinationId,
+      name: choice.name,
+    });
+    render();
+  }
+
+  function deleteSelected() {
+    const state = store.getState();
+    if (state.ui.selectedIds.length !== 1) {
+      return;
+    }
+
+    const itemId = state.ui.selectedIds[0];
+    store.update((draft) => {
+      draft.items = draft.items.filter((item) => item.id !== itemId);
+      draft.ui.selectedIds = [];
+      draft.ui.modal = null;
+      draft.ui.detailItemId = null;
+    });
+
+    tracker.track("item_delete", {
+      itemId,
+    });
+    render();
+  }
+
+  app.addEventListener("submit", (event) => {
+    if (event.target.id !== "drive-search-form") {
+      return;
+    }
+
+    event.preventDefault();
+    const input = document.getElementById("drive-search-input");
+    const query = input ? input.value.trim() : "";
+    store.update((state) => {
+      state.ui.searchQuery = query;
+      state.ui.section = "my-drive";
+      state.ui.currentFolderId = null;
+      state.ui.selectedIds = [];
+    });
+
+    tracker.track("drive_search_execute", {
+      query,
+    });
+    render();
+  });
+
+  app.addEventListener("click", (event) => {
+    const target = event.target.closest("[data-action]");
+    if (!target) {
+      return;
+    }
+
+    const action = target.dataset.action;
+
+    if (action === "set-section") {
+      setSection(target.dataset.section);
+      return;
+    }
+
+    if (action === "open-folder") {
+      openFolder(target.dataset.folderId);
+      return;
+    }
+
+    if (action === "go-root") {
+      store.update((state) => {
+        state.ui.currentFolderId = null;
+        state.ui.selectedIds = [];
+      });
+      render();
+      return;
+    }
+
+    if (action === "set-view") {
+      setView(target.dataset.viewMode);
+      return;
+    }
+
+    if (action === "toggle-select") {
+      toggleSelect(target.dataset.itemId);
+      return;
+    }
+
+    if (action === "focus-item") {
+      setDetail(target.dataset.itemId);
+      render();
+      return;
+    }
+
+    if (action === "open-rename") {
+      openRenameModal();
+      return;
+    }
+
+    if (action === "commit-rename") {
+      commitRename();
+      return;
+    }
+
+    if (action === "open-move") {
+      openDestinationModal("move");
+      return;
+    }
+
+    if (action === "commit-move") {
+      commitMove();
+      return;
+    }
+
+    if (action === "open-shortcut") {
+      openDestinationModal("shortcut");
+      return;
+    }
+
+    if (action === "commit-shortcut") {
+      commitShortcut();
+      return;
+    }
+
+    if (action === "set-modal-destination") {
+      store.update((state) => {
+        if (state.ui.modal) {
+          state.ui.modal.destinationId = target.dataset.destinationId;
+        }
+      });
+      render();
+      return;
+    }
+
+    if (action === "open-share") {
+      openShareDialog();
+      return;
+    }
+
+    if (action === "add-permission") {
+      addPermission();
+      return;
+    }
+
+    if (action === "open-upload") {
+      openUploadModal();
+      return;
+    }
+
+    if (action === "select-upload-choice") {
+      store.update((state) => {
+        if (state.ui.modal?.type === "upload") {
+          state.ui.modal.uploadId = target.dataset.uploadId;
+        }
+      });
+      render();
+      return;
+    }
+
+    if (action === "commit-upload") {
+      commitUpload();
+      return;
+    }
+
+    if (action === "delete-selected") {
+      deleteSelected();
+      return;
+    }
+
+    if (action === "close-modal") {
+      store.update((state) => {
+        state.ui.modal = null;
+      });
+      render();
+    }
+  });
+
+  app.addEventListener("input", (event) => {
+    const field = event.target.dataset.modalField;
+    if (!field) {
+      return;
+    }
+
+    store.update((state) => {
+      if (state.ui.modal) {
+        state.ui.modal[field] = event.target.value;
+      }
+    });
+  });
+
+  app.addEventListener("change", (event) => {
+    if (event.target.dataset.action === "change-permission-role") {
+      changePermission(event.target.dataset.email, event.target.value);
+    }
+  });
+
+  render();
+})();

--- a/eval/evaluate_browser_agent.py
+++ b/eval/evaluate_browser_agent.py
@@ -1645,11 +1645,10 @@ class Evaluator:
             return False
 
         expected_element_href = expected.get("element_href")
-        if expected_element_href and expected_element_href not in (
-            event.get("elementHref") or ""
-        ):
-            # elementHref may not be tracked, we can check selector
-            pass
+        if expected_element_href:
+            element_href = event.get("elementHref")
+            if not element_href or expected_element_href not in element_href:
+                return False
 
         # Check parent text contains (for contextual matching)
         expected_parent_text_contains = expected.get("parent_text_contains")
@@ -1693,9 +1692,28 @@ class Evaluator:
         # Additional custom checks
         expected_check = expected.get("check")
         if expected_check == "upvote_count_changed":
-            # Placeholder for custom logic
-            # Could check if upvote count increased in subsequent events
-            pass
+            if event.get("eventType") == "upvote_toggle":
+                if event.get("voted") is not True:
+                    return False
+            else:
+                previous_count = (
+                    event.get("previousCount")
+                    or event.get("oldCount")
+                    or event.get("beforeCount")
+                )
+                new_count = (
+                    event.get("upvoteCount")
+                    or event.get("count")
+                    or event.get("newCount")
+                    or event.get("afterCount")
+                )
+                if previous_count is None or new_count is None:
+                    return False
+                try:
+                    if int(new_count) <= int(previous_count):
+                        return False
+                except (TypeError, ValueError):
+                    return False
 
         # Check all other expected fields directly against event
         for key, expected_value in expected.items():
@@ -1712,8 +1730,11 @@ class Evaluator:
 
     def _sse_event_matches_expected(self, event: Dict, expected: Dict) -> bool:
         """Check if an SSE event matches expected criteria"""
-        # Currently not using SSE events for criteria
-        return False
+        payload = event.get("data")
+        normalized_event = payload.copy() if isinstance(payload, dict) else {}
+        normalized_event["eventType"] = event.get("type")
+        normalized_event.setdefault("timestamp", event.get("timestamp"))
+        return self._event_matches_expected(normalized_event, expected)
 
     def generate_report(self):
         """Generate evaluation report"""

--- a/eval/evaluate_browser_agent.py
+++ b/eval/evaluate_browser_agent.py
@@ -1853,7 +1853,8 @@ class Evaluator:
         print(
             "\nPerform this task in the browser. Events will be tracked from this moment."
         )
-        print("When you have completed the task, enter 'ok' below.")
+        print("Complete the task using the website's own controls.")
+        print("After you finish in the browser, return here and enter 'ok' below.")
 
         # Start timing when instruction is shown (same as automated test)
         start_time = time.time()
@@ -1861,14 +1862,14 @@ class Evaluator:
         # Wait for user to complete the entire task
         while True:
             response = (
-                input("\nEnter 'ok' when you have completed the task > ")
+                input("\nAfter finishing in the browser, enter 'ok' here > ")
                 .strip()
                 .lower()
             )
             if response == "ok":
                 break
             else:
-                print("Please enter 'ok' when you have completed the task.")
+                print("Please finish the browser task first, then enter 'ok' here.")
 
         end_time = time.time()
         duration = end_time - start_time

--- a/eval/github/css/github.css
+++ b/eval/github/css/github.css
@@ -1,0 +1,207 @@
+.github-body {
+  --mock-accent: #1f6feb;
+  --mock-accent-soft: rgba(31, 111, 235, 0.12);
+  background:
+    radial-gradient(circle at top left, rgba(226, 238, 255, 0.88), transparent 34%),
+    linear-gradient(180deg, #f6f8fb, #eef2f8 40%, #edf1f5 100%);
+}
+
+.github-topbar {
+  display: grid;
+  grid-template-columns: 260px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 18px;
+  padding: 16px 24px;
+}
+
+.github-brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-weight: 800;
+}
+
+.github-brand-mark {
+  display: grid;
+  place-items: center;
+  width: 42px;
+  height: 42px;
+  border-radius: 14px;
+  background: linear-gradient(135deg, #e0ebff, #ffffff);
+  border: 1px solid rgba(31, 111, 235, 0.12);
+  color: var(--mock-accent);
+}
+
+.github-shell {
+  padding: 22px 24px 30px;
+}
+
+.github-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 320px;
+  gap: 18px;
+}
+
+.github-repo-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.github-repo-nav .active {
+  background: rgba(31, 111, 235, 0.12);
+  color: var(--mock-accent);
+}
+
+.github-list-panel,
+.github-detail-panel,
+.github-sidebar {
+  padding: 18px;
+}
+
+.github-list-item,
+.github-file-card,
+.github-comment-card {
+  padding: 14px;
+  border-radius: 18px;
+  border: 1px solid var(--mock-border);
+  background: rgba(255, 255, 255, 0.94);
+  display: grid;
+  gap: 8px;
+}
+
+.github-list {
+  display: grid;
+  gap: 12px;
+}
+
+.github-item-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 14px;
+  align-items: flex-start;
+}
+
+.github-item-title {
+  font-weight: 800;
+  font-size: 20px;
+  line-height: 1.2;
+}
+
+.github-metadata,
+.github-file-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.github-pr-header {
+  display: grid;
+  gap: 10px;
+}
+
+.github-linked-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.github-filter-bar {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 10px;
+  margin-bottom: 14px;
+}
+
+.github-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.github-side-block {
+  padding: 14px;
+  border-radius: 18px;
+  background: rgba(15, 23, 34, 0.03);
+}
+
+.github-tabs {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-bottom: 14px;
+  position: relative;
+  z-index: 1;
+}
+
+.github-tabs .active {
+  background: rgba(31, 111, 235, 0.12);
+  color: var(--mock-accent);
+}
+
+.github-files-layout {
+  display: grid;
+  grid-template-columns: 260px minmax(0, 1fr);
+  gap: 16px;
+}
+
+.github-file-tree {
+  padding: 12px;
+  border-radius: 18px;
+  background: rgba(15, 23, 34, 0.03);
+  display: grid;
+  gap: 8px;
+  max-height: 340px;
+  overflow: auto;
+}
+
+.github-file-tree button.active {
+  background: rgba(31, 111, 235, 0.12);
+  color: var(--mock-accent);
+}
+
+.github-hunk {
+  padding: 12px;
+  border-radius: 14px;
+  background: rgba(15, 23, 34, 0.04);
+}
+
+.github-code {
+  display: block;
+  margin-top: 8px;
+  padding: 10px 12px;
+  border-radius: 12px;
+  background: #0d1117;
+  color: #d1e1ff;
+  font-family: var(--mock-font-mono);
+  font-size: 13px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+}
+
+.github-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+@media (max-width: 1180px) {
+  .github-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .github-files-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 900px) {
+  .github-topbar {
+    grid-template-columns: 1fr;
+  }
+
+  .github-filter-bar {
+    grid-template-columns: 1fr;
+  }
+}

--- a/eval/github/index.html
+++ b/eval/github/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>GitHub Mock</title>
+  <link rel="stylesheet" href="/css/hard-mock-base.css">
+  <link rel="stylesheet" href="/github/css/github.css">
+</head>
+<body class="github-body">
+  <div id="app"></div>
+  <script src="/js/tracker.js"></script>
+  <script src="/js/hard-mock-core.js"></script>
+  <script src="/github/js/github.js"></script>
+</body>
+</html>

--- a/eval/github/js/github.js
+++ b/eval/github/js/github.js
@@ -1,0 +1,1162 @@
+window.tracker = new AgentTracker("github.com", "hard");
+
+(function () {
+  const { createSeededStore, escapeHtml } = window.HardMockSite;
+
+  function createIssue(config) {
+    return {
+      number: config.number,
+      title: config.title,
+      labels: config.labels || [],
+      assignee: config.assignee || "",
+      milestone: config.milestone || "",
+      comments: config.comments || [],
+      linkedPr: config.linkedPr || null,
+      state: "open",
+    };
+  }
+
+  function createPr(config) {
+    return {
+      number: config.number,
+      title: config.title,
+      labels: config.labels || [],
+      linkedIssue: config.linkedIssue || null,
+      conversation: config.conversation || [],
+      files: config.files || [],
+      reviewState: "",
+    };
+  }
+
+  function buildSeedState() {
+    const issues = [
+      createIssue({
+        number: 118,
+        title: "Release blocker: billing webhook retries duplicate invoices",
+        labels: ["release-blocker"],
+        assignee: "",
+        milestone: "",
+        comments: ["The duplicate invoice path still appears in staging after repeated webhook retries."],
+        linkedPr: 42,
+      }),
+      createIssue({
+        number: 119,
+        title: "Release blocker: billing webhook retries stale invoices",
+        labels: ["release-blocker"],
+        assignee: "kenji-review",
+        milestone: "April Patch",
+        comments: [],
+      }),
+      createIssue({
+        number: 127,
+        title: "Review queue: onboarding badge copy mismatch",
+        labels: ["copy"],
+        assignee: "",
+        milestone: "",
+        comments: [],
+      }),
+    ];
+
+    for (let index = 1; index <= 9; index += 1) {
+      issues.push(
+        createIssue({
+          number: 130 + index,
+          title: `Seeded issue ${index}: platform cleanup task`,
+          labels: index % 2 ? ["infra"] : ["ux"],
+          assignee: index % 3 === 0 ? "mila-ops" : "",
+          milestone: index % 4 === 0 ? "May Launch" : "",
+          comments: [],
+        }),
+      );
+    }
+
+    const prs = [
+      createPr({
+        number: 42,
+        title: "Tighten billing retry guard before release",
+        linkedIssue: 118,
+        labels: ["needs-review"],
+        conversation: ["Blocks launch until the billing retry guard and dashboard wording are reviewed."],
+        files: [
+          {
+            path: "api/billing/webhook_retry_adapter.py",
+            viewed: false,
+            hunks: [
+              {
+                id: "adapter-status-map",
+                title: "Adapter response mapping",
+                code: "status = map_retry_status(payload)",
+                comments: [],
+              },
+            ],
+          },
+          {
+            path: "api/billing/webhook_retry_adapter_test.py",
+            viewed: false,
+            hunks: [
+              {
+                id: "adapter-assertion-gap",
+                title: "Adapter retry assertion gap",
+                code: "assert response['retryable'] is True",
+                comments: [],
+              },
+            ],
+          },
+          {
+            path: "docs/billing/retry-policy-rollout.md",
+            viewed: false,
+            hunks: [
+              {
+                id: "rollout-note",
+                title: "Rollout note refresh",
+                code: "- Verify retry guard before launch freeze",
+                comments: [],
+              },
+            ],
+          },
+          {
+            path: "ops/runbooks/webhook-retry-playbook.md",
+            viewed: false,
+            hunks: [
+              {
+                id: "playbook-step",
+                title: "Retry playbook wording",
+                code: "1. Confirm retry count in staging",
+                comments: [],
+              },
+            ],
+          },
+          {
+            path: "server/billing/retry_backoff.py",
+            viewed: false,
+            hunks: [
+              {
+                id: "backoff-jitter",
+                title: "Backoff jitter change",
+                code: "delay = base_delay * multiplier",
+                comments: [],
+              },
+            ],
+          },
+          {
+            path: "server/billing/retry_policy_guard.py",
+            viewed: false,
+            hunks: [
+              {
+                id: "guard-wrapper-inline",
+                title: "Inline retry guard wrapper",
+                code: "return guard.should_block(order, attempts)",
+                comments: [],
+              },
+            ],
+          },
+          {
+            path: "server/billing/retry_policy.py",
+            viewed: false,
+            hunks: [
+              {
+                id: "retry-cap-guard",
+                title: "Cap retries before duplicate invoice emission",
+                code: "if attempts > MAX_RETRIES:\n    emit_duplicate_invoice(order)\n    return False",
+                comments: [],
+              },
+            ],
+          },
+          {
+            path: "server/billing/retry_policies.py",
+            viewed: false,
+            hunks: [
+              {
+                id: "legacy-policy-cleanup",
+                title: "Legacy policy rename",
+                code: "LEGACY_RETRY_POLICY = DEFAULTS.copy()",
+                comments: [],
+              },
+            ],
+          },
+          {
+            path: "server/billing/retry_policy_test.py",
+            viewed: false,
+            hunks: [
+              {
+                id: "retry-test-gap",
+                title: "Expected retry cap",
+                code: "assert retries == 4",
+                comments: [],
+              },
+            ],
+          },
+          {
+            path: "services/invoice/retry_guard.py",
+            viewed: false,
+            hunks: [
+              {
+                id: "guard-wrapper",
+                title: "Guard wrapper around retry policy",
+                code: "return retry_policy.should_retry(invoice, attempts)",
+                comments: [],
+              },
+            ],
+          },
+          {
+            path: "services/invoice/retry_guard_metrics.py",
+            viewed: false,
+            hunks: [
+              {
+                id: "metrics-tag",
+                title: "Retry metrics tag adjustment",
+                code: "metrics.increment('invoice.retry_guard.blocked')",
+                comments: [],
+              },
+            ],
+          },
+          {
+            path: "web/dashboard/release_gate_banner.tsx",
+            viewed: false,
+            hunks: [
+              {
+                id: "banner-copy",
+                title: "Release banner copy",
+                code: "return <Banner tone='info'>{copy}</Banner>",
+                comments: [],
+              },
+            ],
+          },
+          {
+            path: "web/dashboard/release_gate.ts",
+            viewed: false,
+            hunks: [
+              {
+                id: "status-badge-copy",
+                title: "Status badge still reads ready to ship",
+                code: "badge.copy = 'Ready to ship'\nif (hasBlocker) badge.tone = 'green'",
+                comments: [],
+              },
+            ],
+          },
+          {
+            path: "web/dashboard/release_gate_badge.tsx",
+            viewed: false,
+            hunks: [
+              {
+                id: "tone-mismatch",
+                title: "Badge tone mismatch",
+                code: "return <Badge tone='success'>{copy}</Badge>",
+                comments: [],
+              },
+            ],
+          },
+          {
+            path: "docs/release-checklist.md",
+            viewed: false,
+            hunks: [
+              {
+                id: "release-doc-copy",
+                title: "Checklist wording update",
+                code: "- Billing retry guard verified",
+                comments: [],
+              },
+            ],
+          },
+        ],
+      }),
+      createPr({
+        number: 44,
+        title: "Polish review queue counters",
+        linkedIssue: 127,
+        labels: ["ux"],
+        conversation: ["Non-blocking polish PR."],
+        files: [],
+      }),
+    ];
+
+    for (let index = 1; index <= 3; index += 1) {
+      prs.push(
+        createPr({
+          number: 50 + index,
+          title: `Seeded PR ${index}: misc cleanup`,
+          linkedIssue: null,
+          labels: ["maintenance"],
+          conversation: ["Routine seeded PR."],
+          files: [],
+        }),
+      );
+    }
+
+    return {
+      issues,
+      prs,
+      ui: {
+        repoTab: "issues",
+        issueFilter: "",
+        selectedIssueNumber: null,
+        selectedPrNumber: null,
+        prTab: "conversation",
+        fileFilter: "",
+        selectedFilePath: "",
+        modal: null,
+      },
+    };
+  }
+
+  const store = createSeededStore({
+    storageKey: "openbrowser.eval.github",
+    seedState: buildSeedState(),
+  });
+
+  const LABEL_OPTIONS = ["release-blocker", "triage-needs-pm", "release-blocked", "needs-review"];
+  const ASSIGNEE_OPTIONS = ["", "mila-ops", "kenji-review", "sara-devrel"];
+  const MILESTONE_OPTIONS = ["", "May Launch", "April Patch", "Q2 Stabilization"];
+
+  const app = document.getElementById("app");
+
+  function getIssue(state, number) {
+    return state.issues.find((issue) => issue.number === Number(number)) || null;
+  }
+
+  function getPr(state, number) {
+    return state.prs.find((pr) => pr.number === Number(number)) || null;
+  }
+
+  function stemToken(token) {
+    if (token.endsWith("ies") && token.length > 4) {
+      return `${token.slice(0, -3)}y`;
+    }
+    if (token.endsWith("s") && token.length > 4) {
+      return token.slice(0, -1);
+    }
+    return token;
+  }
+
+  function tokenizeSearch(text) {
+    return String(text || "")
+      .toLowerCase()
+      .split(/[^a-z0-9-]+/)
+      .filter(Boolean)
+      .map(stemToken);
+  }
+
+  function parseIssueFilter(query) {
+    const normalized = String(query || "").trim().toLowerCase();
+    const labelMatches = Array.from(normalized.matchAll(/label:([^\s]+)/g)).map((match) => match[1]);
+    const remainder = normalized.replace(/label:[^\s]+/g, " ").replace(/is:open/g, " ");
+    return {
+      requireOpen: normalized.includes("is:open"),
+      labels: labelMatches,
+      terms: tokenizeSearch(remainder),
+    };
+  }
+
+  function matchesIssueFilter(issue, query) {
+    if (!query.trim()) {
+      return true;
+    }
+
+    const parsed = parseIssueFilter(query);
+    if (parsed.requireOpen && issue.state !== "open") {
+      return false;
+    }
+    if (parsed.labels.some((label) => !issue.labels.includes(label))) {
+      return false;
+    }
+
+    const issueTokens = new Set(tokenizeSearch(`${issue.title} ${issue.number} ${issue.labels.join(" ")}`));
+    return parsed.terms.every((term) => issueTokens.has(term));
+  }
+
+  function renderTopbar(state) {
+    return `
+      <header class="mock-topbar">
+        <div class="github-topbar">
+          <div class="github-brand">
+            <div class="github-brand-mark">GH</div>
+            <div>
+              <div>northstar/platform</div>
+              <div class="mock-subtle">Issues, PRs, files changed, review actions</div>
+            </div>
+          </div>
+          <div class="mock-subtle">Many controls reuse the same words, but context matters: issue labels are not PR labels, and diff comments are not review summaries.</div>
+          <div style="display: flex; gap: 10px;">
+            <span class="mock-pill">Issues + PRs</span>
+            <span class="mock-pill">Files changed is separate</span>
+          </div>
+        </div>
+      </header>
+    `;
+  }
+
+  function renderRepoNav(state) {
+    return `
+      <div class="github-repo-nav">
+        <button class="mock-btn-ghost ${state.ui.repoTab === "issues" ? "active" : ""}" data-action="set-repo-tab" data-tab="issues">Issues</button>
+        <button class="mock-btn-ghost ${state.ui.repoTab === "pulls" ? "active" : ""}" data-action="set-repo-tab" data-tab="pulls">Pull requests</button>
+      </div>
+    `;
+  }
+
+  function renderIssueList(state) {
+    const issues = state.issues.filter((issue) => matchesIssueFilter(issue, state.ui.issueFilter));
+
+    return `
+      <section class="github-list-panel mock-card">
+        <div class="github-filter-bar">
+          <input id="issue-filter-input" class="mock-input" value="${escapeHtml(state.ui.issueFilter)}" placeholder="Filter issues with qualifiers">
+          <button class="mock-btn" data-action="apply-issue-filter">Filter</button>
+        </div>
+        <div class="github-list">
+          ${issues
+            .map(
+              (issue) => `
+                <article class="github-list-item">
+                  <div class="github-item-head">
+                    <div>
+                      <div class="github-item-title">#${issue.number} ${escapeHtml(issue.title)}</div>
+                      <div class="github-metadata">
+                        ${issue.labels.map((label) => `<span class="mock-badge">${escapeHtml(label)}</span>`).join("")}
+                        ${issue.milestone ? `<span class="mock-badge">${escapeHtml(issue.milestone)}</span>` : ""}
+                      </div>
+                    </div>
+                    <button class="mock-btn" data-action="open-issue" data-issue-number="${issue.number}">Open</button>
+                  </div>
+                </article>
+              `,
+            )
+            .join("")}
+        </div>
+      </section>
+    `;
+  }
+
+  function renderIssueDetail(state) {
+    const issue = getIssue(state, state.ui.selectedIssueNumber);
+    if (!issue) {
+      return renderIssueList(state);
+    }
+
+    return `
+      <section class="github-detail-panel mock-card">
+        <div class="github-item-head">
+          <div>
+            <p class="mock-kicker">Issue #${issue.number}</p>
+            <h2 class="mock-title">${escapeHtml(issue.title)}</h2>
+            <div class="github-metadata">
+              ${issue.labels.map((label) => `<span class="mock-badge">${escapeHtml(label)}</span>`).join("")}
+              ${issue.assignee ? `<span class="mock-badge">${escapeHtml(issue.assignee)}</span>` : ""}
+              ${issue.milestone ? `<span class="mock-badge">${escapeHtml(issue.milestone)}</span>` : ""}
+            </div>
+          </div>
+          <button class="mock-btn-secondary" data-action="back-to-issue-list">Back</button>
+        </div>
+        <div class="github-comment-card" style="margin-top: 14px;">
+          <div class="mock-kicker">Discussion</div>
+          ${issue.comments.map((comment) => `<div class="mock-subtle">${escapeHtml(comment)}</div>`).join("") || '<div class="mock-subtle">No additional comments yet.</div>'}
+        </div>
+      </section>
+    `;
+  }
+
+  function renderPrList(state) {
+    return `
+      <section class="github-list-panel mock-card">
+        <div class="github-list">
+          ${state.prs
+            .map(
+              (pr) => `
+                <article class="github-list-item">
+                  <div class="github-item-head">
+                    <div>
+                      <div class="github-item-title">#${pr.number} ${escapeHtml(pr.title)}</div>
+                      <div class="github-metadata">
+                        ${pr.labels.map((label) => `<span class="mock-badge">${escapeHtml(label)}</span>`).join("")}
+                        ${pr.linkedIssue ? `<span class="mock-badge">links #${pr.linkedIssue}</span>` : ""}
+                      </div>
+                    </div>
+                    <button class="mock-btn" data-action="open-pr" data-pr-number="${pr.number}">Open</button>
+                  </div>
+                </article>
+              `,
+            )
+            .join("")}
+        </div>
+      </section>
+    `;
+  }
+
+  function renderPrDetail(state) {
+    const pr = getPr(state, state.ui.selectedPrNumber);
+    if (!pr) {
+      return renderPrList(state);
+    }
+
+    const filteredFiles = pr.files.filter((file) => {
+      if (!state.ui.fileFilter.trim()) {
+        return true;
+      }
+      return file.path.toLowerCase().includes(state.ui.fileFilter.trim().toLowerCase());
+    });
+    const selectedFile = filteredFiles.find((file) => file.path === state.ui.selectedFilePath) || filteredFiles[0] || null;
+
+    return `
+      <section class="github-detail-panel mock-card">
+        <div class="github-item-head">
+          <div class="github-pr-header">
+            <p class="mock-kicker">Pull request #${pr.number}</p>
+            <h2 class="mock-title">${escapeHtml(pr.title)}</h2>
+            <div class="github-metadata">
+              ${pr.labels.map((label) => `<span class="mock-badge">${escapeHtml(label)}</span>`).join("")}
+            </div>
+            ${pr.linkedIssue ? `<div class="github-linked-actions"><button class="mock-btn-ghost" data-action="open-linked-issue" data-issue-number="${pr.linkedIssue}">Open linked issue #${pr.linkedIssue}</button></div>` : ""}
+          </div>
+          <button class="mock-btn-secondary" data-action="back-to-pr-list">Back</button>
+        </div>
+        <div class="github-tabs">
+          <button class="mock-btn-ghost ${state.ui.prTab === "conversation" ? "active" : ""}" data-action="set-pr-tab" data-pr-tab="conversation">Conversation</button>
+          <button class="mock-btn-ghost ${state.ui.prTab === "files" ? "active" : ""}" data-action="set-pr-tab" data-pr-tab="files">Files changed</button>
+        </div>
+        ${
+          state.ui.prTab === "conversation"
+            ? `
+              <div class="github-comment-card">
+                <div class="mock-kicker">Conversation</div>
+                ${pr.conversation.map((comment) => `<div class="mock-subtle">${escapeHtml(comment)}</div>`).join("")}
+              </div>
+            `
+            : `
+              <div class="github-filter-bar">
+                <input id="file-filter-input" class="mock-input" value="${escapeHtml(state.ui.fileFilter)}" placeholder="Filter changed files">
+                <button class="mock-btn" data-action="apply-file-filter">Filter files</button>
+              </div>
+              <div class="github-files-layout">
+                <aside class="github-file-tree">
+                  ${filteredFiles
+                    .map(
+                      (file) => `
+                        <button class="mock-btn-ghost ${selectedFile?.path === file.path ? "active" : ""}" data-action="select-file" data-file-path="${file.path}">
+                          ${escapeHtml(file.path)}
+                        </button>
+                      `,
+                    )
+                    .join("")}
+                </aside>
+                <div class="github-list">
+                  ${
+                    selectedFile
+                      ? `
+                        <article class="github-file-card">
+                          <div class="github-item-head">
+                            <div>
+                              <div class="github-item-title" style="font-size: 18px;">${escapeHtml(selectedFile.path)}</div>
+                              <div class="github-file-meta">
+                                <span class="mock-badge">${selectedFile.viewed ? "Viewed" : "Not viewed"}</span>
+                              </div>
+                            </div>
+                            <button class="mock-btn-secondary" data-action="mark-viewed" data-file-path="${selectedFile.path}">Mark viewed</button>
+                          </div>
+                          ${selectedFile.hunks
+                            .map(
+                              (hunk) => `
+                                <div class="github-hunk">
+                                  <div class="mock-kicker">${escapeHtml(hunk.id)}</div>
+                                  <strong>${escapeHtml(hunk.title)}</strong>
+                                  <code class="github-code">${escapeHtml(hunk.code)}</code>
+                                  <div class="github-actions" style="margin-top: 10px;">
+                                    <button class="mock-btn" data-action="open-diff-comment" data-file-path="${selectedFile.path}" data-hunk-id="${hunk.id}">Add inline comment</button>
+                                  </div>
+                                  ${hunk.comments.map((comment) => `<div class="mock-subtle" style="margin-top: 8px;">${escapeHtml(comment)}</div>`).join("")}
+                                </div>
+                              `,
+                            )
+                            .join("")}
+                        </article>
+                      `
+                      : '<div class="mock-empty">No changed files match the current filter.</div>'
+                  }
+                </div>
+              </div>
+            `
+        }
+      </section>
+    `;
+  }
+
+  function renderSidebar(state) {
+    if (state.ui.repoTab === "issues") {
+      const issue = getIssue(state, state.ui.selectedIssueNumber);
+      if (!issue) {
+        return `<aside class="github-sidebar mock-card"><div class="mock-empty">Open an issue to change labels, assignee, milestone, or leave a triage comment.</div></aside>`;
+      }
+
+      return `
+        <aside class="github-sidebar mock-card">
+          <div class="github-side-block">
+            <label class="mock-kicker" for="issue-label-select">Add label</label>
+            <select id="issue-label-select" class="mock-select">
+              ${LABEL_OPTIONS.map((label) => `<option value="${label}">${label}</option>`).join("")}
+            </select>
+            <button class="mock-btn" style="margin-top: 10px;" data-action="add-issue-label">Add label</button>
+          </div>
+          <div class="github-side-block">
+            <label class="mock-kicker" for="issue-assignee-select">Assignee</label>
+            <select id="issue-assignee-select" class="mock-select">
+              ${ASSIGNEE_OPTIONS.map((option) => `<option value="${option}" ${issue.assignee === option ? "selected" : ""}>${option || "Unassigned"}</option>`).join("")}
+            </select>
+            <button class="mock-btn" style="margin-top: 10px;" data-action="set-issue-assignee">Save assignee</button>
+          </div>
+          <div class="github-side-block">
+            <label class="mock-kicker" for="issue-milestone-select">Milestone</label>
+            <select id="issue-milestone-select" class="mock-select">
+              ${MILESTONE_OPTIONS.map((option) => `<option value="${option}" ${issue.milestone === option ? "selected" : ""}>${option || "No milestone"}</option>`).join("")}
+            </select>
+            <button class="mock-btn" style="margin-top: 10px;" data-action="set-issue-milestone">Save milestone</button>
+          </div>
+          <div class="github-side-block">
+            <label class="mock-kicker" for="issue-comment-input">Triage comment</label>
+            <textarea id="issue-comment-input" class="mock-textarea" rows="5" placeholder="Leave an exact triage comment"></textarea>
+            <button class="mock-btn" style="margin-top: 10px;" data-action="submit-issue-comment">Comment</button>
+          </div>
+        </aside>
+      `;
+    }
+
+    const pr = getPr(state, state.ui.selectedPrNumber);
+    if (!pr) {
+      return `<aside class="github-sidebar mock-card"><div class="mock-empty">Open a PR to label it, inspect files changed, or submit a review.</div></aside>`;
+    }
+
+    return `
+      <aside class="github-sidebar mock-card">
+        <div class="github-side-block">
+          <label class="mock-kicker" for="pr-label-select">PR label</label>
+          <select id="pr-label-select" class="mock-select">
+            ${LABEL_OPTIONS.map((label) => `<option value="${label}">${label}</option>`).join("")}
+          </select>
+          <button class="mock-btn" style="margin-top: 10px;" data-action="add-pr-label">Add label</button>
+        </div>
+        <div class="github-side-block">
+          <div class="mock-kicker">Review actions</div>
+          <button class="mock-btn" data-action="open-review-modal">Submit review</button>
+        </div>
+      </aside>
+    `;
+  }
+
+  function renderModal(state) {
+    const modal = state.ui.modal;
+    if (!modal) {
+      return "";
+    }
+
+    if (modal.type === "diff-comment") {
+      return `
+        <div class="mock-modal-backdrop">
+          <div class="mock-modal">
+            <div class="mock-modal-header">
+              <div>
+                <p class="mock-kicker">Inline diff comment</p>
+                <h3 class="mock-title">${escapeHtml(modal.filePath)}</h3>
+              </div>
+              <button class="mock-btn-ghost" data-action="close-modal">Close</button>
+            </div>
+            <div class="mock-modal-body">
+              <div class="mock-subtle">Hunk: ${escapeHtml(modal.hunkId)}</div>
+              <textarea id="diff-comment-input" class="mock-textarea" rows="6">${escapeHtml(modal.body || "")}</textarea>
+            </div>
+            <div class="mock-modal-footer">
+              <span class="mock-subtle">This must land on the exact file and hunk.</span>
+              <button class="mock-btn" data-action="submit-diff-comment">Submit inline comment</button>
+            </div>
+          </div>
+        </div>
+      `;
+    }
+
+    if (modal.type === "review") {
+      return `
+        <div class="mock-modal-backdrop">
+          <div class="mock-modal">
+            <div class="mock-modal-header">
+              <div>
+                <p class="mock-kicker">Review submit</p>
+                <h3 class="mock-title">Choose review state</h3>
+              </div>
+              <button class="mock-btn-ghost" data-action="close-modal">Close</button>
+            </div>
+            <div class="mock-modal-body">
+              <div class="github-actions">
+                <button class="mock-btn-secondary" data-action="set-review-state" data-review-state="comment">Comment</button>
+                <button class="mock-btn-secondary" data-action="set-review-state" data-review-state="approve">Approve</button>
+                <button class="mock-btn-secondary" data-action="set-review-state" data-review-state="request_changes">Request changes</button>
+              </div>
+              <textarea id="review-body-input" class="mock-textarea" rows="6" style="margin-top: 16px;">${escapeHtml(modal.body || "")}</textarea>
+              <div class="mock-subtle" style="margin-top: 8px;">Current state: ${escapeHtml(modal.state || "comment")}</div>
+            </div>
+            <div class="mock-modal-footer">
+              <span class="mock-subtle">The review state is scored independently from inline comments.</span>
+              <button class="mock-btn" data-action="submit-review">Submit review</button>
+            </div>
+          </div>
+        </div>
+      `;
+    }
+
+    return "";
+  }
+
+  function render() {
+    const state = store.getState();
+    const mainContent =
+      state.ui.repoTab === "issues" ? (state.ui.selectedIssueNumber ? renderIssueDetail(state) : renderIssueList(state)) : (state.ui.selectedPrNumber ? renderPrDetail(state) : renderPrList(state));
+
+    app.innerHTML = `
+      <div class="mock-page">
+        ${renderTopbar(state)}
+        <main class="github-shell">
+          ${renderRepoNav(state)}
+          <div class="github-layout">
+            ${mainContent}
+            ${renderSidebar(state)}
+          </div>
+        </main>
+        ${renderModal(state)}
+      </div>
+    `;
+  }
+
+  function setRepoTab(tab) {
+    store.update((state) => {
+      state.ui.repoTab = tab;
+      state.ui.selectedIssueNumber = null;
+      state.ui.selectedPrNumber = null;
+      state.ui.modal = null;
+    });
+    tracker.track("repo_nav", {
+      tab,
+    });
+    render();
+  }
+
+  function applyIssueFilter() {
+    const input = document.getElementById("issue-filter-input");
+    const query = input ? input.value.trim() : "";
+    store.update((state) => {
+      state.ui.issueFilter = query;
+    });
+    tracker.track("issue_filter_apply", {
+      query,
+    });
+    render();
+  }
+
+  function openIssue(number) {
+    store.update((state) => {
+      state.ui.selectedIssueNumber = Number(number);
+    });
+    tracker.track("issue_open", {
+      issueNumber: Number(number),
+    });
+    render();
+  }
+
+  function addIssueLabel() {
+    const state = store.getState();
+    const issue = getIssue(state, state.ui.selectedIssueNumber);
+    const select = document.getElementById("issue-label-select");
+    const label = select ? select.value : "";
+    if (!issue || !label) {
+      return;
+    }
+    store.update((draft) => {
+      const targetIssue = getIssue(draft, issue.number);
+      if (targetIssue && !targetIssue.labels.includes(label)) {
+        targetIssue.labels.push(label);
+      }
+    });
+    tracker.track("label_add", {
+      targetType: "issue",
+      issueNumber: issue.number,
+      labelId: label,
+    });
+    render();
+  }
+
+  function setIssueAssignee() {
+    const state = store.getState();
+    const issue = getIssue(state, state.ui.selectedIssueNumber);
+    const select = document.getElementById("issue-assignee-select");
+    const assignee = select ? select.value : "";
+    if (!issue) {
+      return;
+    }
+    store.update((draft) => {
+      const targetIssue = getIssue(draft, issue.number);
+      if (targetIssue) {
+        targetIssue.assignee = assignee;
+      }
+    });
+    tracker.track("assignee_set", {
+      issueNumber: issue.number,
+      assignee,
+    });
+    render();
+  }
+
+  function setIssueMilestone() {
+    const state = store.getState();
+    const issue = getIssue(state, state.ui.selectedIssueNumber);
+    const select = document.getElementById("issue-milestone-select");
+    const milestone = select ? select.value : "";
+    if (!issue) {
+      return;
+    }
+    store.update((draft) => {
+      const targetIssue = getIssue(draft, issue.number);
+      if (targetIssue) {
+        targetIssue.milestone = milestone;
+      }
+    });
+    tracker.track("milestone_set", {
+      issueNumber: issue.number,
+      milestoneId: milestone,
+    });
+    render();
+  }
+
+  function submitIssueComment() {
+    const state = store.getState();
+    const issue = getIssue(state, state.ui.selectedIssueNumber);
+    const input = document.getElementById("issue-comment-input");
+    const body = input ? input.value.trim() : "";
+    if (!issue || !body) {
+      return;
+    }
+    store.update((draft) => {
+      const targetIssue = getIssue(draft, issue.number);
+      targetIssue?.comments.push(body);
+    });
+    tracker.track("issue_comment_add", {
+      issueNumber: issue.number,
+      commentBody: body,
+    });
+    render();
+  }
+
+  function openPr(number) {
+    store.update((state) => {
+      state.ui.selectedPrNumber = Number(number);
+      state.ui.selectedFilePath = "";
+    });
+    tracker.track("pr_open", {
+      prNumber: Number(number),
+    });
+    render();
+  }
+
+  function setPrTab(prTab) {
+    const state = store.getState();
+    store.update((state) => {
+      state.ui.prTab = prTab;
+    });
+    tracker.track("pr_tab_change", {
+      prNumber: state.ui.selectedPrNumber,
+      tab: prTab,
+    });
+    render();
+  }
+
+  function applyFileFilter() {
+    const state = store.getState();
+    const input = document.getElementById("file-filter-input");
+    const query = input ? input.value.trim() : "";
+    store.update((state) => {
+      state.ui.fileFilter = query;
+    });
+    tracker.track("files_changed_filter_apply", {
+      prNumber: state.ui.selectedPrNumber,
+      query,
+    });
+    render();
+  }
+
+  function selectFile(filePath) {
+    store.update((state) => {
+      state.ui.selectedFilePath = filePath;
+    });
+    render();
+  }
+
+  function markViewed(filePath) {
+    const state = store.getState();
+    const pr = getPr(state, state.ui.selectedPrNumber);
+    if (!pr) {
+      return;
+    }
+    store.update((draft) => {
+      const targetPr = getPr(draft, pr.number);
+      const file = targetPr?.files.find((entry) => entry.path === filePath);
+      if (file) {
+        file.viewed = true;
+      }
+    });
+    tracker.track("file_mark_viewed", {
+      prNumber: pr.number,
+      filePath,
+    });
+    render();
+  }
+
+  function openDiffComment(filePath, hunkId) {
+    store.update((state) => {
+      state.ui.modal = {
+        type: "diff-comment",
+        filePath,
+        hunkId,
+        body: "",
+      };
+    });
+    render();
+  }
+
+  function submitDiffComment() {
+    const state = store.getState();
+    const pr = getPr(state, state.ui.selectedPrNumber);
+    const modal = state.ui.modal;
+    const input = document.getElementById("diff-comment-input");
+    const body = input ? input.value.trim() : "";
+    if (!pr || !modal || modal.type !== "diff-comment" || !body) {
+      return;
+    }
+    store.update((draft) => {
+      const targetPr = getPr(draft, pr.number);
+      const file = targetPr?.files.find((entry) => entry.path === modal.filePath);
+      const hunk = file?.hunks.find((entry) => entry.id === modal.hunkId);
+      hunk?.comments.push(body);
+      draft.ui.modal = null;
+    });
+    tracker.track("diff_comment_add", {
+      prNumber: pr.number,
+      filePath: modal.filePath,
+      hunkId: modal.hunkId,
+      commentBody: body,
+    });
+    render();
+  }
+
+  function addPrLabel() {
+    const state = store.getState();
+    const pr = getPr(state, state.ui.selectedPrNumber);
+    const select = document.getElementById("pr-label-select");
+    const label = select ? select.value : "";
+    if (!pr || !label) {
+      return;
+    }
+    store.update((draft) => {
+      const targetPr = getPr(draft, pr.number);
+      if (targetPr && !targetPr.labels.includes(label)) {
+        targetPr.labels.push(label);
+      }
+    });
+    tracker.track("label_add", {
+      targetType: "pr",
+      prNumber: pr.number,
+      labelId: label,
+    });
+    render();
+  }
+
+  function openReviewModal() {
+    store.update((state) => {
+      state.ui.modal = {
+        type: "review",
+        state: "comment",
+        body: "",
+      };
+    });
+    render();
+  }
+
+  function submitReview() {
+    const state = store.getState();
+    const pr = getPr(state, state.ui.selectedPrNumber);
+    const modal = state.ui.modal;
+    const input = document.getElementById("review-body-input");
+    const body = input ? input.value.trim() : "";
+    if (!pr || !modal || modal.type !== "review") {
+      return;
+    }
+    store.update((draft) => {
+      const targetPr = getPr(draft, pr.number);
+      if (targetPr) {
+        targetPr.reviewState = modal.state;
+      }
+      draft.ui.modal = null;
+    });
+    tracker.track("review_submit", {
+      prNumber: pr.number,
+      state: modal.state,
+      body,
+    });
+    render();
+  }
+
+  app.addEventListener("change", (event) => {
+    const target = event.target;
+    if (!(target instanceof HTMLElement)) {
+      return;
+    }
+
+    if (target.id === "issue-label-select") {
+      addIssueLabel();
+      return;
+    }
+
+    if (target.id === "issue-assignee-select") {
+      setIssueAssignee();
+      return;
+    }
+
+    if (target.id === "issue-milestone-select") {
+      setIssueMilestone();
+      return;
+    }
+
+    if (target.id === "pr-label-select") {
+      addPrLabel();
+    }
+  });
+
+  app.addEventListener("click", (event) => {
+    const target = event.target.closest("[data-action]");
+    if (!target) {
+      return;
+    }
+
+    const action = target.dataset.action;
+
+    if (action === "set-repo-tab") {
+      setRepoTab(target.dataset.tab);
+      return;
+    }
+
+    if (action === "apply-issue-filter") {
+      applyIssueFilter();
+      return;
+    }
+
+    if (action === "open-issue") {
+      openIssue(target.dataset.issueNumber);
+      return;
+    }
+
+    if (action === "back-to-issue-list") {
+      store.update((state) => {
+        state.ui.selectedIssueNumber = null;
+      });
+      render();
+      return;
+    }
+
+    if (action === "add-issue-label") {
+      addIssueLabel();
+      return;
+    }
+
+    if (action === "set-issue-assignee") {
+      setIssueAssignee();
+      return;
+    }
+
+    if (action === "set-issue-milestone") {
+      setIssueMilestone();
+      return;
+    }
+
+    if (action === "submit-issue-comment") {
+      submitIssueComment();
+      return;
+    }
+
+    if (action === "open-pr") {
+      openPr(target.dataset.prNumber);
+      return;
+    }
+
+    if (action === "back-to-pr-list") {
+      store.update((state) => {
+        state.ui.selectedPrNumber = null;
+        state.ui.selectedFilePath = "";
+      });
+      render();
+      return;
+    }
+
+    if (action === "set-pr-tab") {
+      setPrTab(target.dataset.prTab);
+      return;
+    }
+
+    if (action === "apply-file-filter") {
+      applyFileFilter();
+      return;
+    }
+
+    if (action === "select-file") {
+      selectFile(target.dataset.filePath);
+      return;
+    }
+
+    if (action === "mark-viewed") {
+      markViewed(target.dataset.filePath);
+      return;
+    }
+
+    if (action === "open-diff-comment") {
+      openDiffComment(target.dataset.filePath, target.dataset.hunkId);
+      return;
+    }
+
+    if (action === "submit-diff-comment") {
+      submitDiffComment();
+      return;
+    }
+
+    if (action === "add-pr-label") {
+      addPrLabel();
+      return;
+    }
+
+    if (action === "open-review-modal") {
+      openReviewModal();
+      return;
+    }
+
+    if (action === "set-review-state") {
+      store.update((state) => {
+        if (state.ui.modal?.type === "review") {
+          state.ui.modal.state = target.dataset.reviewState;
+        }
+      });
+      render();
+      return;
+    }
+
+    if (action === "submit-review") {
+      submitReview();
+      return;
+    }
+
+    if (action === "open-linked-issue") {
+      setRepoTab("issues");
+      openIssue(target.dataset.issueNumber);
+      return;
+    }
+
+    if (action === "close-modal") {
+      store.update((state) => {
+        state.ui.modal = null;
+      });
+      render();
+    }
+  });
+
+  render();
+})();

--- a/eval/github/js/github.js
+++ b/eval/github/js/github.js
@@ -762,7 +762,7 @@ window.tracker = new AgentTracker("github.com", "hard");
     const issue = getIssue(state, state.ui.selectedIssueNumber);
     const select = document.getElementById("issue-label-select");
     const label = select ? select.value : "";
-    if (!issue || !label) {
+    if (!issue || !label || issue.labels.includes(label)) {
       return;
     }
     store.update((draft) => {
@@ -784,7 +784,7 @@ window.tracker = new AgentTracker("github.com", "hard");
     const issue = getIssue(state, state.ui.selectedIssueNumber);
     const select = document.getElementById("issue-assignee-select");
     const assignee = select ? select.value : "";
-    if (!issue) {
+    if (!issue || issue.assignee === assignee) {
       return;
     }
     store.update((draft) => {
@@ -805,7 +805,7 @@ window.tracker = new AgentTracker("github.com", "hard");
     const issue = getIssue(state, state.ui.selectedIssueNumber);
     const select = document.getElementById("issue-milestone-select");
     const milestone = select ? select.value : "";
-    if (!issue) {
+    if (!issue || issue.milestone === milestone) {
       return;
     }
     store.update((draft) => {
@@ -946,7 +946,7 @@ window.tracker = new AgentTracker("github.com", "hard");
     const pr = getPr(state, state.ui.selectedPrNumber);
     const select = document.getElementById("pr-label-select");
     const label = select ? select.value : "";
-    if (!pr || !label) {
+    if (!pr || !label || pr.labels.includes(label)) {
       return;
     }
     store.update((draft) => {

--- a/eval/gmail/css/gmail.css
+++ b/eval/gmail/css/gmail.css
@@ -1,0 +1,391 @@
+.gmail-body {
+  --mock-accent: #0b57d0;
+  --mock-accent-soft: rgba(11, 87, 208, 0.12);
+  background:
+    radial-gradient(circle at top right, rgba(225, 235, 255, 0.95), transparent 32%),
+    linear-gradient(180deg, #f3f7fd, #edf2fa 42%, #eef3f9 100%);
+}
+
+.gmail-page {
+  padding-bottom: 32px;
+}
+
+.gmail-topbar-inner {
+  display: grid;
+  grid-template-columns: 260px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 18px;
+  padding: 16px 24px;
+}
+
+.gmail-brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-weight: 800;
+  letter-spacing: 0.02em;
+}
+
+.gmail-brand-mark {
+  display: grid;
+  place-items: center;
+  width: 42px;
+  height: 42px;
+  border-radius: 14px;
+  background: linear-gradient(135deg, #ffffff, #dce8ff);
+  border: 1px solid rgba(11, 87, 208, 0.12);
+  box-shadow: 0 10px 24px rgba(11, 87, 208, 0.12);
+  color: var(--mock-accent);
+}
+
+.gmail-search-form {
+  position: relative;
+}
+
+.gmail-search-form .mock-input {
+  padding-left: 18px;
+  padding-right: 130px;
+  border-radius: 18px;
+  background: rgba(232, 240, 254, 0.86);
+}
+
+.gmail-search-submit {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  bottom: 6px;
+  min-width: 112px;
+}
+
+.gmail-topbar-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.gmail-layout {
+  display: grid;
+  grid-template-columns: 250px minmax(320px, 1.05fr) minmax(360px, 0.95fr);
+  gap: 18px;
+  padding: 22px 24px 0;
+}
+
+.gmail-sidebar,
+.gmail-list-panel,
+.gmail-detail-panel {
+  min-height: calc(100vh - 122px);
+}
+
+.gmail-sidebar {
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.gmail-compose-btn {
+  justify-content: flex-start;
+  padding-inline: 18px;
+  min-height: 50px;
+  border-radius: 18px;
+}
+
+.gmail-nav-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.gmail-nav-item {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  gap: 10px;
+  padding: 11px 13px;
+  border-radius: 14px;
+  color: var(--mock-text-muted);
+}
+
+.gmail-nav-item.active {
+  background: rgba(11, 87, 208, 0.12);
+  color: var(--mock-accent);
+  font-weight: 700;
+}
+
+.gmail-label-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.gmail-label-item {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 9px 12px;
+  border-radius: 12px;
+  background: rgba(15, 23, 34, 0.04);
+  color: var(--mock-text-muted);
+}
+
+.gmail-list-panel {
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.gmail-list-toolbar {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 18px;
+  border-bottom: 1px solid var(--mock-border);
+  background: rgba(255, 255, 255, 0.94);
+}
+
+.gmail-toolbar-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.gmail-thread-list {
+  padding: 12px 10px 12px 14px;
+  overflow: auto;
+}
+
+.gmail-thread-row {
+  display: grid;
+  grid-template-columns: auto auto 1fr auto;
+  gap: 12px;
+  align-items: start;
+  padding: 13px 12px;
+  border-radius: 16px;
+  border: 1px solid transparent;
+}
+
+.gmail-thread-row + .gmail-thread-row {
+  margin-top: 8px;
+}
+
+.gmail-thread-row:hover {
+  background: rgba(15, 23, 34, 0.03);
+}
+
+.gmail-thread-row.active {
+  background: rgba(11, 87, 208, 0.08);
+  border-color: rgba(11, 87, 208, 0.14);
+}
+
+.gmail-thread-row.selected {
+  background: rgba(11, 87, 208, 0.12);
+}
+
+.gmail-thread-checkbox,
+.gmail-thread-star {
+  width: 18px;
+  height: 18px;
+  margin-top: 2px;
+}
+
+.gmail-thread-main {
+  display: grid;
+  gap: 6px;
+}
+
+.gmail-thread-topline {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+}
+
+.gmail-thread-subject {
+  font-weight: 700;
+}
+
+.gmail-thread-row.unread .gmail-thread-subject,
+.gmail-thread-row.unread .gmail-thread-sender {
+  color: var(--mock-text);
+}
+
+.gmail-thread-sender {
+  color: var(--mock-text-muted);
+  font-weight: 700;
+}
+
+.gmail-thread-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+  color: var(--mock-text-faint);
+  font-size: 13px;
+}
+
+.gmail-thread-snippet {
+  color: var(--mock-text-muted);
+  line-height: 1.45;
+}
+
+.gmail-detail-panel {
+  padding: 20px 22px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.gmail-thread-detail {
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.gmail-thread-header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.gmail-message-card {
+  padding: 16px;
+  border-radius: 18px;
+  background: rgba(15, 23, 34, 0.03);
+  border: 1px solid rgba(15, 23, 34, 0.07);
+}
+
+.gmail-message-head {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.gmail-message-body {
+  color: var(--mock-text-muted);
+  line-height: 1.55;
+  white-space: pre-line;
+}
+
+.gmail-detail-actions,
+.gmail-compose-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.gmail-collapsed-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 14px 16px;
+  border-radius: 16px;
+  background: linear-gradient(180deg, rgba(239, 242, 247, 0.82), rgba(226, 232, 241, 0.82));
+}
+
+.gmail-compose-modal {
+  width: min(860px, 100%);
+}
+
+.gmail-compose-grid {
+  display: grid;
+  gap: 12px;
+}
+
+.gmail-compose-grid.two-col {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.gmail-compose-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  padding: 10px 0 0;
+}
+
+.gmail-attachment-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.gmail-attachment-card {
+  padding: 14px;
+  border-radius: 18px;
+  border: 1px solid var(--mock-border);
+  background: rgba(15, 23, 34, 0.03);
+}
+
+.gmail-attachment-card.active {
+  border-color: rgba(11, 87, 208, 0.28);
+  background: rgba(11, 87, 208, 0.08);
+}
+
+.gmail-label-grid {
+  display: grid;
+  gap: 10px;
+}
+
+.gmail-label-option {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 14px;
+  border-radius: 14px;
+  border: 1px solid var(--mock-border);
+}
+
+.gmail-draft-row {
+  display: grid;
+  gap: 5px;
+}
+
+.gmail-thread-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.gmail-thread-tags .mock-badge {
+  background: rgba(11, 87, 208, 0.08);
+  color: var(--mock-accent);
+}
+
+@media (max-width: 1280px) {
+  .gmail-layout {
+    grid-template-columns: 220px minmax(300px, 1fr) minmax(320px, 0.95fr);
+  }
+}
+
+@media (max-width: 1080px) {
+  .gmail-topbar-inner {
+    grid-template-columns: 1fr;
+  }
+
+  .gmail-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .gmail-sidebar,
+  .gmail-list-panel,
+  .gmail-detail-panel {
+    min-height: auto;
+  }
+
+  .gmail-attachment-grid,
+  .gmail-compose-grid.two-col {
+    grid-template-columns: 1fr;
+  }
+}

--- a/eval/gmail/index.html
+++ b/eval/gmail/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Gmail Mock Workspace</title>
+  <link rel="stylesheet" href="/css/hard-mock-base.css">
+  <link rel="stylesheet" href="/gmail/css/gmail.css">
+</head>
+<body class="gmail-body">
+  <div id="app"></div>
+  <script src="/js/tracker.js"></script>
+  <script src="/js/hard-mock-core.js"></script>
+  <script src="/gmail/js/gmail.js"></script>
+</body>
+</html>

--- a/eval/gmail/js/gmail.js
+++ b/eval/gmail/js/gmail.js
@@ -1,0 +1,1406 @@
+window.tracker = new AgentTracker("mail.google.com", "hard");
+
+(function () {
+  const { createSeededStore, escapeHtml, parseOperatorQuery, uniqueSorted, normalize, debounce, formatLongDate } =
+    window.HardMockSite;
+
+  const LABELS = [
+    { id: "lbl-finance-q2", name: "Finance/Q2" },
+    { id: "lbl-vendors-shipping", name: "Vendors/Shipping" },
+    { id: "lbl-campaigns-q3", name: "Campaigns/Q3" },
+    { id: "lbl-legal-signoff", name: "Legal/Signoff" },
+  ];
+
+  const ATTACHMENTS = {
+    upload: [
+      { id: "pdf-board-pack-revision-c", name: "Board-Pack-Revision-C.pdf", kind: "pdf", size: "1.8 MB" },
+      { id: "pdf-vendor-rate-sheet", name: "Vendor-Rate-Sheet-Delta.pdf", kind: "pdf", size: "880 KB" },
+      { id: "pdf-campaign-recap", name: "Campaign-Recap-April.pdf", kind: "pdf", size: "2.1 MB" },
+    ],
+    drive: [
+      { id: "drive-vendor-sla-summary", name: "Drive link: Vendor SLA Summary", kind: "drive", size: "Shortcut" },
+      { id: "drive-board-annotations", name: "Drive link: Board annotations", kind: "drive", size: "Shortcut" },
+      { id: "drive-renewal-notes", name: "Drive link: Renewal notes", kind: "drive", size: "Shortcut" },
+    ],
+  };
+
+  function createThread(config) {
+    return {
+      id: config.id,
+      category: config.category,
+      senderName: config.senderName,
+      senderEmail: config.senderEmail,
+      subject: config.subject,
+      snippet: config.snippet,
+      unread: Boolean(config.unread),
+      starred: Boolean(config.starred),
+      archived: Boolean(config.archived),
+      labelIds: config.labelIds || [],
+      messages: config.messages || [],
+      attachments: config.attachments || [],
+      updatedAt: config.updatedAt,
+      cluster: config.cluster || "general",
+    };
+  }
+
+  function buildSeedThreads() {
+    const importantThreads = [
+      createThread({
+        id: "thr-fin-board-pack",
+        category: "updates",
+        senderName: "Mira Lin",
+        senderEmail: "mira.lin@aldercap.com",
+        subject: "RE: Q2 Board Packet revisions",
+        snippet: "Need your finance follow-up and the signed revision packet before 4 PM.",
+        unread: true,
+        labelIds: ["lbl-finance-q2"],
+        attachments: ["pdf-board-pack-revision-c"],
+        updatedAt: "2026-04-10T09:16:00",
+        cluster: "board-packet",
+        messages: [
+          {
+            id: "msg-fin-board-pack-1",
+            from: "Mira Lin",
+            email: "mira.lin@aldercap.com",
+            timestamp: "Apr 9, 8:14 PM",
+            body:
+              "We tightened the appendix and need one final reply before Friday's board prep.\n\nPlease use search operators if needed because there is a promotions decoy with a similar subject.",
+          },
+          {
+            id: "msg-fin-board-pack-2",
+            from: "Mira Lin",
+            email: "mira.lin@aldercap.com",
+            timestamp: "Apr 10, 9:16 AM",
+            body:
+              "Reply with the exact sentence: Approved for Friday board prep. Please route the signed PDF back before 4 PM.\nAttach the revised PDF, not a Drive link.\nAdd the thread to the Finance/Board-Prep label once you respond.",
+          },
+        ],
+      }),
+      createThread({
+        id: "thr-fin-board-pack-decoy",
+        category: "promotions",
+        senderName: "Mira Line Rewards",
+        senderEmail: "bonus@mira-line-travel.com",
+        subject: "Q2 Board Packet bonus fares",
+        snippet: "Board packet members unlock Q2 reward routing and lounge upgrades.",
+        unread: true,
+        attachments: ["pdf-campaign-recap"],
+        updatedAt: "2026-04-10T08:05:00",
+        cluster: "board-packet",
+        messages: [
+          {
+            id: "msg-fin-board-pack-decoy-1",
+            from: "Mira Line Rewards",
+            email: "bonus@mira-line-travel.com",
+            timestamp: "Apr 10, 8:05 AM",
+            body: "This is a promotions decoy thread and should not be labeled or replied to.",
+          },
+        ],
+      }),
+      createThread({
+        id: "thr-campaign-april-pulse",
+        category: "promotions",
+        senderName: "Campaign Ops",
+        senderEmail: "pulse@sendercamp.co",
+        subject: "April Pulse relaunch / campaign thread",
+        snippet: "Creative hold remains unresolved. Archive this campaign once reviewed.",
+        unread: true,
+        labelIds: ["lbl-campaigns-q3"],
+        updatedAt: "2026-04-08T12:10:00",
+        cluster: "campaign-cleanup",
+        messages: [
+          {
+            id: "msg-campaign-april-pulse-1",
+            from: "Campaign Ops",
+            email: "pulse@sendercamp.co",
+            timestamp: "Apr 8, 12:10 PM",
+            body: "Archive this outdated relaunch campaign thread during inbox cleanup.",
+          },
+        ],
+      }),
+      createThread({
+        id: "thr-campaign-april-pulse-followup",
+        category: "promotions",
+        senderName: "Campaign Ops",
+        senderEmail: "pulse@sendercamp.co",
+        subject: "April Pulse relaunch / campaign thread follow-up",
+        snippet: "The retargeting push is canceled. Archive this campaign thread too.",
+        unread: true,
+        updatedAt: "2026-04-08T12:26:00",
+        cluster: "campaign-cleanup",
+        messages: [
+          {
+            id: "msg-campaign-april-pulse-followup-1",
+            from: "Campaign Ops",
+            email: "pulse@sendercamp.co",
+            timestamp: "Apr 8, 12:26 PM",
+            body: "This second campaign thread also belongs in the archive.",
+          },
+        ],
+      }),
+      createThread({
+        id: "thr-campaign-decoy-metrics",
+        category: "updates",
+        senderName: "Campaign Analytics",
+        senderEmail: "metrics@sendercamp.co",
+        subject: "April Pulse relaunch metrics snapshot",
+        snippet: "This analytics digest looks similar but should stay in the inbox.",
+        unread: false,
+        updatedAt: "2026-04-08T14:14:00",
+        cluster: "campaign-cleanup",
+        messages: [
+          {
+            id: "msg-campaign-decoy-metrics-1",
+            from: "Campaign Analytics",
+            email: "metrics@sendercamp.co",
+            timestamp: "Apr 8, 2:14 PM",
+            body: "Keep this metrics digest. It is not one of the campaign threads for archiving.",
+          },
+        ],
+      }),
+      createThread({
+        id: "thr-urgent-payroll",
+        category: "primary",
+        senderName: "Priya Shah",
+        senderEmail: "priya.shah@northstar.com",
+        subject: "Urgent: payroll exception needs review",
+        snippet: "Star this thread so the ops lead can find it later today.",
+        unread: true,
+        updatedAt: "2026-04-10T07:40:00",
+        cluster: "inbox-cleanup",
+        messages: [
+          {
+            id: "msg-urgent-payroll-1",
+            from: "Priya Shah",
+            email: "priya.shah@northstar.com",
+            timestamp: "Apr 10, 7:40 AM",
+            body: "Please star this urgent payroll exception thread during cleanup.",
+          },
+        ],
+      }),
+      createThread({
+        id: "thr-renewal-redline",
+        category: "updates",
+        senderName: "Legal Ops",
+        senderEmail: "legal.ops@northstar.com",
+        subject: "Vendor renewal redline summary",
+        snippet: "Mark this unread so it remains queued for the legal review block.",
+        unread: false,
+        labelIds: ["lbl-legal-signoff"],
+        updatedAt: "2026-04-09T16:02:00",
+        cluster: "inbox-cleanup",
+        messages: [
+          {
+            id: "msg-renewal-redline-1",
+            from: "Legal Ops",
+            email: "legal.ops@northstar.com",
+            timestamp: "Apr 9, 4:02 PM",
+            body: "Mark this thread unread after cleanup. It should remain visible for legal follow-up.",
+          },
+        ],
+      }),
+      createThread({
+        id: "thr-vendor-delta-blocker",
+        category: "updates",
+        senderName: "Casey Moran",
+        senderEmail: "casey.moran@deltacomponents.io",
+        subject: "Re: Delta Components customs hold",
+        snippet: "The latest reply includes the exact escalation recipients and attachment path.",
+        unread: true,
+        labelIds: ["lbl-vendors-shipping"],
+        updatedAt: "2026-04-10T11:05:00",
+        cluster: "vendor-escalation",
+        messages: [
+          {
+            id: "msg-vendor-delta-1",
+            from: "Casey Moran",
+            email: "casey.moran@deltacomponents.io",
+            timestamp: "Apr 7, 6:18 PM",
+            body:
+              "We hit a customs hold in Rotterdam. Initial recommendation was to wait twenty-four hours before escalating.",
+          },
+          {
+            id: "msg-vendor-delta-2",
+            from: "Operations Desk",
+            email: "ops@northstar.com",
+            timestamp: "Apr 8, 8:45 AM",
+            body:
+              "Please expand the hidden history before acting. The most recent reply changes the escalation path and references a Drive attachment, not a PDF upload.",
+          },
+          {
+            id: "msg-vendor-delta-3",
+            from: "Casey Moran",
+            email: "casey.moran@deltacomponents.io",
+            timestamp: "Apr 10, 11:05 AM",
+            body:
+              "Escalate this to mila.ops@northstar.com and CC arun.procurement@northstar.com.\nUse the sentence: Escalating the Delta Components shipment blocker. Mila and Arun are looped in for a decision today.\nSave it as a draft first, reopen the draft, then attach the Drive link named Vendor SLA Summary before sending.",
+          },
+        ],
+      }),
+      createThread({
+        id: "thr-vendor-delta-decoy",
+        category: "updates",
+        senderName: "Delta Loyalty",
+        senderEmail: "offers@deltarewards.travel",
+        subject: "Delta travel customs hold FAQ",
+        snippet: "A plausible search decoy with the same customs wording.",
+        unread: false,
+        updatedAt: "2026-04-10T09:48:00",
+        cluster: "vendor-escalation",
+        messages: [
+          {
+            id: "msg-vendor-delta-decoy-1",
+            from: "Delta Loyalty",
+            email: "offers@deltarewards.travel",
+            timestamp: "Apr 10, 9:48 AM",
+            body: "This travel decoy should not be forwarded or drafted.",
+          },
+        ],
+      }),
+    ];
+
+    const fillerClusters = [
+      {
+        cluster: "finance",
+        category: "primary",
+        senderName: "Finance Ops",
+        senderEmail: "finance.ops@northstar.com",
+        baseSubject: "Q2 variance note",
+      },
+      {
+        cluster: "product",
+        category: "updates",
+        senderName: "Product Announce",
+        senderEmail: "announce@northstar.com",
+        baseSubject: "Workspace release digest",
+      },
+      {
+        cluster: "sales",
+        category: "promotions",
+        senderName: "Revenue Studio",
+        senderEmail: "hello@revenuestudio.io",
+        baseSubject: "Pipeline acceleration package",
+      },
+      {
+        cluster: "vendors",
+        category: "updates",
+        senderName: "Vendor Desk",
+        senderEmail: "vendor.desk@northstar.com",
+        baseSubject: "Shipping checkpoint",
+      },
+    ];
+
+    const fillerThreads = [];
+    fillerClusters.forEach((cluster, clusterIndex) => {
+      for (let index = 1; index <= 8; index += 1) {
+        fillerThreads.push(
+          createThread({
+            id: `thr-${cluster.cluster}-${index}`,
+            category: cluster.category,
+            senderName: cluster.senderName,
+            senderEmail: cluster.senderEmail,
+            subject: `${cluster.baseSubject} ${index}`,
+            snippet: `Routine seeded message ${index} for ${cluster.cluster}.`,
+            unread: index % 3 === 0,
+            starred: index === clusterIndex + 2,
+            updatedAt: `2026-04-${String((index % 8) + 1).padStart(2, "0")}T0${(clusterIndex % 4) + 8}:12:00`,
+            cluster: cluster.cluster,
+            messages: [
+              {
+                id: `msg-${cluster.cluster}-${index}`,
+                from: cluster.senderName,
+                email: cluster.senderEmail,
+                timestamp: `Apr ${String((index % 8) + 1).padStart(2, "0")}, 8:12 AM`,
+                body: `Routine seeded message ${index} in the ${cluster.cluster} cluster.`,
+              },
+            ],
+          }),
+        );
+      }
+    });
+
+    return fillerThreads.concat(importantThreads);
+  }
+
+  function buildSeedState() {
+    return {
+      labels: LABELS.slice(),
+      threads: buildSeedThreads(),
+      drafts: [],
+      ui: {
+        mailbox: "primary",
+        searchQuery: "",
+        openThreadId: null,
+        selectedThreadIds: [],
+        expandedThreadIds: [],
+        modal: null,
+      },
+      counters: {
+        draft: 1,
+        label: 1,
+      },
+    };
+  }
+
+  const store = createSeededStore({
+    storageKey: "openbrowser.eval.gmail",
+    seedState: buildSeedState(),
+  });
+
+  const app = document.getElementById("app");
+
+  function getThreadById(state, threadId) {
+    return state.threads.find((thread) => thread.id === threadId) || null;
+  }
+
+  function getDraftById(state, draftId) {
+    return state.drafts.find((draft) => draft.id === draftId) || null;
+  }
+
+  function getLabelName(state, labelId) {
+    return state.labels.find((label) => label.id === labelId)?.name || labelId;
+  }
+
+  function getVisibleThreads(state) {
+    const query = state.ui.searchQuery.trim();
+    const { operators, terms } = parseOperatorQuery(query);
+    const visibleThreads = state.threads.filter((thread) => !thread.archived);
+
+    if (!query) {
+      if (state.ui.mailbox === "drafts") {
+        return [];
+      }
+
+      return visibleThreads.filter((thread) => thread.category === state.ui.mailbox);
+    }
+
+    return visibleThreads.filter((thread) => {
+      if (operators.from) {
+        const senderBlob = `${thread.senderName} ${thread.senderEmail}`;
+        if (!normalize(senderBlob).includes(normalize(operators.from))) {
+          return false;
+        }
+      }
+
+      if (operators.subject && !normalize(thread.subject).includes(normalize(operators.subject))) {
+        return false;
+      }
+
+      if (operators.category && normalize(thread.category) !== normalize(operators.category)) {
+        return false;
+      }
+
+      if (operators.label) {
+        const labelNames = thread.labelIds.map((labelId) => getLabelName(state, labelId)).join(" ");
+        if (!normalize(labelNames).includes(normalize(operators.label))) {
+          return false;
+        }
+      }
+
+      if (operators.has === "attachment" && thread.attachments.length === 0) {
+        return false;
+      }
+
+      const searchBlob = `${thread.senderName} ${thread.senderEmail} ${thread.subject} ${thread.snippet} ${
+        thread.messages[thread.messages.length - 1]?.body || ""
+      }`;
+      return terms.every((term) => normalize(searchBlob).includes(normalize(term)));
+    });
+  }
+
+  function getMailboxCount(state, mailbox) {
+    if (mailbox === "drafts") {
+      return state.drafts.length;
+    }
+
+    return state.threads.filter((thread) => !thread.archived && thread.category === mailbox).length;
+  }
+
+  function getOpenDetail(state) {
+    if (state.ui.mailbox === "drafts") {
+      return null;
+    }
+
+    const openThread = getThreadById(state, state.ui.openThreadId);
+    if (openThread && !openThread.archived) {
+      return openThread;
+    }
+
+    return null;
+  }
+
+  function renderSidebar(state) {
+    const mailboxes = [
+      { id: "primary", label: "Primary" },
+      { id: "promotions", label: "Promotions" },
+      { id: "updates", label: "Updates" },
+      { id: "drafts", label: "Drafts" },
+    ];
+
+    return `
+      <aside class="gmail-sidebar mock-card">
+        <button class="mock-btn gmail-compose-btn" data-action="open-compose" data-mode="new">
+          Compose
+        </button>
+        <div class="gmail-nav-group">
+          ${mailboxes
+            .map(
+              (mailbox) => `
+                <button class="gmail-nav-item ${state.ui.mailbox === mailbox.id ? "active" : ""}" data-action="set-mailbox" data-mailbox="${mailbox.id}">
+                  <span>${mailbox.label}</span>
+                  <span>${getMailboxCount(state, mailbox.id)}</span>
+                </button>
+              `,
+            )
+            .join("")}
+        </div>
+        <div>
+          <p class="mock-kicker">Nested Labels</p>
+          <div class="gmail-label-list">
+            ${state.labels
+              .map(
+                (label) => `
+                  <div class="gmail-label-item">
+                    <span>${escapeHtml(label.name)}</span>
+                    <span>${state.threads.filter((thread) => thread.labelIds.includes(label.id) && !thread.archived).length}</span>
+                  </div>
+                `,
+              )
+              .join("")}
+          </div>
+        </div>
+      </aside>
+    `;
+  }
+
+  function renderThreadRow(state, thread) {
+    const activeClass = state.ui.openThreadId === thread.id ? "active" : "";
+    const selectedClass = state.ui.selectedThreadIds.includes(thread.id) ? "selected" : "";
+    return `
+      <article class="gmail-thread-row ${activeClass} ${selectedClass} ${thread.unread ? "unread" : ""}" data-thread-id="${thread.id}">
+        <input class="gmail-thread-checkbox" type="checkbox" data-action="select-thread" data-thread-id="${thread.id}" ${
+          state.ui.selectedThreadIds.includes(thread.id) ? "checked" : ""
+        }>
+        <button class="gmail-thread-star mock-btn-ghost" data-action="toggle-star" data-thread-id="${thread.id}">
+          ${thread.starred ? "★" : "☆"}
+        </button>
+        <button class="gmail-thread-main mock-btn-ghost" data-action="open-thread" data-thread-id="${thread.id}">
+          <div class="gmail-thread-topline">
+            <span class="gmail-thread-sender">${escapeHtml(thread.senderName)}</span>
+            <span class="gmail-thread-subject">${escapeHtml(thread.subject)}</span>
+          </div>
+          <div class="gmail-thread-meta">
+            <span>${escapeHtml(thread.senderEmail)}</span>
+            <span>${thread.attachments.length ? "Has attachment" : "No attachment"}</span>
+            <span>${thread.category}</span>
+          </div>
+          <div class="gmail-thread-snippet">${escapeHtml(thread.snippet)}</div>
+          <div class="gmail-thread-tags">
+            ${thread.labelIds.map((labelId) => `<span class="mock-badge">${escapeHtml(getLabelName(state, labelId))}</span>`).join("")}
+          </div>
+        </button>
+        <div class="gmail-thread-meta">
+          <span>${formatLongDate(thread.updatedAt.slice(0, 10))}</span>
+        </div>
+      </article>
+    `;
+  }
+
+  function renderListPanel(state) {
+    const visibleThreads = getVisibleThreads(state);
+    const selectionLabel = state.ui.selectedThreadIds.length
+      ? `${state.ui.selectedThreadIds.length} selected`
+      : state.ui.searchQuery
+        ? `Search results for "${escapeHtml(state.ui.searchQuery)}"`
+        : state.ui.mailbox[0].toUpperCase() + state.ui.mailbox.slice(1);
+
+    return `
+      <section class="gmail-list-panel mock-card">
+        <div class="gmail-list-toolbar">
+          <div>
+            <p class="mock-kicker">Mailbox</p>
+            <h2 class="mock-title">${selectionLabel}</h2>
+          </div>
+          <div class="gmail-toolbar-actions">
+            <button class="mock-btn-secondary" data-action="apply-label" ${
+              state.ui.selectedThreadIds.length ? "" : "disabled"
+            }>Apply label</button>
+            <button class="mock-btn-secondary" data-action="archive-selected" ${
+              state.ui.selectedThreadIds.length ? "" : "disabled"
+            }>Archive</button>
+            <button class="mock-btn-secondary" data-action="mark-unread-selected" ${
+              state.ui.selectedThreadIds.length ? "" : "disabled"
+            }>Mark unread</button>
+          </div>
+        </div>
+        <div class="gmail-thread-list">
+          ${
+            state.ui.mailbox === "drafts"
+              ? renderDraftList(state)
+              : visibleThreads.length
+                ? visibleThreads.map((thread) => renderThreadRow(state, thread)).join("")
+                : '<div class="mock-empty">No conversations match the current mailbox or operator search.</div>'
+          }
+        </div>
+      </section>
+    `;
+  }
+
+  function renderDraftList(state) {
+    if (!state.drafts.length) {
+      return '<div class="mock-empty">No drafts saved yet.</div>';
+    }
+
+    return state.drafts
+      .map(
+        (draft) => `
+          <article class="gmail-thread-row" data-draft-id="${draft.id}">
+            <div></div>
+            <div></div>
+            <button class="gmail-thread-main mock-btn-ghost" data-action="open-draft" data-draft-id="${draft.id}">
+              <div class="gmail-draft-row">
+                <span class="gmail-thread-subject">${escapeHtml(draft.subject || "(no subject)")}</span>
+                <span class="gmail-thread-sender">${escapeHtml((draft.to || []).join(", ") || "No recipients")}</span>
+                <span class="gmail-thread-snippet">${escapeHtml(draft.body || "Draft body is empty")}</span>
+              </div>
+            </button>
+            <div class="gmail-thread-meta"><span>${formatLongDate(draft.updatedAt.slice(0, 10))}</span></div>
+          </article>
+        `,
+      )
+      .join("");
+  }
+
+  function renderDetailPanel(state) {
+    const thread = getOpenDetail(state);
+
+    if (!thread) {
+      return `
+        <section class="gmail-detail-panel mock-card">
+          <div class="mock-empty">Open a thread to inspect the latest message, expand history, or start a reply.</div>
+        </section>
+      `;
+    }
+
+    const isExpanded = state.ui.expandedThreadIds.includes(thread.id);
+    const hiddenMessages = thread.messages.length > 1 && !isExpanded ? thread.messages.slice(0, -1) : [];
+    const visibleMessages = isExpanded ? thread.messages : thread.messages.slice(-1);
+
+    return `
+      <section class="gmail-detail-panel mock-card">
+        <div class="gmail-thread-detail">
+          <div class="gmail-thread-header">
+            <div>
+              <p class="mock-kicker">Conversation</p>
+              <h2 class="mock-title">${escapeHtml(thread.subject)}</h2>
+              <p class="mock-subtle">${escapeHtml(thread.senderName)} · ${escapeHtml(thread.senderEmail)}</p>
+            </div>
+            <div class="gmail-detail-actions">
+              <button class="mock-btn-secondary" data-action="toggle-star" data-thread-id="${thread.id}">
+                ${thread.starred ? "Unstar" : "Star"}
+              </button>
+              <button class="mock-btn-secondary" data-action="mark-thread-unread" data-thread-id="${thread.id}">
+                Mark unread
+              </button>
+              <button class="mock-btn-secondary" data-action="open-compose" data-mode="reply" data-thread-id="${thread.id}">
+                Reply
+              </button>
+              <button class="mock-btn-secondary" data-action="open-compose" data-mode="forward" data-thread-id="${thread.id}">
+                Forward
+              </button>
+            </div>
+          </div>
+          ${
+            hiddenMessages.length
+              ? `
+                <div class="gmail-collapsed-banner">
+                  <div>
+                    <strong>${hiddenMessages.length} older replies are collapsed</strong>
+                    <div class="mock-subtle">Expand the history before acting if the latest reply references older context.</div>
+                  </div>
+                  <button class="mock-btn-secondary" data-action="expand-thread" data-thread-id="${thread.id}">
+                    Show history
+                  </button>
+                </div>
+              `
+              : ""
+          }
+          ${visibleMessages
+            .map(
+              (message) => `
+                <article class="gmail-message-card">
+                  <div class="gmail-message-head">
+                    <div>
+                      <strong>${escapeHtml(message.from)}</strong>
+                      <div class="mock-subtle">${escapeHtml(message.email)}</div>
+                    </div>
+                    <span class="mock-badge">${escapeHtml(message.timestamp)}</span>
+                  </div>
+                  <div class="gmail-message-body">${escapeHtml(message.body)}</div>
+                </article>
+              `,
+            )
+            .join("")}
+          ${
+            thread.attachments.length
+              ? `
+                <div>
+                  <p class="mock-kicker">Existing Attachments</p>
+                  <div class="gmail-thread-tags">
+                    ${thread.attachments
+                      .map((attachmentId) => {
+                        const attachment = ATTACHMENTS.upload
+                          .concat(ATTACHMENTS.drive)
+                          .find((item) => item.id === attachmentId);
+                        return `<span class="mock-badge">${escapeHtml(attachment ? attachment.name : attachmentId)}</span>`;
+                      })
+                      .join("")}
+                  </div>
+                </div>
+              `
+              : ""
+          }
+        </div>
+      </section>
+    `;
+  }
+
+  function renderComposeModal(state) {
+    const modal = state.ui.modal;
+    if (!modal || modal.type !== "compose") {
+      return "";
+    }
+
+    const attachmentSource = modal.attachmentSource || "upload";
+    const attachmentChoices = ATTACHMENTS[attachmentSource];
+
+    return `
+      <div class="mock-modal-backdrop">
+        <div class="mock-modal gmail-compose-modal">
+          <div class="mock-modal-header">
+            <div>
+              <p class="mock-kicker">${escapeHtml(modal.mode)} draft</p>
+              <h3 class="mock-title">${escapeHtml(modal.subject || "(no subject)")}</h3>
+            </div>
+            <button class="mock-btn-ghost" data-action="close-compose">Close</button>
+          </div>
+          <div class="mock-modal-body">
+            <div class="gmail-compose-grid two-col">
+              <div>
+                <label class="mock-kicker" for="compose-to">To</label>
+                <input id="compose-to" class="mock-input" data-field="to" value="${escapeHtml((modal.to || []).join(", "))}">
+              </div>
+              <div>
+                <label class="mock-kicker" for="compose-cc">CC</label>
+                <input id="compose-cc" class="mock-input" data-field="cc" value="${escapeHtml((modal.cc || []).join(", "))}">
+              </div>
+            </div>
+            <div class="gmail-compose-grid">
+              <div>
+                <label class="mock-kicker" for="compose-subject">Subject</label>
+                <input id="compose-subject" class="mock-input" data-field="subject" value="${escapeHtml(modal.subject || "")}">
+              </div>
+              <div>
+                <label class="mock-kicker" for="compose-body">Message</label>
+                <textarea id="compose-body" class="mock-textarea" rows="9" data-field="body">${escapeHtml(modal.body || "")}</textarea>
+              </div>
+            </div>
+            <div class="gmail-compose-toolbar">
+              <button class="mock-btn-secondary" data-action="open-attachment-picker">Add attachment</button>
+              <button class="mock-btn-secondary" data-action="save-draft">Save draft</button>
+              <span class="mock-pill">Draft ID: ${escapeHtml(modal.id)}</span>
+              <span class="mock-pill">Autosaves on typing</span>
+            </div>
+            <div>
+              <p class="mock-kicker">Attachments</p>
+              <div class="gmail-thread-tags">
+                ${(modal.attachments || []).length
+                  ? modal.attachments
+                      .map((attachmentId) => {
+                        const attachment = ATTACHMENTS.upload.concat(ATTACHMENTS.drive).find((item) => item.id === attachmentId);
+                        return `<span class="mock-badge">${escapeHtml(attachment ? attachment.name : attachmentId)}</span>`;
+                      })
+                      .join("")
+                  : '<span class="mock-subtle">No attachments yet.</span>'}
+              </div>
+            </div>
+            ${
+              modal.showAttachmentPicker
+                ? `
+                  <div class="mock-card" style="padding: 18px; margin-top: 18px;">
+                    <div class="gmail-detail-actions" style="margin-bottom: 14px;">
+                      <button class="mock-btn-secondary" data-action="set-attachment-source" data-source="upload">Mock upload</button>
+                      <button class="mock-btn-secondary" data-action="set-attachment-source" data-source="drive">Drive link</button>
+                    </div>
+                    <div class="gmail-attachment-grid">
+                      ${attachmentChoices
+                        .map(
+                          (attachment) => `
+                            <button class="gmail-attachment-card ${modal.attachments.includes(attachment.id) ? "active" : ""}" data-action="attach-item" data-attachment-id="${attachment.id}">
+                              <div class="mock-kicker">${escapeHtml(attachment.kind)}</div>
+                              <strong>${escapeHtml(attachment.name)}</strong>
+                              <div class="mock-subtle">${escapeHtml(attachment.size)}</div>
+                            </button>
+                          `,
+                        )
+                        .join("")}
+                    </div>
+                  </div>
+                `
+                : ""
+            }
+          </div>
+          <div class="mock-modal-footer">
+            <span class="mock-subtle">Underlying inbox stays visible beneath the compose modal, similar to Gmail.</span>
+            <div class="gmail-compose-actions">
+              <button class="mock-btn-secondary" data-action="apply-label-from-compose">Apply label</button>
+              <button class="mock-btn" data-action="send-compose">Send</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  function renderLabelModal(state) {
+    const modal = state.ui.modal;
+    if (!modal || modal.type !== "label") {
+      return "";
+    }
+
+    return `
+      <div class="mock-modal-backdrop">
+        <div class="mock-modal">
+          <div class="mock-modal-header">
+            <div>
+              <p class="mock-kicker">Thread labels</p>
+              <h3 class="mock-title">Apply or create a nested label</h3>
+            </div>
+            <button class="mock-btn-ghost" data-action="close-label-modal">Close</button>
+          </div>
+          <div class="mock-modal-body">
+            <div class="gmail-label-grid">
+              ${state.labels
+                .map(
+                  (label) => `
+                    <button class="gmail-label-option" data-action="commit-label" data-label-id="${label.id}">
+                      <span>${escapeHtml(label.name)}</span>
+                      <span class="mock-subtle">Apply</span>
+                    </button>
+                  `,
+                )
+                .join("")}
+            </div>
+            <div style="margin-top: 18px;">
+              <label class="mock-kicker" for="new-label-name">Create a new label</label>
+              <input id="new-label-name" class="mock-input" data-role="new-label-name" value="${escapeHtml(modal.newLabelName || "")}" placeholder="Finance/Board-Prep">
+            </div>
+          </div>
+          <div class="mock-modal-footer">
+            <span class="mock-subtle">Selected threads: ${escapeHtml((modal.threadIds || []).join(", "))}</span>
+            <button class="mock-btn" data-action="create-label">Create label</button>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  function render() {
+    const state = store.getState();
+    app.innerHTML = `
+      <div class="mock-page gmail-page">
+        <header class="mock-topbar">
+          <div class="gmail-topbar-inner">
+            <div class="gmail-brand">
+              <div class="gmail-brand-mark">M</div>
+              <div>
+                <div>Mailbox Workspace</div>
+                <div class="mock-subtle">Primary, Promotions, Updates, Drafts</div>
+              </div>
+            </div>
+            <form class="gmail-search-form" id="gmail-search-form">
+              <input class="mock-input" id="gmail-search-input" value="${escapeHtml(state.ui.searchQuery)}" placeholder='Search mail. Operators: from:, subject:, label:, category:, has:attachment'>
+              <button class="mock-btn gmail-search-submit" type="submit">Search</button>
+            </form>
+            <div class="gmail-topbar-actions">
+              <span class="mock-pill">35+ seeded threads</span>
+              <span class="mock-pill">Selection toolbar is stateful</span>
+            </div>
+          </div>
+        </header>
+        <main class="gmail-layout">
+          ${renderSidebar(state)}
+          ${renderListPanel(state)}
+          ${renderDetailPanel(state)}
+        </main>
+        ${renderComposeModal(state)}
+        ${renderLabelModal(state)}
+      </div>
+    `;
+  }
+
+  function trackSearch(query) {
+    const parsed = parseOperatorQuery(query);
+    tracker.track("mail_search_execute", {
+      query,
+      operators: Object.keys(parsed.operators).sort(),
+      hasAttachmentOperator: parsed.operators.has === "attachment",
+    });
+  }
+
+  function setMailbox(mailbox) {
+    store.update((state) => {
+      state.ui.mailbox = mailbox;
+      state.ui.selectedThreadIds = [];
+      state.ui.searchQuery = "";
+    });
+    render();
+  }
+
+  function openThread(threadId) {
+    const nextState = store.update((state) => {
+      state.ui.openThreadId = threadId;
+      state.ui.mailbox = getThreadById(state, threadId)?.category || state.ui.mailbox;
+      const thread = getThreadById(state, threadId);
+      if (thread) {
+        thread.unread = false;
+      }
+    });
+    const thread = getThreadById(nextState, threadId);
+    if (thread) {
+      tracker.track("thread_open", {
+        threadId: thread.id,
+        category: thread.category,
+        cluster: thread.cluster,
+      });
+    }
+    render();
+  }
+
+  function toggleSelection(threadId) {
+    const nextState = store.update((state) => {
+      const selected = new Set(state.ui.selectedThreadIds);
+      if (selected.has(threadId)) {
+        selected.delete(threadId);
+      } else {
+        selected.add(threadId);
+      }
+      state.ui.selectedThreadIds = Array.from(selected);
+    });
+
+    tracker.track("thread_select", {
+      threadId,
+      threadIds: uniqueSorted(nextState.ui.selectedThreadIds),
+    });
+    render();
+  }
+
+  function toggleStar(threadId) {
+    const nextState = store.update((state) => {
+      const thread = getThreadById(state, threadId);
+      if (thread) {
+        thread.starred = !thread.starred;
+      }
+    });
+    const thread = getThreadById(nextState, threadId);
+    if (thread) {
+      tracker.track("thread_star_toggle", {
+        threadId,
+        starred: thread.starred,
+      });
+    }
+    render();
+  }
+
+  function archiveSelected() {
+    const stateBefore = store.getState();
+    const targetIds = uniqueSorted(stateBefore.ui.selectedThreadIds);
+    if (!targetIds.length) {
+      return;
+    }
+
+    store.update((state) => {
+      state.threads.forEach((thread) => {
+        if (targetIds.includes(thread.id)) {
+          thread.archived = true;
+        }
+      });
+      state.ui.selectedThreadIds = [];
+      if (targetIds.includes(state.ui.openThreadId)) {
+        state.ui.openThreadId = null;
+      }
+    });
+
+    tracker.track("thread_archive", {
+      threadIds: targetIds,
+    });
+    render();
+  }
+
+  function markUnread(targetIds) {
+    const sortedIds = uniqueSorted(targetIds);
+    if (!sortedIds.length) {
+      return;
+    }
+
+    store.update((state) => {
+      state.threads.forEach((thread) => {
+        if (sortedIds.includes(thread.id)) {
+          thread.unread = true;
+        }
+      });
+      state.ui.selectedThreadIds = [];
+    });
+
+    tracker.track("thread_mark_unread", {
+      threadIds: sortedIds,
+      threadId: sortedIds[0],
+    });
+    render();
+  }
+
+  function expandThread(threadId) {
+    const nextState = store.update((state) => {
+      if (!state.ui.expandedThreadIds.includes(threadId)) {
+        state.ui.expandedThreadIds.push(threadId);
+      }
+    });
+    const thread = getThreadById(nextState, threadId);
+    tracker.track("thread_expand", {
+      threadId,
+      expandedMessages: thread ? thread.messages.length : 0,
+    });
+    render();
+  }
+
+  function openLabelModal(threadIds) {
+    store.update((state) => {
+      state.ui.modal = {
+        type: "label",
+        threadIds: uniqueSorted(threadIds),
+        newLabelName: "",
+      };
+    });
+    render();
+  }
+
+  function applyLabel(labelId, threadIds) {
+    const targetIds = uniqueSorted(threadIds);
+    store.update((state) => {
+      state.threads.forEach((thread) => {
+        if (targetIds.includes(thread.id) && !thread.labelIds.includes(labelId)) {
+          thread.labelIds.push(labelId);
+        }
+      });
+      if (state.ui.modal?.type === "label") {
+        state.ui.modal = null;
+      }
+    });
+
+    tracker.track("label_apply", {
+      labelId,
+      labelName: getLabelName(store.getState(), labelId),
+      threadIds: targetIds,
+      threadId: targetIds[0],
+    });
+    render();
+  }
+
+  function createLabel() {
+    const state = store.getState();
+    const modal = state.ui.modal;
+    if (!modal || modal.type !== "label") {
+      return;
+    }
+
+    const name = (modal.newLabelName || "").trim();
+    if (!name) {
+      return;
+    }
+
+    const labelId = `lbl-custom-${state.counters.label}`;
+    store.update((draft) => {
+      draft.labels.push({ id: labelId, name });
+      draft.counters.label += 1;
+    });
+
+    tracker.track("label_create", {
+      labelId,
+      labelName: name,
+    });
+    applyLabel(labelId, modal.threadIds || []);
+  }
+
+  function createComposeModal(mode, threadId, existingDraft) {
+    const state = store.getState();
+    const thread = threadId ? getThreadById(state, threadId) : null;
+    const draftId = existingDraft?.id || `draft-${state.counters.draft}`;
+    const subjectPrefix = mode === "forward" ? "Fwd: " : mode === "reply" ? "Re: " : "";
+
+    const composeModal = {
+      type: "compose",
+      id: draftId,
+      mode,
+      threadId: threadId || null,
+      subject: existingDraft?.subject || (thread ? `${subjectPrefix}${thread.subject}` : ""),
+      to:
+        existingDraft?.to ||
+        (mode === "reply" && thread ? [thread.senderEmail] : mode === "forward" ? [] : []),
+      cc: existingDraft?.cc || [],
+      body: existingDraft?.body || "",
+      attachments: existingDraft?.attachments || [],
+      attachmentSource: existingDraft?.attachmentSource || "upload",
+      showAttachmentPicker: false,
+    };
+
+    store.update((draft) => {
+      if (!existingDraft) {
+        draft.counters.draft += 1;
+      }
+      draft.ui.modal = composeModal;
+    });
+
+    if (mode === "reply") {
+      tracker.track("reply_open", {
+        threadId,
+        draftId,
+      });
+    } else {
+      tracker.track("compose_open", {
+        threadId: threadId || null,
+        draftId,
+        mode,
+      });
+    }
+
+    render();
+  }
+
+  const autosaveDraft = debounce(() => {
+    const state = store.getState();
+    const modal = state.ui.modal;
+    if (!modal || modal.type !== "compose") {
+      return;
+    }
+
+    tracker.track("draft_autosave", {
+      draftId: modal.id,
+      threadId: modal.threadId || null,
+      mode: modal.mode,
+    });
+  }, 300);
+
+  function upsertDraftFromModal(closeAfterSave) {
+    const state = store.getState();
+    const modal = state.ui.modal;
+    if (!modal || modal.type !== "compose") {
+      return;
+    }
+
+    const draftRecord = {
+      id: modal.id,
+      threadId: modal.threadId,
+      subject: modal.subject,
+      to: modal.to || [],
+      cc: modal.cc || [],
+      body: modal.body,
+      attachments: modal.attachments || [],
+      attachmentSource: modal.attachmentSource || "upload",
+      updatedAt: new Date().toISOString(),
+    };
+
+    store.update((draft) => {
+      const existingIndex = draft.drafts.findIndex((item) => item.id === draftRecord.id);
+      if (existingIndex >= 0) {
+        draft.drafts.splice(existingIndex, 1, draftRecord);
+      } else {
+        draft.drafts.unshift(draftRecord);
+      }
+
+      if (closeAfterSave) {
+        draft.ui.modal = null;
+      }
+    });
+
+    tracker.track("draft_autosave", {
+      draftId: draftRecord.id,
+      threadId: draftRecord.threadId || null,
+      mode: modal.mode,
+    });
+
+    if (closeAfterSave) {
+      render();
+    }
+  }
+
+  function sendCompose() {
+    const state = store.getState();
+    const modal = state.ui.modal;
+    if (!modal || modal.type !== "compose") {
+      return;
+    }
+
+    store.update((draft) => {
+      if (modal.threadId) {
+        const thread = getThreadById(draft, modal.threadId);
+        if (thread) {
+          thread.messages.push({
+            id: `${modal.id}-sent`,
+            from: "You",
+            email: "me@northstar.com",
+            timestamp: "Apr 10, 12:30 PM",
+            body: modal.body,
+          });
+          thread.unread = false;
+          if (modal.attachments.length) {
+            thread.attachments = uniqueSorted(thread.attachments.concat(modal.attachments));
+          }
+        }
+      }
+
+      draft.drafts = draft.drafts.filter((item) => item.id !== modal.id);
+      draft.ui.modal = null;
+    });
+
+    tracker.track("mail_send", {
+      draftId: modal.id,
+      threadId: modal.threadId || null,
+      mode: modal.mode,
+      to: modal.to || [],
+      cc: modal.cc || [],
+      subject: modal.subject,
+      body: modal.body,
+      attachmentIds: uniqueSorted(modal.attachments || []),
+    });
+
+    render();
+  }
+
+  function updateComposeField(field, value) {
+    store.update((state) => {
+      const modal = state.ui.modal;
+      if (!modal || modal.type !== "compose") {
+        return;
+      }
+
+      if (field === "to" || field === "cc") {
+        modal[field] = value
+          .split(",")
+          .map((part) => part.trim())
+          .filter(Boolean);
+      } else {
+        modal[field] = value;
+      }
+    });
+    upsertDraftFromModal(false);
+    autosaveDraft();
+  }
+
+  function attachItem(attachmentId) {
+    const state = store.getState();
+    const modal = state.ui.modal;
+    if (!modal || modal.type !== "compose") {
+      return;
+    }
+
+    const attachmentPool = ATTACHMENTS.upload.concat(ATTACHMENTS.drive);
+    const attachment = attachmentPool.find((item) => item.id === attachmentId);
+    if (!attachment) {
+      return;
+    }
+
+    store.update((draft) => {
+      const compose = draft.ui.modal;
+      if (!compose || compose.type !== "compose") {
+        return;
+      }
+      if (!compose.attachments.includes(attachmentId)) {
+        compose.attachments.push(attachmentId);
+      }
+    });
+
+    tracker.track("attachment_add", {
+      draftId: modal.id,
+      attachmentId,
+      source: normalize(attachment.kind) === "drive" ? "drive" : "upload",
+    });
+    upsertDraftFromModal(false);
+    render();
+  }
+
+  app.addEventListener("submit", (event) => {
+    if (event.target.id !== "gmail-search-form") {
+      return;
+    }
+
+    event.preventDefault();
+    const input = document.getElementById("gmail-search-input");
+    const query = input ? input.value.trim() : "";
+    store.update((state) => {
+      state.ui.searchQuery = query;
+      state.ui.selectedThreadIds = [];
+    });
+    trackSearch(query);
+    render();
+  });
+
+  app.addEventListener("click", (event) => {
+    const target = event.target.closest("[data-action]");
+    if (!target) {
+      return;
+    }
+
+    const action = target.dataset.action;
+    const threadId = target.dataset.threadId;
+    const draftId = target.dataset.draftId;
+
+    if (action === "set-mailbox") {
+      setMailbox(target.dataset.mailbox);
+      return;
+    }
+
+    if (action === "open-thread" && threadId) {
+      openThread(threadId);
+      return;
+    }
+
+    if (action === "select-thread" && threadId) {
+      toggleSelection(threadId);
+      return;
+    }
+
+    if (action === "toggle-star" && threadId) {
+      toggleStar(threadId);
+      return;
+    }
+
+    if (action === "archive-selected") {
+      archiveSelected();
+      return;
+    }
+
+    if (action === "mark-unread-selected") {
+      markUnread(store.getState().ui.selectedThreadIds);
+      return;
+    }
+
+    if (action === "mark-thread-unread" && threadId) {
+      markUnread([threadId]);
+      return;
+    }
+
+    if (action === "expand-thread" && threadId) {
+      expandThread(threadId);
+      return;
+    }
+
+    if (action === "apply-label") {
+      openLabelModal(store.getState().ui.selectedThreadIds);
+      return;
+    }
+
+    if (action === "commit-label") {
+      const modal = store.getState().ui.modal;
+      applyLabel(target.dataset.labelId, modal?.threadIds || []);
+      return;
+    }
+
+    if (action === "create-label") {
+      createLabel();
+      return;
+    }
+
+    if (action === "close-label-modal") {
+      store.update((state) => {
+        state.ui.modal = null;
+      });
+      render();
+      return;
+    }
+
+    if (action === "open-compose") {
+      createComposeModal(target.dataset.mode || "new", threadId || null, null);
+      return;
+    }
+
+    if (action === "close-compose") {
+      upsertDraftFromModal(true);
+      return;
+    }
+
+    if (action === "open-draft" && draftId) {
+      const draft = getDraftById(store.getState(), draftId);
+      if (draft) {
+        createComposeModal(draft.threadId ? "forward" : "draft", draft.threadId || null, draft);
+      }
+      return;
+    }
+
+    if (action === "save-draft") {
+      upsertDraftFromModal(true);
+      return;
+    }
+
+    if (action === "send-compose") {
+      sendCompose();
+      return;
+    }
+
+    if (action === "open-attachment-picker") {
+      store.update((state) => {
+        if (state.ui.modal?.type === "compose") {
+          state.ui.modal.showAttachmentPicker = !state.ui.modal.showAttachmentPicker;
+        }
+      });
+      render();
+      return;
+    }
+
+    if (action === "set-attachment-source") {
+      store.update((state) => {
+        if (state.ui.modal?.type === "compose") {
+          state.ui.modal.attachmentSource = target.dataset.source;
+        }
+      });
+      render();
+      return;
+    }
+
+    if (action === "attach-item") {
+      attachItem(target.dataset.attachmentId);
+      return;
+    }
+
+    if (action === "apply-label-from-compose") {
+      const modal = store.getState().ui.modal;
+      const threadIds = modal?.threadId ? [modal.threadId] : [];
+      if (threadIds.length) {
+        openLabelModal(threadIds);
+      }
+      return;
+    }
+  });
+
+  app.addEventListener("input", (event) => {
+    const modal = store.getState().ui.modal;
+    if (!modal) {
+      return;
+    }
+
+    const field = event.target.dataset.field;
+    if (modal.type === "compose" && field) {
+      updateComposeField(field, event.target.value);
+      return;
+    }
+
+    if (modal.type === "label" && event.target.dataset.role === "new-label-name") {
+      store.update((state) => {
+        if (state.ui.modal?.type === "label") {
+          state.ui.modal.newLabelName = event.target.value;
+        }
+      });
+    }
+  });
+
+  render();
+})();

--- a/eval/gmail/js/gmail.js
+++ b/eval/gmail/js/gmail.js
@@ -1100,6 +1100,7 @@ window.tracker = new AgentTracker("mail.google.com", "hard");
     const draftRecord = {
       id: modal.id,
       threadId: modal.threadId,
+      mode: modal.mode,
       subject: modal.subject,
       to: modal.to || [],
       cc: modal.cc || [],
@@ -1331,7 +1332,7 @@ window.tracker = new AgentTracker("mail.google.com", "hard");
     if (action === "open-draft" && draftId) {
       const draft = getDraftById(store.getState(), draftId);
       if (draft) {
-        createComposeModal(draft.threadId ? "forward" : "draft", draft.threadId || null, draft);
+        createComposeModal(draft.mode || (draft.threadId ? "forward" : "draft"), draft.threadId || null, draft);
       }
       return;
     }

--- a/eval/js/hard-mock-core.js
+++ b/eval/js/hard-mock-core.js
@@ -1,0 +1,157 @@
+(function () {
+  function deepClone(value) {
+    return JSON.parse(JSON.stringify(value));
+  }
+
+  function normalize(value) {
+    return String(value ?? "").trim().toLowerCase();
+  }
+
+  function escapeHtml(value) {
+    return String(value ?? "")
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#39;");
+  }
+
+  function uniqueSorted(values) {
+    return Array.from(new Set((values || []).filter(Boolean))).sort();
+  }
+
+  function formatCurrency(amount, currency) {
+    const numericAmount = Number(amount || 0);
+    return `${currency || "$"}${numericAmount.toFixed(0)}`;
+  }
+
+  function formatLongDate(value) {
+    if (!value) {
+      return "";
+    }
+
+    const date = new Date(`${value}T12:00:00`);
+    if (Number.isNaN(date.getTime())) {
+      return value;
+    }
+
+    return date.toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    });
+  }
+
+  function debounce(callback, wait) {
+    let timeoutId = null;
+
+    return function debounced(...args) {
+      clearTimeout(timeoutId);
+      timeoutId = window.setTimeout(() => callback.apply(this, args), wait);
+    };
+  }
+
+  function getSearchTerms(query) {
+    return normalize(query)
+      .split(/\s+/)
+      .filter(Boolean);
+  }
+
+  function createSeededStore(config) {
+    const storageKey = config.storageKey;
+    const seedState = deepClone(config.seedState);
+    const query = new URLSearchParams(window.location.search);
+
+    if (query.get("reset") === "1") {
+      window.localStorage.removeItem(storageKey);
+    }
+
+    let state = seedState;
+    const existingValue = window.localStorage.getItem(storageKey);
+    if (existingValue) {
+      try {
+        state = JSON.parse(existingValue);
+      } catch (error) {
+        state = seedState;
+      }
+    }
+
+    if (typeof config.migrate === "function") {
+      state = config.migrate(state, seedState);
+    }
+
+    function persist(nextState) {
+      state = nextState;
+      window.localStorage.setItem(storageKey, JSON.stringify(state));
+      return state;
+    }
+
+    persist(state);
+
+    if (query.get("reset") === "1") {
+      query.delete("reset");
+      const nextQuery = query.toString();
+      const nextUrl = `${window.location.pathname}${
+        nextQuery ? `?${nextQuery}` : ""
+      }${window.location.hash}`;
+      window.history.replaceState({}, "", nextUrl);
+    }
+
+    return {
+      getState() {
+        return deepClone(state);
+      },
+      save(nextState) {
+        return deepClone(persist(nextState));
+      },
+      update(mutator) {
+        const draft = deepClone(state);
+        const nextState = mutator(draft) || draft;
+        return deepClone(persist(nextState));
+      },
+      reset() {
+        return deepClone(persist(deepClone(seedState)));
+      },
+    };
+  }
+
+  function parseOperatorQuery(query) {
+    const source = String(query || "");
+    const operators = {};
+    let remainder = source;
+    const pattern = /([a-z]+):("[^"]+"|\S+)/gi;
+    let match = pattern.exec(source);
+
+    while (match) {
+      const key = match[1].toLowerCase();
+      const rawValue = match[2].replace(/^"|"$/g, "");
+      operators[key] = rawValue;
+      remainder = remainder.replace(match[0], " ");
+      match = pattern.exec(source);
+    }
+
+    return {
+      operators,
+      terms: getSearchTerms(remainder),
+    };
+  }
+
+  function matchesTerms(haystack, terms) {
+    const normalizedHaystack = normalize(haystack);
+    return (terms || []).every((term) => normalizedHaystack.includes(normalize(term)));
+  }
+
+  window.HardMockSite = {
+    createSeededStore,
+    debounce,
+    deepClone,
+    escapeHtml,
+    formatCurrency,
+    formatLongDate,
+    getSearchTerms,
+    matchesTerms,
+    normalize,
+    parseOperatorQuery,
+    uniqueSorted,
+  };
+})();

--- a/eval/js/tracker.js
+++ b/eval/js/tracker.js
@@ -74,6 +74,7 @@ class AgentTracker {
                 elementId: target.id || null,
                 elementClass: target.className || null,
                 elementText: target.textContent?.trim().substring(0, 100) || null,
+                elementHref: this.getElementHref(target),
                 parentText: parentWithText || null,
                 selector: this.getSelector(target),
                 x: e.clientX,
@@ -149,6 +150,7 @@ class AgentTracker {
                     element: e.target.tagName,
                     elementId: e.target.id || null,
                     elementClass: e.target.className || null,
+                    elementHref: this.getElementHref(e.target),
                     selector: this.getSelector(e.target)
                 });
             }, 500);
@@ -185,6 +187,14 @@ class AgentTracker {
             return element.tagName.toLowerCase() + '.' + element.className.split(' ').join('.');
         }
         return element.tagName.toLowerCase();
+    }
+
+    getElementHref(element) {
+        if (!element || typeof element.closest !== 'function') {
+            return null;
+        }
+        const link = element.closest('a[href]');
+        return link ? (link.getAttribute('href') || null) : null;
     }
     
     getEvents() {

--- a/eval/mapquest/css/mapquest.css
+++ b/eval/mapquest/css/mapquest.css
@@ -1,0 +1,845 @@
+/* ============================================================
+   MapQuest — Google Maps-like Mock Site
+   ============================================================ */
+
+*, *::before, *::after {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+html, body {
+    height: 100%;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+    font-size: 14px;
+    color: #3c4043;
+    overflow: hidden;
+}
+
+/* ---------- App Layout ---------- */
+#app {
+    display: flex;
+    height: 100vh;
+    width: 100vw;
+    position: relative;
+}
+
+/* ---------- Left Panel ---------- */
+.panel {
+    position: relative;
+    width: 380px;
+    min-width: 0;
+    height: 100vh;
+    background: #fff;
+    box-shadow: 2px 0 6px rgba(0,0,0,0.12);
+    z-index: 10;
+    display: flex;
+    flex-direction: column;
+    transition: width 0.3s ease, min-width 0.3s ease, opacity 0.3s ease;
+    overflow: hidden;
+}
+
+.panel.collapsed {
+    width: 0;
+    min-width: 0;
+    opacity: 0;
+    pointer-events: none;
+}
+
+.panel.collapsed + .map-container {
+    width: 100%;
+}
+
+/* Panel Header (back arrow) */
+.panel-header {
+    display: flex;
+    align-items: center;
+    padding: 12px 16px;
+    border-bottom: 1px solid #e8eaed;
+    min-height: 48px;
+}
+
+.panel-header.hidden {
+    display: none;
+}
+
+.panel-back-btn {
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 4px;
+    border-radius: 50%;
+    color: #5f6368;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.panel-back-btn:hover {
+    background: #f1f3f4;
+}
+
+.panel-header-title {
+    margin-left: 12px;
+    font-size: 16px;
+    font-weight: 500;
+    color: #202124;
+}
+
+/* Panel States */
+.panel-state {
+    display: none;
+    flex: 1;
+    overflow-y: auto;
+    overflow-x: hidden;
+}
+
+.panel-state.active {
+    display: flex;
+    flex-direction: column;
+}
+
+/* ---------- Search ---------- */
+.search-container {
+    padding: 12px 16px;
+    position: relative;
+}
+
+.search-box {
+    display: flex;
+    align-items: center;
+    background: #f1f3f4;
+    border-radius: 24px;
+    padding: 8px 16px;
+    transition: background 0.2s, box-shadow 0.2s;
+}
+
+.search-box:focus-within {
+    background: #fff;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+}
+
+.search-icon {
+    flex-shrink: 0;
+    margin-right: 10px;
+}
+
+.search-input {
+    flex: 1;
+    border: none;
+    outline: none;
+    background: transparent;
+    font-size: 15px;
+    color: #202124;
+    font-family: inherit;
+}
+
+.search-input::placeholder {
+    color: #9aa0a6;
+}
+
+/* ---------- Autocomplete Dropdown ---------- */
+.autocomplete-dropdown {
+    position: absolute;
+    top: 100%;
+    left: 16px;
+    right: 16px;
+    background: #fff;
+    border-radius: 0 0 8px 8px;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+    z-index: 100;
+    max-height: 320px;
+    overflow-y: auto;
+}
+
+.autocomplete-dropdown.hidden {
+    display: none;
+}
+
+.autocomplete-item {
+    display: flex;
+    align-items: center;
+    padding: 10px 16px;
+    cursor: pointer;
+    gap: 12px;
+}
+
+.autocomplete-item:hover {
+    background: #f1f3f4;
+}
+
+.autocomplete-item-icon {
+    width: 24px;
+    height: 24px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #70757a;
+    flex-shrink: 0;
+}
+
+.autocomplete-item-text {
+    flex: 1;
+}
+
+.autocomplete-item-name {
+    font-size: 14px;
+    color: #202124;
+}
+
+.autocomplete-item-type {
+    font-size: 12px;
+    color: #70757a;
+}
+
+/* ---------- Chip Bar ---------- */
+.chip-bar-wrapper {
+    padding: 4px 0;
+    border-bottom: 1px solid #e8eaed;
+    overflow: hidden;
+}
+
+.chip-bar {
+    display: flex;
+    flex-wrap: nowrap;
+    gap: 8px;
+    padding: 8px 16px;
+    overflow-x: auto;
+    scrollbar-width: none;          /* Firefox */
+    -ms-overflow-style: none;       /* IE 10+ */
+}
+
+.chip-bar::-webkit-scrollbar {
+    display: none;                   /* Chrome/Safari */
+}
+
+.chip {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 14px;
+    border: 1px solid #dadce0;
+    border-radius: 20px;
+    background: #fff;
+    font-size: 13px;
+    color: #3c4043;
+    cursor: pointer;
+    white-space: nowrap;
+    flex-shrink: 0;
+    transition: background 0.15s, border-color 0.15s;
+    font-family: inherit;
+}
+
+.chip:hover {
+    background: #f1f3f4;
+}
+
+.chip.active {
+    background: #e8f0fe;
+    border-color: #1a73e8;
+    color: #1a73e8;
+}
+
+.chip-icon {
+    font-size: 14px;
+}
+
+/* ---------- Search Suggestions ---------- */
+.search-suggestions {
+    padding: 8px 0;
+}
+
+.suggestion-header {
+    padding: 12px 16px 6px;
+    font-size: 12px;
+    font-weight: 500;
+    color: #70757a;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.suggestion-item {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 16px;
+    cursor: pointer;
+}
+
+.suggestion-item:hover {
+    background: #f1f3f4;
+}
+
+.suggestion-icon {
+    font-size: 16px;
+}
+
+/* ---------- Search Results ---------- */
+.results-list {
+    flex: 1;
+    overflow-y: auto;
+}
+
+.result-item {
+    display: flex;
+    gap: 12px;
+    padding: 14px 16px;
+    border-bottom: 1px solid #e8eaed;
+    cursor: pointer;
+    transition: background 0.15s;
+}
+
+.result-item:hover {
+    background: #f8f9fa;
+}
+
+.result-item-icon {
+    width: 40px;
+    height: 40px;
+    background: #e8eaed;
+    border-radius: 4px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 20px;
+    flex-shrink: 0;
+}
+
+.result-item-info {
+    flex: 1;
+    min-width: 0;
+}
+
+.result-item-name {
+    font-size: 14px;
+    font-weight: 500;
+    color: #202124;
+    margin-bottom: 2px;
+}
+
+.result-item-meta {
+    font-size: 12px;
+    color: #70757a;
+}
+
+.result-item-rating {
+    color: #f4b400;
+    margin-right: 4px;
+}
+
+/* ---------- Place Detail ---------- */
+.place-detail-scroll {
+    flex: 1;
+    overflow-y: auto;
+}
+
+.place-photos {
+    display: flex;
+    gap: 2px;
+    height: 200px;
+}
+
+.photo-main {
+    flex: 2;
+    background: #dadce0;
+    min-width: 0;
+}
+
+.photo-grid {
+    flex: 1;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-template-rows: 1fr 1fr;
+    gap: 2px;
+    min-width: 0;
+}
+
+.photo-thumb {
+    background: #e8eaed;
+}
+
+.place-info {
+    padding: 16px;
+}
+
+.place-name {
+    font-size: 22px;
+    font-weight: 400;
+    color: #202124;
+    margin-bottom: 8px;
+    line-height: 1.3;
+}
+
+.place-rating {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    margin-bottom: 4px;
+}
+
+.rating-number {
+    font-size: 14px;
+    font-weight: 500;
+    color: #202124;
+}
+
+.rating-stars {
+    color: #f4b400;
+    font-size: 14px;
+    letter-spacing: 1px;
+}
+
+.review-count {
+    font-size: 14px;
+    color: #70757a;
+}
+
+.place-category {
+    font-size: 13px;
+    color: #70757a;
+    margin-bottom: 8px;
+}
+
+.place-hours {
+    font-size: 13px;
+    margin-bottom: 16px;
+}
+
+.hours-status {
+    font-weight: 500;
+}
+
+.hours-status.open {
+    color: #0d652d;
+}
+
+.hours-status.closed {
+    color: #c5221f;
+}
+
+.hours-detail {
+    color: #70757a;
+}
+
+/* Action Buttons */
+.place-actions {
+    display: flex;
+    gap: 8px;
+    margin-bottom: 20px;
+    flex-wrap: wrap;
+}
+
+.action-btn {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 16px;
+    border-radius: 20px;
+    border: 1px solid #dadce0;
+    background: #fff;
+    font-size: 13px;
+    color: #1a73e8;
+    cursor: pointer;
+    font-family: inherit;
+    transition: background 0.15s;
+}
+
+.action-btn:hover {
+    background: #f8f9fa;
+}
+
+.action-primary {
+    background: #1a73e8;
+    color: #fff;
+    border-color: #1a73e8;
+}
+
+.action-primary:hover {
+    background: #1765cc;
+}
+
+.action-primary svg {
+    stroke: #fff;
+}
+
+/* Place info rows */
+.place-address,
+.place-website,
+.place-phone {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+    padding: 10px 0;
+    border-top: 1px solid #e8eaed;
+    font-size: 13px;
+    color: #3c4043;
+}
+
+.place-address svg,
+.place-website svg,
+.place-phone svg {
+    flex-shrink: 0;
+    margin-top: 1px;
+}
+
+/* ---------- Directions ---------- */
+.directions-form {
+    padding: 0;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+}
+
+.transport-tabs {
+    display: flex;
+    border-bottom: 1px solid #e8eaed;
+    padding: 0 16px;
+}
+
+.transport-tab {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 12px 0;
+    background: none;
+    border: none;
+    border-bottom: 3px solid transparent;
+    color: #5f6368;
+    cursor: pointer;
+    transition: color 0.15s, border-color 0.15s;
+}
+
+.transport-tab:hover {
+    color: #202124;
+    background: #f1f3f4;
+}
+
+.transport-tab.active {
+    color: #1a73e8;
+    border-bottom-color: #1a73e8;
+}
+
+.directions-fields {
+    padding: 16px;
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.directions-field-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    position: relative;
+}
+
+.field-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+
+.origin-dot {
+    background: #4285f4;
+    border: 2px solid #1a73e8;
+}
+
+.dest-dot {
+    background: #ea4335;
+    border: 2px solid #c5221f;
+}
+
+.field-input-wrap {
+    flex: 1;
+    position: relative;
+}
+
+.directions-input {
+    width: 100%;
+    padding: 10px 12px;
+    border: 1px solid #dadce0;
+    border-radius: 8px;
+    font-size: 14px;
+    color: #202124;
+    outline: none;
+    font-family: inherit;
+    transition: border-color 0.15s;
+}
+
+.directions-input:focus {
+    border-color: #1a73e8;
+}
+
+.directions-input::placeholder {
+    color: #9aa0a6;
+}
+
+.swap-btn {
+    position: absolute;
+    right: 16px;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    border: 1px solid #dadce0;
+    background: #fff;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    color: #5f6368;
+    z-index: 2;
+    transition: background 0.15s;
+}
+
+.swap-btn:hover {
+    background: #f1f3f4;
+}
+
+/* Route Results */
+.route-results {
+    padding: 0 16px 16px;
+    flex: 1;
+    overflow-y: auto;
+}
+
+.route-results.hidden {
+    display: none;
+}
+
+.route-results-header {
+    font-size: 12px;
+    font-weight: 500;
+    color: #70757a;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    padding: 12px 0 8px;
+    border-top: 1px solid #e8eaed;
+}
+
+.route-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 12px;
+    border-radius: 8px;
+    cursor: pointer;
+    transition: background 0.15s;
+    margin-bottom: 4px;
+}
+
+.route-item:hover {
+    background: #f1f3f4;
+}
+
+.route-item.active {
+    background: #e8f0fe;
+}
+
+.route-time {
+    font-size: 16px;
+    font-weight: 500;
+    color: #202124;
+}
+
+.route-item.active .route-time {
+    color: #1a73e8;
+}
+
+.route-distance {
+    font-size: 13px;
+    color: #70757a;
+}
+
+.route-via {
+    font-size: 12px;
+    color: #70757a;
+}
+
+/* ---------- Panel Toggle ---------- */
+/* Lives as a sibling of .panel inside #app so it isn't clipped by the panel's
+   own overflow:hidden. Positioned at the panel's right edge via absolute
+   offsets into #app. */
+.panel-toggle {
+    position: absolute;
+    left: 380px;            /* panel width */
+    top: 50%;
+    transform: translateY(-50%);
+    width: 24px;
+    height: 56px;
+    background: #fff;
+    border: 1px solid #dadce0;
+    border-left: none;
+    border-radius: 0 8px 8px 0;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 11;
+    color: #5f6368;
+    padding: 0;
+    transition: left 0.3s ease, background 0.15s;
+}
+
+.panel-toggle:hover {
+    background: #f1f3f4;
+}
+
+/* When the panel is collapsed, slide the toggle to x=0 and flip its chevron. */
+#app:has(.panel.collapsed) .panel-toggle {
+    left: 0;
+}
+#app:has(.panel.collapsed) .panel-toggle svg {
+    transform: rotate(180deg);
+}
+
+/* ---------- Map Container ---------- */
+.map-container {
+    flex: 1;
+    position: relative;
+    background: #e8f4f0;
+    overflow: hidden;
+    transition: width 0.3s ease;
+}
+
+.map-svg {
+    width: 100%;
+    height: 100%;
+}
+
+/* Roads */
+.road {
+    stroke: #fff;
+    stroke-width: 3;
+    stroke-linecap: round;
+}
+
+.major-road {
+    stroke: #fffde7;
+    stroke-width: 5;
+}
+
+.diagonal-road {
+    stroke-width: 3;
+}
+
+/* Pins */
+.map-pin {
+    cursor: pointer;
+    transition: transform 0.15s;
+    filter: url(#pin-shadow);
+    /* Scale around the pin's own centre, not the SVG origin. Without this,
+       hover scale drifts the pin away from the cursor and causes a rapid
+       enter/leave shake loop. */
+    transform-box: fill-box;
+    transform-origin: center;
+}
+
+.map-pin:hover {
+    transform: scale(1.2);
+}
+
+.pin-regular {
+    fill: #ea4335;
+    stroke: #b31412;
+    stroke-width: 1.5;
+}
+
+.pin-parking {
+    fill: #4285f4;
+    stroke: #1a5dc4;
+    stroke-width: 1.5;
+}
+
+.pin-coffee {
+    fill: #ea4335;
+    stroke: #b31412;
+    stroke-width: 1.5;
+}
+
+.pin-shopping {
+    fill: #ea4335;
+    stroke: #b31412;
+    stroke-width: 1.5;
+}
+
+.pin-ad {
+    fill: #f4b400;
+    stroke: #d89f00;
+    stroke-width: 1.5;
+}
+
+/* Tooltip */
+.pin-tooltip text {
+    pointer-events: none;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+
+/* Route paths */
+.route-path {
+    pointer-events: none;
+    transition: opacity 0.3s;
+}
+
+/* ---------- Map Controls ---------- */
+.map-controls-zoom {
+    position: absolute;
+    bottom: 100px;
+    right: 16px;
+    display: flex;
+    flex-direction: column;
+    box-shadow: 0 1px 4px rgba(0,0,0,0.2);
+    border-radius: 8px;
+    overflow: hidden;
+}
+
+.map-controls-compass {
+    position: absolute;
+    top: 16px;
+    right: 16px;
+    box-shadow: 0 1px 4px rgba(0,0,0,0.2);
+    border-radius: 8px;
+    overflow: hidden;
+}
+
+.map-ctrl-btn {
+    width: 40px;
+    height: 40px;
+    background: #fff;
+    border: none;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 20px;
+    color: #5f6368;
+    transition: background 0.15s;
+    font-family: inherit;
+}
+
+.map-ctrl-btn:hover {
+    background: #f1f3f4;
+}
+
+.map-ctrl-btn + .map-ctrl-btn {
+    border-top: 1px solid #e8eaed;
+}
+
+.compass-btn {
+    padding: 8px;
+}
+
+/* ---------- Responsive ---------- */
+@media (max-width: 700px) {
+    .panel {
+        width: 100%;
+        position: absolute;
+        top: 0;
+        left: 0;
+        z-index: 20;
+    }
+}

--- a/eval/mapquest/index.html
+++ b/eval/mapquest/index.html
@@ -1,0 +1,306 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>MapQuest — Maps, Directions, Traffic</title>
+    <link rel="stylesheet" href="/mapquest/css/mapquest.css">
+</head>
+<body>
+    <div id="app">
+        <!-- Left Panel -->
+        <div id="left-panel" class="panel open">
+            <!-- Panel Header with Back Arrow -->
+            <div id="panel-header" class="panel-header hidden">
+                <button id="panel-back-btn" class="panel-back-btn" aria-label="Back">
+                    <svg width="20" height="20" viewBox="0 0 20 20"><path d="M13 4l-6 6 6 6" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                </button>
+                <span id="panel-header-title" class="panel-header-title"></span>
+            </div>
+
+            <!-- Search State -->
+            <div id="state-search" class="panel-state active">
+                <div class="search-container">
+                    <div class="search-box" id="search-box">
+                        <svg class="search-icon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#70757a" stroke-width="2">
+                            <circle cx="11" cy="11" r="8"></circle>
+                            <path d="m21 21-4.35-4.35"></path>
+                        </svg>
+                        <input type="text" id="search-input" class="search-input" placeholder="Search Google Maps" autocomplete="off">
+                    </div>
+                    <div id="autocomplete-dropdown" class="autocomplete-dropdown hidden"></div>
+                </div>
+                <!-- Nearby Category Chips -->
+                <div class="chip-bar-wrapper">
+                    <div class="chip-bar">
+                        <button class="chip" data-category="restaurants">
+                            <span class="chip-icon">🍽️</span> Restaurants
+                        </button>
+                        <button class="chip" data-category="gas">
+                            <span class="chip-icon">⛽</span> Gas stations
+                        </button>
+                        <button class="chip" data-category="coffee">
+                            <span class="chip-icon">☕</span> Coffee
+                        </button>
+                        <button class="chip" data-category="hotels">
+                            <span class="chip-icon">🏨</span> Hotels
+                        </button>
+                        <button class="chip" data-category="parking">
+                            <span class="chip-icon">🅿️</span> Parking
+                        </button>
+                        <button class="chip" data-category="groceries">
+                            <span class="chip-icon">🛒</span> Groceries
+                        </button>
+                        <button class="chip" data-category="attractions">
+                            <span class="chip-icon">🎭</span> Attractions
+                        </button>
+                        <button class="chip" data-category="pharmacies">
+                            <span class="chip-icon">💊</span> Pharmacies
+                        </button>
+                    </div>
+                </div>
+                <div class="search-suggestions">
+                    <div class="suggestion-header">Explore nearby</div>
+                    <div class="suggestion-item" data-place-id="pike-place-market">
+                        <span class="suggestion-icon">📍</span>
+                        <span>Pike Place Market</span>
+                    </div>
+                    <div class="suggestion-item" data-place-id="space-needle">
+                        <span class="suggestion-icon">📍</span>
+                        <span>Space Needle</span>
+                    </div>
+                    <div class="suggestion-item" data-place-id="starbucks-roastery">
+                        <span class="suggestion-icon">☕</span>
+                        <span>Starbucks Reserve Roastery</span>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Search Results State -->
+            <div id="state-results" class="panel-state">
+                <div class="search-container">
+                    <div class="search-box" id="results-search-box">
+                        <svg class="search-icon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#70757a" stroke-width="2">
+                            <circle cx="11" cy="11" r="8"></circle>
+                            <path d="m21 21-4.35-4.35"></path>
+                        </svg>
+                        <input type="text" id="results-search-input" class="search-input" placeholder="Search Google Maps" autocomplete="off">
+                    </div>
+                </div>
+                <div id="results-list" class="results-list"></div>
+            </div>
+
+            <!-- Place Detail State -->
+            <div id="state-place-detail" class="panel-state">
+                <!-- Nearby Category Chips (also visible here so users can explore after selecting a place) -->
+                <div class="chip-bar-wrapper">
+                    <div class="chip-bar">
+                        <button class="chip" data-category="restaurants">
+                            <span class="chip-icon">🍽️</span> Restaurants
+                        </button>
+                        <button class="chip" data-category="gas">
+                            <span class="chip-icon">⛽</span> Gas stations
+                        </button>
+                        <button class="chip" data-category="coffee">
+                            <span class="chip-icon">☕</span> Coffee
+                        </button>
+                        <button class="chip" data-category="hotels">
+                            <span class="chip-icon">🏨</span> Hotels
+                        </button>
+                        <button class="chip" data-category="parking">
+                            <span class="chip-icon">🅿️</span> Parking
+                        </button>
+                        <button class="chip" data-category="groceries">
+                            <span class="chip-icon">🛒</span> Groceries
+                        </button>
+                        <button class="chip" data-category="attractions">
+                            <span class="chip-icon">🎭</span> Attractions
+                        </button>
+                        <button class="chip" data-category="pharmacies">
+                            <span class="chip-icon">💊</span> Pharmacies
+                        </button>
+                    </div>
+                </div>
+                <div class="place-detail-scroll">
+                    <!-- Photo placeholders -->
+                    <div class="place-photos">
+                        <div class="photo-main"></div>
+                        <div class="photo-grid">
+                            <div class="photo-thumb"></div>
+                            <div class="photo-thumb"></div>
+                            <div class="photo-thumb"></div>
+                            <div class="photo-thumb"></div>
+                        </div>
+                    </div>
+                    <div class="place-info">
+                        <h1 id="place-name" class="place-name"></h1>
+                        <div class="place-rating">
+                            <span id="place-rating-number" class="rating-number"></span>
+                            <span id="place-stars" class="rating-stars"></span>
+                            <span id="place-review-count" class="review-count"></span>
+                        </div>
+                        <div class="place-category" id="place-category"></div>
+                        <div class="place-hours" id="place-hours">
+                            <span class="hours-status open">Open now</span>
+                            <span class="hours-detail"> · Closes 9 PM</span>
+                        </div>
+                        <div class="place-actions">
+                            <button id="directions-btn" class="action-btn action-primary">
+                                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 11l19-9-9 19-2-8-8-2z"/></svg>
+                                Directions
+                            </button>
+                            <button class="action-btn" id="save-btn">
+                                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M19 21l-7-5-7 5V5a2 2 0 012-2h10a2 2 0 012 2z"/></svg>
+                                Save
+                            </button>
+                            <button class="action-btn" id="share-btn">
+                                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><path d="M8.59 13.51l6.83 3.98M15.41 6.51l-6.82 3.98"/></svg>
+                                Share
+                            </button>
+                        </div>
+                        <div class="place-address" id="place-address">
+                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#70757a" stroke-width="2"><path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0118 0z"/><circle cx="12" cy="10" r="3"/></svg>
+                            <span id="place-address-text"></span>
+                        </div>
+                        <div class="place-website" id="place-website">
+                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#70757a" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M2 12h20M12 2a15.3 15.3 0 014 10 15.3 15.3 0 01-4 10 15.3 15.3 0 01-4-10 15.3 15.3 0 014-10z"/></svg>
+                            <span id="place-website-text"></span>
+                        </div>
+                        <div class="place-phone" id="place-phone">
+                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#70757a" stroke-width="2"><path d="M22 16.92v3a2 2 0 01-2.18 2 19.79 19.79 0 01-8.63-3.07 19.5 19.5 0 01-6-6 19.79 19.79 0 01-3.07-8.67A2 2 0 014.11 2h3a2 2 0 012 1.72c.127.96.362 1.903.7 2.81a2 2 0 01-.45 2.11L8.09 9.91a16 16 0 006 6l1.27-1.27a2 2 0 012.11-.45c.907.338 1.85.573 2.81.7A2 2 0 0122 16.92z"/></svg>
+                            <span id="place-phone-text"></span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Directions State -->
+            <div id="state-directions" class="panel-state">
+                <div class="directions-form">
+                    <!-- Transport Mode Tabs -->
+                    <div class="transport-tabs" id="transport-tabs">
+                        <button class="transport-tab active" data-mode="drive" aria-label="Driving">
+                            <svg width="22" height="22" viewBox="0 0 24 24" fill="currentColor"><path d="M18.92 6.01C18.72 5.42 18.16 5 17.5 5h-11c-.66 0-1.21.42-1.42 1.01L3 12v8c0 .55.45 1 1 1h1c.55 0 1-.45 1-1v-1h12v1c0 .55.45 1 1 1h1c.55 0 1-.45 1-1v-8l-2.08-5.99zM6.5 16c-.83 0-1.5-.67-1.5-1.5S5.67 13 6.5 13s1.5.67 1.5 1.5S7.33 16 6.5 16zm11 0c-.83 0-1.5-.67-1.5-1.5s.67-1.5 1.5-1.5 1.5.67 1.5 1.5-.67 1.5-1.5 1.5zM5 11l1.5-4.5h11L19 11H5z"/></svg>
+                        </button>
+                        <button class="transport-tab" data-mode="transit" aria-label="Transit">
+                            <svg width="22" height="22" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2c-4 0-8 .5-8 4v9.5C4 17.43 5.57 19 7.5 19L6 20.5v.5h2l2-2h4l2 2h2v-.5L16.5 19c1.93 0 3.5-1.57 3.5-3.5V6c0-3.5-4-4-8-4zM7.5 17c-.83 0-1.5-.67-1.5-1.5S6.67 14 7.5 14s1.5.67 1.5 1.5S8.33 17 7.5 17zm9 0c-.83 0-1.5-.67-1.5-1.5s.67-1.5 1.5-1.5 1.5.67 1.5 1.5-.67 1.5-1.5 1.5zm1.5-6H6V6h12v5z"/></svg>
+                        </button>
+                        <button class="transport-tab" data-mode="walk" aria-label="Walking">
+                            <svg width="22" height="22" viewBox="0 0 24 24" fill="currentColor"><path d="M13.5 5.5c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zM9.8 8.9L7 23h2.1l1.8-8 2.1 2v6h2v-7.5l-2.1-2 .6-3C14.8 12 16.8 13 19 13v-2c-1.9 0-3.5-1-4.3-2.4l-1-1.6c-.4-.6-1-1-1.7-1-.3 0-.5.1-.8.1L6 8.3V13h2V9.6l1.8-.7z"/></svg>
+                        </button>
+                        <button class="transport-tab" data-mode="bike" aria-label="Cycling">
+                            <svg width="22" height="22" viewBox="0 0 24 24" fill="currentColor"><path d="M15.5 5.5c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zM5 12c-2.8 0-5 2.2-5 5s2.2 5 5 5 5-2.2 5-5-2.2-5-5-5zm0 8.5c-1.93 0-3.5-1.57-3.5-3.5s1.57-3.5 3.5-3.5 3.5 1.57 3.5 3.5-1.57 3.5-3.5 3.5zm5.8-10l2.4-2.4.8.8c1.3 1.3 3 2.1 5 2.1V9c-1.5 0-2.7-.6-3.6-1.5l-1.9-1.9c-.5-.4-1-.6-1.6-.6s-1.1.2-1.4.6L7.8 8.4c-.4.4-.6.9-.6 1.4 0 .6.2 1.1.6 1.4L11 14v5h2v-6.2l-2.2-2.3zM19 12c-2.8 0-5 2.2-5 5s2.2 5 5 5 5-2.2 5-5-2.2-5-5-5zm0 8.5c-1.93 0-3.5-1.57-3.5-3.5s1.57-3.5 3.5-3.5 3.5 1.57 3.5 3.5-1.57 3.5-3.5 3.5z"/></svg>
+                        </button>
+                    </div>
+                    <!-- Origin / Destination Fields -->
+                    <div class="directions-fields">
+                        <div class="directions-field-row">
+                            <span class="field-dot origin-dot"></span>
+                            <div class="field-input-wrap">
+                                <input type="text" id="directions-origin" class="directions-input" placeholder="Choose starting point, or click on the map" autocomplete="off">
+                                <div id="origin-autocomplete" class="autocomplete-dropdown hidden"></div>
+                            </div>
+                        </div>
+                        <button id="swap-btn" class="swap-btn" aria-label="Swap origin and destination">
+                            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M7 16V4m0 12l-3-3m3 3l3-3M17 8v12m0-12l3 3m-3-3l-3 3"/></svg>
+                        </button>
+                        <div class="directions-field-row">
+                            <span class="field-dot dest-dot"></span>
+                            <div class="field-input-wrap">
+                                <input type="text" id="directions-destination" class="directions-input" placeholder="Choose destination" autocomplete="off">
+                                <div id="dest-autocomplete" class="autocomplete-dropdown hidden"></div>
+                            </div>
+                        </div>
+                    </div>
+                    <!-- Route Results -->
+                    <div id="route-results" class="route-results hidden">
+                        <div class="route-results-header">Suggested routes</div>
+                        <div id="route-list" class="route-list"></div>
+                    </div>
+                </div>
+            </div>
+
+        </div>
+
+        <!-- Panel Collapse Toggle (sibling of panel so it isn't clipped by panel overflow) -->
+        <button id="panel-toggle" class="panel-toggle" aria-label="Collapse panel">
+            <svg width="12" height="20" viewBox="0 0 12 20"><path d="M10 2L2 10l8 8" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        </button>
+
+        <!-- Map Canvas -->
+        <div id="map-container" class="map-container">
+            <svg id="map-svg" class="map-svg" viewBox="0 0 400 450" preserveAspectRatio="xMidYMid meet">
+                <!-- Water / background -->
+                <rect width="400" height="450" fill="#e8f4f8"/>
+
+                <!-- Land mass -->
+                <rect x="40" y="20" width="350" height="420" fill="#f0f0f0" rx="4"/>
+
+                <!-- Major Roads — simplified Seattle downtown grid -->
+                <!-- East-West roads -->
+                <line x1="50" y1="100" x2="380" y2="100" class="road major-road"/>
+                <line x1="50" y1="150" x2="380" y2="150" class="road"/>
+                <line x1="50" y1="200" x2="380" y2="200" class="road major-road"/>
+                <line x1="50" y1="250" x2="380" y2="250" class="road"/>
+                <line x1="50" y1="300" x2="380" y2="300" class="road major-road"/>
+                <line x1="50" y1="350" x2="380" y2="350" class="road"/>
+                <line x1="50" y1="400" x2="380" y2="400" class="road"/>
+
+                <!-- North-South roads -->
+                <line x1="100" y1="30" x2="100" y2="440" class="road"/>
+                <line x1="150" y1="30" x2="150" y2="440" class="road major-road"/>
+                <line x1="200" y1="30" x2="200" y2="440" class="road"/>
+                <line x1="250" y1="30" x2="250" y2="440" class="road major-road"/>
+                <line x1="300" y1="30" x2="300" y2="440" class="road"/>
+                <line x1="350" y1="30" x2="350" y2="440" class="road"/>
+
+                <!-- Diagonal road (like Yesler Way) -->
+                <line x1="60" y1="280" x2="300" y2="350" class="road diagonal-road"/>
+
+                <!-- Water (Elliott Bay approximation) -->
+                <path d="M40 20 Q30 200 40 440 L40 440 L40 20Z" fill="#b3d9f2" opacity="0.6"/>
+
+                <!-- Route lines (hidden by default) -->
+                <g id="route-lines" class="route-lines">
+                    <path id="route-0" class="route-path" d="" stroke="#4285f4" stroke-width="5" fill="none" opacity="0" stroke-linecap="round" stroke-linejoin="round"/>
+                    <path id="route-1" class="route-path" d="" stroke="#9aa0a6" stroke-width="4" fill="none" opacity="0" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="8,6"/>
+                    <path id="route-2" class="route-path" d="" stroke="#9aa0a6" stroke-width="4" fill="none" opacity="0" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="4,8"/>
+                </g>
+
+                <!-- Map Pins Group -->
+                <g id="map-pins"></g>
+
+                <!-- Tooltip -->
+                <g id="pin-tooltip" class="pin-tooltip" style="display:none;">
+                    <rect id="tooltip-bg" x="0" y="0" width="160" height="28" rx="4" fill="white" stroke="#dadce0" stroke-width="1" filter="url(#shadow)"/>
+                    <text id="tooltip-text" x="8" y="18" font-size="12" fill="#3c4043"></text>
+                </g>
+
+                <!-- SVG Filter for shadow -->
+                <defs>
+                    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+                        <feDropShadow dx="0" dy="1" stdDeviation="2" flood-opacity="0.25"/>
+                    </filter>
+                    <filter id="pin-shadow" x="-50%" y="-50%" width="200%" height="200%">
+                        <feDropShadow dx="0" dy="1" stdDeviation="1" flood-opacity="0.3"/>
+                    </filter>
+                </defs>
+            </svg>
+
+            <!-- Map Controls -->
+            <div class="map-controls-zoom">
+                <button id="zoom-in" class="map-ctrl-btn" aria-label="Zoom in">+</button>
+                <button id="zoom-out" class="map-ctrl-btn" aria-label="Zoom out">−</button>
+            </div>
+            <div class="map-controls-compass">
+                <button class="map-ctrl-btn compass-btn" aria-label="Reset north">
+                    <svg width="20" height="20" viewBox="0 0 20 20"><polygon points="10,2 13,10 10,8 7,10" fill="#ea4335"/><polygon points="10,18 7,10 10,12 13,10" fill="#c5c5c5"/></svg>
+                </button>
+            </div>
+        </div>
+    </div>
+
+    <script src="/js/tracker.js"></script>
+    <script src="/mapquest/js/mapquest.js"></script>
+</body>
+</html>

--- a/eval/mapquest/js/mapquest.js
+++ b/eval/mapquest/js/mapquest.js
@@ -1,0 +1,769 @@
+/* ==========================================================
+   MapQuest — Google Maps-like Mock Site  (mapquest.js)
+   ========================================================== */
+
+// ── Tracker ──────────────────────────────────────────────────
+window.tracker = new AgentTracker('mapquest.com', 'hard');
+
+// ── Place Data ───────────────────────────────────────────────
+const PLACES = [
+    {
+        id: 'pike-place-market',
+        name: 'Pike Place Market',
+        coords: [180, 250],
+        type: 'attraction',
+        address: '85 Pike St, Seattle, WA 98101',
+        rating: 4.6,
+        reviews: 82417,
+        hours: { open: true, close: '6 PM' },
+        phone: '(206) 682-7453',
+        website: 'pikeplacemarket.org',
+        category: 'Public market'
+    },
+    {
+        id: 'space-needle',
+        name: 'Space Needle',
+        coords: [120, 140],
+        type: 'attraction',
+        address: '400 Broad St, Seattle, WA 98109',
+        rating: 4.5,
+        reviews: 34812,
+        hours: { open: true, close: '10 PM' },
+        phone: '(206) 905-2100',
+        website: 'spaceneedle.com',
+        category: 'Observation tower'
+    },
+    {
+        id: 'pike-place-parking-garage',
+        name: 'Pike Place Market Parking Garage',
+        coords: [185, 245],
+        type: 'parking',
+        address: '1531 Western Ave, Seattle, WA 98101',
+        rating: 3.8,
+        reviews: 412,
+        hours: { open: true, close: '1 AM' },
+        phone: '(206) 622-0570',
+        website: '',
+        category: 'Parking garage'
+    },
+    {
+        id: 'pacific-place-parking',
+        name: 'Pacific Place Parking',
+        coords: [190, 248],
+        type: 'parking',
+        address: '600 Pine St, Seattle, WA 98101',
+        rating: 3.5,
+        reviews: 287,
+        hours: { open: true, close: '12 AM' },
+        phone: '(206) 405-2655',
+        website: '',
+        category: 'Parking garage'
+    },
+    {
+        id: 'seattle-center',
+        name: 'Seattle Center',
+        coords: [115, 135],
+        type: 'attraction',
+        address: '305 Harrison St, Seattle, WA 98109',
+        rating: 4.4,
+        reviews: 12930,
+        hours: { open: true, close: '9 PM' },
+        phone: '(206) 684-7200',
+        website: 'seattlecenter.com',
+        category: 'Cultural center'
+    },
+    {
+        id: 'starbucks-roastery',
+        name: 'Starbucks Reserve Roastery',
+        coords: [210, 200],
+        type: 'coffee',
+        address: '1124 Pike St, Seattle, WA 98101',
+        rating: 4.4,
+        reviews: 18245,
+        hours: { open: true, close: '9 PM' },
+        phone: '(206) 624-0173',
+        website: 'starbucksreserve.com',
+        category: 'Coffee roastery'
+    },
+    {
+        id: 'pioneer-square',
+        name: 'Pioneer Square',
+        coords: [195, 310],
+        type: 'attraction',
+        address: 'Pioneer Square, Seattle, WA 98104',
+        rating: 4.2,
+        reviews: 7641,
+        hours: { open: true, close: '11 PM' },
+        phone: '',
+        website: 'pioneersquare.org',
+        category: 'Historic district'
+    },
+    {
+        id: 'westlake-center',
+        name: 'Westlake Center',
+        coords: [200, 220],
+        type: 'shopping',
+        address: '400 Pine St, Seattle, WA 98101',
+        rating: 4.0,
+        reviews: 4521,
+        hours: { open: true, close: '8 PM' },
+        phone: '(206) 467-1600',
+        website: 'westlakecenter.com',
+        category: 'Shopping mall'
+    }
+];
+
+const AD_PLACES = [
+    {
+        id: 'ad-seattle-tours',
+        name: 'Sponsored: Seattle Tours',
+        coords: [160, 190],
+        type: 'ad',
+        address: '1234 Tourist Way, Seattle, WA 98101',
+        rating: 4.1,
+        reviews: 523,
+        hours: { open: true, close: '7 PM' },
+        phone: '(206) 555-0199',
+        website: 'seattletours.example.com',
+        category: 'Tour operator · Ad',
+        adDescription: 'Book award-winning Seattle city tours! Daily departures, waterfront views, local guides.'
+    },
+    {
+        id: 'ad-best-western',
+        name: 'Sponsored: Best Western',
+        coords: [220, 270],
+        type: 'ad',
+        address: '200 Sixth Ave N, Seattle, WA 98109',
+        rating: 3.9,
+        reviews: 1892,
+        hours: { open: true, close: '24 hours' },
+        phone: '(206) 555-0177',
+        website: 'bestwestern.example.com',
+        category: 'Hotel · Ad',
+        adDescription: 'Comfortable stays in the heart of Seattle. Free parking & breakfast included.'
+    }
+];
+
+const ALL_PLACES = [...PLACES, ...AD_PLACES];
+
+// ── State ────────────────────────────────────────────────────
+let panelHistory = ['search'];   // stack of states
+let currentState = 'search';
+let currentPlaceId = null;
+let activeChip = null;
+let activeTransportMode = 'drive';
+let activeRouteIndex = null;
+let debounceTimer = null;
+
+// ── DOM References ───────────────────────────────────────────
+const panel = document.getElementById('left-panel');
+const panelHeader = document.getElementById('panel-header');
+const panelHeaderTitle = document.getElementById('panel-header-title');
+const panelBackBtn = document.getElementById('panel-back-btn');
+const panelToggle = document.getElementById('panel-toggle');
+
+const stateSearch = document.getElementById('state-search');
+const stateResults = document.getElementById('state-results');
+const statePlaceDetail = document.getElementById('state-place-detail');
+const stateDirections = document.getElementById('state-directions');
+
+const searchInput = document.getElementById('search-input');
+const resultsSearchInput = document.getElementById('results-search-input');
+const autocompleteDropdown = document.getElementById('autocomplete-dropdown');
+
+const chipBars = document.querySelectorAll('.chip-bar');
+
+const mapPinsGroup = document.getElementById('map-pins');
+const pinTooltipGroup = document.getElementById('pin-tooltip');
+const tooltipBg = document.getElementById('tooltip-bg');
+const tooltipText = document.getElementById('tooltip-text');
+
+// Directions
+const directionsOrigin = document.getElementById('directions-origin');
+const directionsDestination = document.getElementById('directions-destination');
+const originAutocomplete = document.getElementById('origin-autocomplete');
+const destAutocomplete = document.getElementById('dest-autocomplete');
+const swapBtn = document.getElementById('swap-btn');
+const routeResults = document.getElementById('route-results');
+const routeList = document.getElementById('route-list');
+const transportTabs = document.getElementById('transport-tabs');
+
+// ── Utility ──────────────────────────────────────────────────
+function getPlaceById(id) {
+    return ALL_PLACES.find(p => p.id === id) || null;
+}
+
+function starsHtml(rating) {
+    const full = Math.floor(rating);
+    const half = rating - full >= 0.3 && rating - full < 0.8;
+    const empty = 5 - full - (half ? 1 : 0);
+    return '★'.repeat(full) + (half ? '½' : '') + '☆'.repeat(empty);
+}
+
+function typeIcon(type) {
+    const map = {
+        attraction: '🏛️',
+        parking: '🅿️',
+        coffee: '☕',
+        shopping: '🛍️',
+        ad: '📢'
+    };
+    return map[type] || '📍';
+}
+
+// ── Panel State Machine ──────────────────────────────────────
+function switchPanelState(state, placeId) {
+    // Deactivate all
+    [stateSearch, stateResults, statePlaceDetail, stateDirections].forEach(el => el.classList.remove('active'));
+
+    currentState = state;
+    currentPlaceId = placeId || null;
+
+    tracker.track('panel_state_change', { state, placeId: placeId || null });
+
+    if (state === 'search') {
+        stateSearch.classList.add('active');
+        panelHeader.classList.add('hidden');
+    } else if (state === 'results') {
+        stateResults.classList.add('active');
+        panelHeader.classList.remove('hidden');
+        panelHeaderTitle.textContent = 'Search results';
+    } else if (state === 'place-detail') {
+        statePlaceDetail.classList.add('active');
+        panelHeader.classList.remove('hidden');
+        panelHeaderTitle.textContent = '';
+        if (placeId) renderPlaceDetail(placeId);
+    } else if (state === 'directions') {
+        stateDirections.classList.add('active');
+        panelHeader.classList.remove('hidden');
+        panelHeaderTitle.textContent = '';
+    }
+}
+
+function pushState(state, placeId) {
+    panelHistory.push(state);
+    switchPanelState(state, placeId);
+}
+
+function popState() {
+    if (panelHistory.length > 1) {
+        panelHistory.pop();
+        const prev = panelHistory[panelHistory.length - 1];
+        switchPanelState(prev);
+    }
+}
+
+panelBackBtn.addEventListener('click', () => {
+    popState();
+    // Clear route drawings
+    clearRoutes();
+});
+
+// ── Place Detail Renderer ────────────────────────────────────
+function renderPlaceDetail(placeId) {
+    const place = getPlaceById(placeId);
+    if (!place) return;
+
+    document.getElementById('place-name').textContent = place.name;
+    document.getElementById('place-rating-number').textContent = place.rating.toFixed(1);
+    document.getElementById('place-stars').textContent = starsHtml(place.rating);
+    document.getElementById('place-review-count').textContent = `(${place.reviews.toLocaleString()} reviews)`;
+    document.getElementById('place-category').textContent = place.category;
+    document.getElementById('place-address-text').textContent = place.address;
+    document.getElementById('place-website-text').textContent = place.website || 'N/A';
+    document.getElementById('place-phone-text').textContent = place.phone || 'N/A';
+
+    const hoursEl = document.getElementById('place-hours');
+    if (place.hours.open) {
+        hoursEl.innerHTML = `<span class="hours-status open">Open now</span><span class="hours-detail"> · Closes ${place.hours.close}</span>`;
+    } else {
+        hoursEl.innerHTML = `<span class="hours-status closed">Closed</span>`;
+    }
+
+    // Sponsored badge
+    if (place.type === 'ad') {
+        document.getElementById('place-category').textContent = place.category;
+    }
+}
+
+// ── Directions Button ────────────────────────────────────────
+document.getElementById('directions-btn').addEventListener('click', () => {
+    const place = getPlaceById(currentPlaceId);
+    if (place) {
+        directionsDestination.value = place.name;
+    }
+    directionsOrigin.value = '';
+    routeResults.classList.add('hidden');
+    clearRoutes();
+    pushState('directions', currentPlaceId);
+});
+
+// ── Save / Share buttons ─────────────────────────────────────
+document.getElementById('save-btn').addEventListener('click', () => {
+    tracker.track('place_save', { placeId: currentPlaceId });
+});
+
+document.getElementById('share-btn').addEventListener('click', () => {
+    tracker.track('place_share', { placeId: currentPlaceId });
+});
+
+// ── Search Autocomplete ──────────────────────────────────────
+function showAutocomplete(query, dropdown, fieldName) {
+    if (!query.trim()) {
+        dropdown.classList.add('hidden');
+        return;
+    }
+    const lower = query.toLowerCase();
+    const matches = ALL_PLACES.filter(p => p.name.toLowerCase().includes(lower));
+
+    if (matches.length === 0) {
+        dropdown.classList.add('hidden');
+        return;
+    }
+
+    dropdown.innerHTML = matches.map(p => `
+        <div class="autocomplete-item" data-place-id="${p.id}" data-field="${fieldName}">
+            <div class="autocomplete-item-icon">${typeIcon(p.type)}</div>
+            <div class="autocomplete-item-text">
+                <div class="autocomplete-item-name">${p.name}</div>
+                <div class="autocomplete-item-type">${p.category}</div>
+            </div>
+        </div>
+    `).join('');
+    dropdown.classList.remove('hidden');
+
+    tracker.track('autocomplete_show', {});
+}
+
+function handleAutocompleteClick(e) {
+    const item = e.target.closest('.autocomplete-item');
+    if (!item) return;
+    const placeId = item.dataset.placeId;
+    const field = item.dataset.field;
+    const place = getPlaceById(placeId);
+    if (!place) return;
+
+    const itemText = place.name;
+
+    tracker.track('autocomplete_select', { itemText, field });
+
+    if (field === 'search') {
+        searchInput.value = itemText;
+        autocompleteDropdown.classList.add('hidden');
+        pushState('place-detail', placeId);
+        highlightPin(placeId);
+    } else if (field === 'origin') {
+        directionsOrigin.value = itemText;
+        originAutocomplete.classList.add('hidden');
+        tryShowRoutes();
+    } else if (field === 'destination') {
+        directionsDestination.value = itemText;
+        destAutocomplete.classList.add('hidden');
+        tryShowRoutes();
+    }
+}
+
+autocompleteDropdown.addEventListener('click', handleAutocompleteClick);
+originAutocomplete.addEventListener('click', handleAutocompleteClick);
+destAutocomplete.addEventListener('click', handleAutocompleteClick);
+
+// Debounced input for search
+searchInput.addEventListener('input', () => {
+    clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(() => {
+        showAutocomplete(searchInput.value, autocompleteDropdown, 'search');
+    }, 300);
+});
+
+// Enter key on search
+searchInput.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') {
+        e.preventDefault();
+        const query = searchInput.value.trim();
+        if (!query) return;
+        autocompleteDropdown.classList.add('hidden');
+        tracker.track('search_enter', { query });
+        renderSearchResults(query);
+        pushState('results');
+    }
+});
+
+// Directions origin autocomplete
+directionsOrigin.addEventListener('input', () => {
+    clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(() => {
+        showAutocomplete(directionsOrigin.value, originAutocomplete, 'origin');
+    }, 300);
+});
+
+// Directions destination autocomplete
+directionsDestination.addEventListener('input', () => {
+    clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(() => {
+        showAutocomplete(directionsDestination.value, destAutocomplete, 'destination');
+    }, 300);
+});
+
+// Close dropdowns on outside click
+document.addEventListener('click', (e) => {
+    if (!e.target.closest('.search-container') && !e.target.closest('.field-input-wrap')) {
+        autocompleteDropdown.classList.add('hidden');
+        originAutocomplete.classList.add('hidden');
+        destAutocomplete.classList.add('hidden');
+    }
+});
+
+// ── Search Results ───────────────────────────────────────────
+function renderSearchResults(query) {
+    const lower = query.toLowerCase();
+    const matches = ALL_PLACES.filter(p => p.name.toLowerCase().includes(lower));
+    const resultsList = document.getElementById('results-list');
+    resultsSearchInput.value = query;
+
+    if (matches.length === 0) {
+        resultsList.innerHTML = '<div style="padding:24px 16px;color:#70757a;">No results found</div>';
+        return;
+    }
+
+    resultsList.innerHTML = matches.map(p => `
+        <div class="result-item" data-place-id="${p.id}">
+            <div class="result-item-icon">${typeIcon(p.type)}</div>
+            <div class="result-item-info">
+                <div class="result-item-name">${p.name}</div>
+                <div class="result-item-meta">
+                    <span class="result-item-rating">${starsHtml(p.rating)}</span>
+                    ${p.rating.toFixed(1)} (${p.reviews.toLocaleString()}) · ${p.category}
+                </div>
+                <div class="result-item-meta">${p.address}</div>
+            </div>
+        </div>
+    `).join('');
+
+    // Click handler for results
+    resultsList.querySelectorAll('.result-item').forEach(item => {
+        item.addEventListener('click', () => {
+            const placeId = item.dataset.placeId;
+            pushState('place-detail', placeId);
+            highlightPin(placeId);
+        });
+    });
+}
+
+// ── Suggestion Items in default search state ─────────────────
+document.querySelectorAll('.suggestion-item').forEach(item => {
+    item.addEventListener('click', () => {
+        const placeId = item.dataset.placeId;
+        if (placeId) {
+            pushState('place-detail', placeId);
+            highlightPin(placeId);
+        }
+    });
+});
+
+// ── Chip Bar ─────────────────────────────────────────────────
+let chipScrollTracked = false;
+chipBars.forEach(bar => {
+    bar.addEventListener('scroll', () => {
+        if (!chipScrollTracked) {
+            tracker.track('chip_bar_scroll', { direction: 'right' });
+            chipScrollTracked = true;
+            setTimeout(() => { chipScrollTracked = false; }, 1000);
+        }
+    });
+});
+
+document.querySelectorAll('.chip').forEach(chip => {
+    chip.addEventListener('click', () => {
+        const category = chip.dataset.category;
+
+        // Toggle active across all chip bars (they are duplicated across panel states)
+        if (activeChip === category) {
+            document.querySelectorAll(`.chip[data-category="${category}"]`).forEach(c => c.classList.remove('active'));
+            activeChip = null;
+        } else {
+            document.querySelectorAll('.chip').forEach(c => c.classList.remove('active'));
+            document.querySelectorAll(`.chip[data-category="${category}"]`).forEach(c => c.classList.add('active'));
+            activeChip = category;
+        }
+
+        tracker.track('nearby_chip_select', { category });
+        renderPins();
+    });
+});
+
+// ── Map Pins ─────────────────────────────────────────────────
+function renderPins() {
+    mapPinsGroup.innerHTML = '';
+
+    // Determine which places to show pins for
+    let visiblePlaces;
+    if (activeChip) {
+        // Category mapping
+        const catMap = {
+            restaurants: [],
+            gas: [],
+            coffee: ['coffee'],
+            hotels: [],
+            parking: ['parking'],
+            groceries: [],
+            attractions: ['attraction'],
+            pharmacies: []
+        };
+        const types = catMap[activeChip] || [];
+        visiblePlaces = PLACES.filter(p => types.includes(p.type));
+        // Always show ad pins regardless of category
+        visiblePlaces = visiblePlaces.concat(AD_PLACES);
+    } else {
+        // Default: all non-parking regular + ads
+        visiblePlaces = PLACES.filter(p => p.type !== 'parking').concat(AD_PLACES);
+    }
+
+    visiblePlaces.forEach(place => {
+        const [cx, cy] = place.coords;
+        let pinEl;
+
+        if (place.type === 'ad') {
+            // Square pin for ads
+            pinEl = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+            pinEl.setAttribute('x', cx - 7);
+            pinEl.setAttribute('y', cy - 7);
+            pinEl.setAttribute('width', 14);
+            pinEl.setAttribute('height', 14);
+            pinEl.setAttribute('rx', 2);
+            pinEl.classList.add('map-pin', 'pin-ad');
+        } else {
+            // Circle pin
+            pinEl = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+            pinEl.setAttribute('cx', cx);
+            pinEl.setAttribute('cy', cy);
+            pinEl.setAttribute('r', 8);
+            const pinClass = place.type === 'parking' ? 'pin-parking'
+                : place.type === 'coffee' ? 'pin-coffee'
+                : place.type === 'shopping' ? 'pin-shopping'
+                : 'pin-regular';
+            pinEl.classList.add('map-pin', pinClass);
+        }
+
+        pinEl.setAttribute('data-pin-id', place.id);
+        pinEl.setAttribute('data-place-name', place.name);
+
+        // Click
+        pinEl.addEventListener('click', () => {
+            tracker.track('pin_click', { pinId: place.id, placeName: place.name });
+            pushState('place-detail', place.id);
+        });
+
+        // Hover — tooltip
+        pinEl.addEventListener('mouseenter', () => {
+            tracker.track('pin_hover', { pinId: place.id });
+            showTooltip(place.name, cx, cy);
+        });
+        pinEl.addEventListener('mouseleave', () => {
+            hideTooltip();
+        });
+
+        mapPinsGroup.appendChild(pinEl);
+    });
+}
+
+function highlightPin(placeId) {
+    // Briefly flash a pin
+    const pin = mapPinsGroup.querySelector(`[data-pin-id="${placeId}"]`);
+    if (pin) {
+        pin.style.transform = 'scale(1.4)';
+        setTimeout(() => { pin.style.transform = ''; }, 500);
+    }
+}
+
+function showTooltip(text, cx, cy) {
+    tooltipText.textContent = text;
+    // Measure text width approx
+    const textLen = text.length * 7 + 16;
+    tooltipBg.setAttribute('width', textLen);
+    // Position above pin
+    const tx = cx - textLen / 2;
+    const ty = cy - 38;
+    pinTooltipGroup.setAttribute('transform', `translate(${tx}, ${ty})`);
+    pinTooltipGroup.style.display = '';
+}
+
+function hideTooltip() {
+    pinTooltipGroup.style.display = 'none';
+}
+
+// ── Panel Collapse / Expand ──────────────────────────────────
+panelToggle.addEventListener('click', (e) => {
+    e.stopPropagation();
+    const isCollapsed = panel.classList.contains('collapsed');
+    if (isCollapsed) {
+        panel.classList.remove('collapsed');
+        tracker.track('panel_expand', {});
+    } else {
+        panel.classList.add('collapsed');
+        tracker.track('panel_collapse', {});
+    }
+    tracker.track('map_viewport_change', {});
+});
+
+// Panel-toggle is now a sibling of .panel inside #app, so no DOM reparenting
+// is needed. CSS uses #app:has(.panel.collapsed) to slide the button left and
+// flip the chevron when the panel is collapsed.
+
+// ── Transport Mode Tabs ──────────────────────────────────────
+transportTabs.querySelectorAll('.transport-tab').forEach(tab => {
+    tab.addEventListener('click', () => {
+        transportTabs.querySelectorAll('.transport-tab').forEach(t => t.classList.remove('active'));
+        tab.classList.add('active');
+        activeTransportMode = tab.dataset.mode;
+        tracker.track('transport_mode_select', { mode: activeTransportMode });
+        tryShowRoutes();
+    });
+});
+
+// ── Swap Button ──────────────────────────────────────────────
+swapBtn.addEventListener('click', () => {
+    const tmp = directionsOrigin.value;
+    directionsOrigin.value = directionsDestination.value;
+    directionsDestination.value = tmp;
+    tryShowRoutes();
+});
+
+// ── Route Generation ─────────────────────────────────────────
+function tryShowRoutes() {
+    const origin = directionsOrigin.value.trim();
+    const dest = directionsDestination.value.trim();
+    if (!origin || !dest) {
+        routeResults.classList.add('hidden');
+        clearRoutes();
+        return;
+    }
+
+    // Generate mock routes — scaled by active transport mode
+    const routes = generateRoutes(origin, dest, activeTransportMode);
+    renderRouteResults(routes);
+    drawRoutes(origin, dest);
+}
+
+function generateRoutes(origin, dest, mode) {
+    // Pseudo-random but deterministic distances based on the O/D strings.
+    const seed = (origin + dest).length;
+    const dists = [
+        0.5 + seed * 0.05,
+        0.8 + seed * 0.05,
+        1.1 + seed * 0.05,
+    ];
+    // Rough avg speeds in mph by mode; urban + stop lights baked in.
+    const speedMph = ({ drive: 22, transit: 9, walk: 3, bike: 11 })[mode] || 22;
+    function durMin(miles) {
+        const mins = (miles / speedMph) * 60;
+        return Math.max(1, Math.round(mins));
+    }
+    const labels = ['via Pike St', 'via 1st Ave', 'via Denny Way'];
+    return dists.map((d, i) => ({
+        time: `${durMin(d)} min`,
+        distance: `${d.toFixed(1)} mi`,
+        via: labels[i],
+    }));
+}
+
+function renderRouteResults(routes) {
+    routeList.innerHTML = routes.map((r, i) => `
+        <div class="route-item${i === 0 ? ' active' : ''}" data-route-index="${i}">
+            <div>
+                <div class="route-time">${r.time}</div>
+                <div class="route-via">${r.via}</div>
+            </div>
+            <div class="route-distance">${r.distance}</div>
+        </div>
+    `).join('');
+
+    routeResults.classList.remove('hidden');
+    activeRouteIndex = 0;
+    tracker.track('route_results_render', {});
+
+    // Route click handlers
+    routeList.querySelectorAll('.route-item').forEach(item => {
+        item.addEventListener('click', () => {
+            routeList.querySelectorAll('.route-item').forEach(r => r.classList.remove('active'));
+            item.classList.add('active');
+            const idx = parseInt(item.dataset.routeIndex, 10);
+            activeRouteIndex = idx;
+            tracker.track('route_select', { routeIndex: idx });
+            updateRouteHighlight(idx);
+        });
+    });
+}
+
+function drawRoutes(origin, dest) {
+    // Find coords for origin and dest
+    const oPlace = ALL_PLACES.find(p => p.name.toLowerCase() === origin.toLowerCase());
+    const dPlace = ALL_PLACES.find(p => p.name.toLowerCase() === dest.toLowerCase());
+
+    const ox = oPlace ? oPlace.coords[0] : 150;
+    const oy = oPlace ? oPlace.coords[1] : 150;
+    const dx = dPlace ? dPlace.coords[0] : 200;
+    const dy = dPlace ? dPlace.coords[1] : 250;
+
+    // Three route paths (slight variations)
+    const midX = (ox + dx) / 2;
+    const midY = (oy + dy) / 2;
+
+    const r0 = document.getElementById('route-0');
+    const r1 = document.getElementById('route-1');
+    const r2 = document.getElementById('route-2');
+
+    r0.setAttribute('d', `M${ox},${oy} Q${midX - 20},${midY - 10} ${dx},${dy}`);
+    r1.setAttribute('d', `M${ox},${oy} Q${midX + 30},${midY - 30} ${dx},${dy}`);
+    r2.setAttribute('d', `M${ox},${oy} Q${midX - 10},${midY + 40} ${dx},${dy}`);
+
+    // Show first route highlighted
+    updateRouteHighlight(0);
+}
+
+function updateRouteHighlight(activeIdx) {
+    const routes = document.querySelectorAll('.route-path');
+    routes.forEach((r, i) => {
+        if (i === activeIdx) {
+            r.setAttribute('opacity', '0.8');
+            r.setAttribute('stroke', '#4285f4');
+            r.setAttribute('stroke-width', '5');
+        } else {
+            r.setAttribute('opacity', '0.4');
+            r.setAttribute('stroke', '#9aa0a6');
+            r.setAttribute('stroke-width', '4');
+        }
+    });
+}
+
+function clearRoutes() {
+    document.querySelectorAll('.route-path').forEach(r => {
+        r.setAttribute('opacity', '0');
+        r.setAttribute('d', '');
+    });
+}
+
+// ── Zoom Controls ────────────────────────────────────────────
+let zoomLevel = 1;
+const mapSvg = document.getElementById('map-svg');
+
+document.getElementById('zoom-in').addEventListener('click', () => {
+    zoomLevel = Math.min(zoomLevel + 0.2, 3);
+    applyZoom();
+});
+
+document.getElementById('zoom-out').addEventListener('click', () => {
+    zoomLevel = Math.max(zoomLevel - 0.2, 0.5);
+    applyZoom();
+});
+
+function applyZoom() {
+    const cx = 200, cy = 225;
+    const w = 400 / zoomLevel;
+    const h = 450 / zoomLevel;
+    const x = cx - w / 2;
+    const y = cy - h / 2;
+    mapSvg.setAttribute('viewBox', `${x} ${y} ${w} ${h}`);
+}
+
+// ── Init ─────────────────────────────────────────────────────
+renderPins();

--- a/eval/reports/20260411_full_eval.md
+++ b/eval/reports/20260411_full_eval.md
@@ -1,0 +1,228 @@
+# OpenBrowser Full-Eval Observation Report
+
+**Run**: `20260411_161839`
+**Duration**: 16:18:40 → 19:20:44 (≈3h02m wall-clock)
+**Tests**: 35 YAMLs × 3 models = **105 runs**
+**Models**: `dashscope/qwen3.5-flash`, `dashscope/qwen3.5-plus`, `dashscope/qwen3.6-plus`
+**Scheduler**: `--parallel 3 --single-model-parallel 1`
+**Host**: Chrome ext UUID `9a577a99-…`, eval server on port 16605, agent channel on 8765
+
+---
+
+## 1. Headline numbers
+
+| Model | Pass rate | Task score | Avg duration | Avg cost |
+|---|---|---|---|---|
+| qwen3.5-flash | **80.0%** (28/35) | 254.4/304.8 (83.5%) | 222s | $0.192 |
+| qwen3.5-plus  | **85.7%** (30/35) | 262.8/304.8 (86.2%) | 264s | $0.721 |
+| qwen3.6-plus  | **82.9%** (29/35) | 250.7/304.8 (82.3%) | 308s | $1.449 |
+
+- **3.5-plus leads** on both pass rate and task score.
+- **3.6-plus is 8× more expensive than flash** and scores *lower* — cost-vs-capability Pareto curve is not flattering.
+- Duration scales with cost/capability: more capable models reason longer per step.
+
+## 2. Fail surface (16 fail events, 9 unique tests)
+
+Tests that failed for **at least one model**:
+
+| Test | flash | 3.5-plus | 3.6-plus | Failure mode |
+|---|---|---|---|---|
+| `replay_techforum_upvote` | F 4.0 | F 4.0 | F 4.0 | **Universal** — loose keyword match |
+| `taskflow_full_workflow` | F 3.0 | F 2.5 | F 3.0 | **Universal** — stale-DOM / lost card + loops |
+| `taskflow_drag_and_edit` | F 0.5 | F 5.5 | F 0.5 | **Universal** — drag primitive missing |
+| `mapquest_nearby_pins` | F 4.5 | F 6.5 | F 4.5 | **Universal** — pin-click on map canvas |
+| `staybnb_book` | F 11.0 | F 2.0* | F 2.0* | 1 real (slider), 2 infra (HTTP 8765 timeout) |
+| `gmail_inbox_cleanup` | F 2.0 | P 7.0 | P 7.0 | flash-specific loop |
+| `drive_project_reorg` | F 5.5 | P 7.5 | P 7.5 | flash-specific step skip |
+| `amazon_variant_checkout` | P 10.2 | P 10.2 | F 6.6 | 3.6-plus skipped shipping option |
+
+*= killed by infrastructure, not agent incapability.
+
+## 3. Root-cause findings
+
+Each finding is supported by concrete event evidence from the run output at
+`/Users/yangxiao/git/OpenBrowser/eval/output/20260411_161839/`.
+
+### 3.1 Loose keyword matching (F2/F5) — **universal**
+
+`replay_techforum_upvote` failed identically on all 3 models with **exactly 4.0/10.0**. Agents were asked to upvote posts whose title mentioned "agent", "agents", or "agentic". The ground-truth posts are Q7/Q12/Q18 (the only posts whose titles contain "agents").
+
+- flash upvoted Q1 + Q16 (AI topics, not agents)
+- 3.5-plus upvoted Q1 + Q9 + Q16
+- 3.6-plus upvoted similar unrelated AI posts
+
+**Both 3.5-plus and 3.6-plus** — the stronger models — also conflate "agent-related" with "AI-related". This is not a flash-specific weakness; it's the **entire OpenBrowser class of models loose-matching task descriptions** to any semantically nearby posts. The instruction, routine file, and YAML criterion all agree on Q7/Q12/Q18; the agent simply doesn't discriminate.
+
+### 3.2 Drag-and-drop tool is missing or unreliable (F9/F12) — **universal**
+
+Two drag-heavy tests have 0% pass rate:
+
+- **`taskflow_drag_and_edit`**: all 3 models 0.5 / 5.5 / 0.5 out of 11.5. Zero `card_drag_start` / `card_drop` events across all runs — no agent ever *attempts* a drag. Flash opened the card modal instead of dragging.
+- **`staybnb_book` (slider)**: flash scored 11.0/15 (only missing the dual-handle `price_slider_change` events).
+
+OpenBrowser clearly has **click and type primitives** but drag is either absent, unreliable, or the LLMs don't know it exists. The pattern holds: any test whose solution requires horizontal/vertical dragging of a DOM element is currently unsolvable in this agent.
+
+### 3.3 Map-canvas pin targeting (F8) — **universal**
+
+`mapquest_nearby_pins` fails on all 3 models, zero `pin_click` events emitted by any model. The winning criterion requires clicking `pike-place-parking-garage` next to a decoy pin; the agent gets the chip/autocomplete steps right but can never land a click on a specific SVG pin.
+
+- 3.5-plus routed around it by using autocomplete to set the parking garage as destination (got 6.5 — creative shortcut).
+- flash and 3.6-plus looped on chips/panel collapse 20+ times until time-limit.
+
+Map-canvas targets — small, clustered, non-standard DOM — are outside OpenBrowser's current pointing ability.
+
+### 3.4 Stale DOM after re-render (F4/F6) — **universal**
+
+`taskflow_full_workflow` fails on all 3 models with scores 2.5–3.0 out of 13. In every run the agent successfully creates "Security audit" in Review (criteria 1–2 pass) and then loses track of it:
+
+- flash: opens wrong card "Code review: payments", then loops `add_card_click` 5 more times doing nothing
+- 3.5-plus: finds "Security audit" but targets the hover-only `card-edit-btn` → `element_interaction` returns "Element is not visible" → no recovery, times out
+- 3.6-plus: hovers "Update user permissions" (wrong), opens "Fix login bug" (wrong)
+
+Root cause: `col.cards.push(newCard); renderBoard();` appends the new card at the **bottom of the column** (possibly off-screen) and **re-renders the entire board DOM**. Any element IDs the agent was tracking go stale, and the agent doesn't re-scan → commits to a wrong card or loops.
+
+### 3.5 Hover-reveal controls (F6) — **interaction-recovery weakness**
+
+TaskFlow's `card-edit-btn` (pencil icon) is hidden until hover. 3.5-plus targeted it directly, and OpenBrowser returned `Element is not visible`. The agent interpreted this as a **terminal error** and retried the same click instead of hovering first. OpenBrowser needs either:
+
+1. An error taxonomy that distinguishes "not in DOM" from "in DOM but requires hover".
+2. An auto-hover fallback when the click target is `display:none` or `opacity:0`.
+3. A hint in the error message saying "did you mean to hover first?".
+
+### 3.6 Feedback-perception on no-op clicks (F3) — **interaction loop**
+
+`vidhub_comment` revealed a subtle agent-capability split. Both 3.6-plus and flash clicked `#volume-slider` at `(195, 225)` **three times in a row at the identical pixel** — that pixel was the slider's existing thumb position so no value change fired, no `volume_change` event, −2pts. Meanwhile 3.5-plus clicked once at `(195, 532)` and it worked.
+
+The agent **cannot perceive that a click had no effect** and keeps retrying the same coordinate rather than adjusting target or using a different input mechanism (arrow keys, drag). This is a general form of the loop pattern: when the action doesn't advance state, the agent repeats it verbatim.
+
+### 3.7 Agent doesn't signal completion — wastes wall-time and cost
+
+`replay_finviz_filter_simple` passed with **full marks on all 3 models** but used the **entire 600s time limit** on each run. That's **30 minutes of wasted compute + ≈$1 of wasted LLM tokens** for a task the agent had already completed. The agent either:
+
+1. Doesn't emit a `task_complete` signal, or
+2. Doesn't recognize when all goals are achieved, or
+3. Keeps exploring as a precaution.
+
+Counterexample: `replay_techforum_upvote/flash` failed fast at 158s — the agent decided it was done *too early* (only 2 upvotes, not 3). So the completion heuristic is both too-eager *and* too-lax depending on the scenario.
+
+### 3.8 HTTP channel timeout causes false failures (F11) — **critical infrastructure**
+
+Two errors in the log:
+
+```
+18:01:50 ERROR Failed to send message: HTTPConnectionPool(host='localhost', port=8765): Read timed out.
+18:22:03 ERROR Failed to send message: HTTPConnectionPool(host='localhost', port=8765): Read timed out.
+```
+
+Both corresponded to `staybnb_book` runs:
+
+- `staybnb_book/3.5-plus`: 235s, 2.0/15.0, **cost $0.027** (normal plus runs cost ~$0.72)
+- `staybnb_book/3.6-plus`: 526s, 2.0/15.0, **cost $0.067** (normal 3.6-plus runs cost ~$1.45)
+
+The 10–20× lower cost is the smoking gun: the session was killed after only a handful of LLM calls. The score pattern (2.0 = first 2 criteria) is consistent with the agent being cut off during the price-slider step (which is where all 3 models struggled).
+
+Conservative interpretation: **2 of the 3.5-plus/3.6-plus staybnb_book failures are false negatives**. If we re-score ignoring infra failures, pass rates become:
+- 3.5-plus: 31/35 = 88.6% (from 85.7%)
+- 3.6-plus: 30/35 = 85.7% (from 82.9%)
+
+### 3.9 Flash-specific ping-pong loops (F4/F7) — capability-scaling finding
+
+Two tests fail on flash but pass on both plus variants:
+
+- `gmail_inbox_cleanup/flash`: 13 `thread_select` + 7 `thread_open` events ping-ponging on same 3 threads, zero `thread_archive`/`delete`/`move`. Used the full 600s and scored 2.0/7.
+- `drive_project_reorg/flash`: 5.5/7.5, ran the full 660s.
+
+These are **not** universal — 3.5-plus and 3.6-plus solved them cleanly. Flash's weaker planner cannot hold a multi-step reasoning plan, degrades to repetitive no-op actions when the state becomes ambiguous, and exhausts the time limit before it notices.
+
+## 4. Time-limit / wall-time analysis
+
+- **13 `time limit exceeded` warnings** in the log.
+- **3 of those are passing-at-full-marks but didn't exit** (replay_finviz_filter_simple × 3 models) — see §3.7.
+- **2 HTTP timeouts** — see §3.8.
+- Tests that hit the time limit AND failed: gmail_inbox_cleanup/flash, mapquest_nearby_pins (×2), taskflow_full_workflow (×3), taskflow_drag_and_edit/3.6-plus, drive_project_reorg/flash. Every one of these corresponds to an agent-stuck pattern (loop, wrong target, missing primitive).
+
+**No test had a too-short time limit**. Every test that ran to the wall either completed with full marks (redundantly) or was genuinely unsolvable with the current agent primitives.
+
+## 5. Theory of OpenBrowser's main issues
+
+Consolidating the patterns:
+
+**T1. Interaction primitive gaps.** The agent's tool surface appears to cover click/type reliably, but drag-and-drop and drag-based continuous controls (sliders) are absent or unreliable. Any site that has a native-range-input slider, an HTML5 dnd card, or a canvas/SVG pin with pixel-precision targeting becomes a failure cliff, regardless of model capability.
+
+**T2. Stale-DOM disorientation.** When a page re-renders substantially (TaskFlow's `renderBoard()` after card creation; anywhere a React-style diff swaps children), the agent's internal model of "which element is where" doesn't refresh. It commits to an obsolete target and either fails silently ("Element not visible") or opens the wrong neighbour.
+
+**T3. Terminal error interpretation.** Errors like `Element is not visible` are treated as dead-ends instead of hints. The agent retries the same call or abandons the thread entirely, rather than attempting the obvious repair (hover → reveal → click).
+
+**T4. Feedback-loop blindness.** When an action produces no state change (no-op click on a range input already at the target value, hover on wrong card), the agent cannot tell and repeats the action verbatim. This is the root of every "click loop" and "select loop" observed in the run.
+
+**T5. Instruction-precision drift.** For semantically-discriminated tasks ("upvote posts mentioning *agents*, not AI generally"), all three models conflate the specific keyword with the broader topic. Criteria that require reading a list and picking by exact substring fail universally.
+
+**T6. Completion-signal absence.** The agent does not reliably emit a "task done" after achieving the goal, nor does it bail when the goal is clearly unreachable. Both ends of the spectrum waste resources: passing tests run the full time-limit, failing tests churn in loops.
+
+**T7. Infrastructure fragility.** The HTTP channel at `localhost:8765` has an inflexible read timeout that, once triggered, returns a hard error and terminates the run. A slow LLM turn or a long action sequence can kill a test that would otherwise have succeeded.
+
+## 6. Proposed solutions (by theory)
+
+### T1 — Missing drag primitive
+
+1. **Add a first-class `drag_and_drop(src, dst)` tool** to the OpenBrowser action surface. Thin wrapper over CDP `Input.dispatchMouseEvent` (mousedown → mousemove steps → mouseup) plus synthetic HTML5 dnd events (`dragstart`, `dragover`, `drop`, `dragend`) when the source has `draggable="true"`.
+2. **Slider-specific primitive `set_slider(element, value)`** that reads the range's `min/max/step`, computes the target value, then dispatches `input`/`change` events directly. Bypasses the need for pixel-perfect drag.
+3. **Advertise both tools in the agent system prompt** so the LLM knows they exist. Current models never attempted drag, suggesting they don't know the tool exists.
+
+### T2 — Stale DOM
+
+1. **Force a DOM re-scan after any action that mutates page structure** (cart add, card create, filter apply). Cheap proxy: if the AX tree or element-id list differs by >N nodes after an action, invalidate the in-memory element cache and re-observe before the next action.
+2. **Scroll-into-view for newly-created elements** on the page side: a small site-level hint that calls `element.scrollIntoView({block: 'center'})` on tracker events like `card_create_submit`. Not a fix to OpenBrowser, but a mitigation that reveals the disorientation pattern.
+
+### T3 — Error taxonomy
+
+1. **Distinguish error codes in `element_interaction` return values**: `ELEMENT_NOT_IN_DOM`, `ELEMENT_IN_DOM_BUT_HIDDEN`, `ELEMENT_IN_DOM_BUT_ZERO_SIZE`, `ELEMENT_COVERED_BY_OTHER`. The LLM can reason about "hidden" differently from "missing".
+2. **Auto-hover fallback**: when asked to click an element that is in the DOM but has `display:none` or zero opacity, first hover its parent card/container for 300ms and retry. This is what a human would do.
+3. **Error message hints**: include "The element exists but is hidden. It may be revealed on hover of its parent." in the failure string so the LLM has the clue in its context.
+
+### T4 — Feedback perception
+
+1. **State-diff feedback in observation**: after each action, compare page state hashes (URL, scroll position, focused element, visible text delta) and emit a "no change detected" warning if the action was a no-op.
+2. **Click-fingerprint deduplication**: if the agent issues the same (selector, x, y) click three times in a row with no state change, inject a correction prompt suggesting a different target or a drag.
+
+### T5 — Instruction precision
+
+1. **Structured criteria extraction step**: before action, force the LLM to enumerate the *exact* strings/entities it's looking for. For `replay_techforum_upvote`, this would surface "I need to find posts whose title contains 'agent', 'agents', or 'agentic'" as an intermediate artifact, which the agent can then grep against each post title literally.
+2. **Two-pass review on list-type tasks**: for "upvote every post matching X" tasks, require the agent to emit a candidate list first, then verify each entry against the criterion before committing actions.
+
+### T6 — Completion signals
+
+1. **Explicit `task_complete(reason, evidence)` tool** that the agent must call to end a session. Harness treats missing call after the last useful action as a soft-pass (no penalty) but flags for review.
+2. **Idle detection**: if the agent performs N consecutive actions with zero state change (no new tracker events, no scroll, no URL change), emit a "you appear to be stuck or done" observation so the LLM gets a chance to reason about it.
+
+### T7 — HTTP channel fragility
+
+1. **Raise read timeout on `localhost:8765`** from the default (looks like ≈60s by the 2 observed timeouts) to 300s for evals, or make it configurable per-test from the dataset YAML.
+2. **Idempotent retry on send failure**: if the harness fails to deliver a message to the agent, retry once after a 2s backoff before declaring the run dead.
+3. **Heartbeat keepalive** from agent → harness during long LLM turns so the harness knows the session is alive.
+4. **Separate "session dead" from "test failed"**: infra failures should produce a distinct outcome that doesn't contaminate the pass-rate metric.
+
+## 7. Tests with invalid results (recommend re-run)
+
+- `staybnb_book/3.5-plus` (2.0/15) — HTTP timeout
+- `staybnb_book/3.6-plus` (2.0/15) — HTTP timeout
+
+Suggest re-running these two only after raising the 8765 timeout.
+
+## 8. Tests that exposed the most signal
+
+Best "agent-capability discriminators" in this dataset (highest variance between models or biggest gap between attempted and completed):
+
+1. **`replay_techforum_upvote`** — universal fail, clearly isolates instruction-precision.
+2. **`taskflow_full_workflow`** — universal fail, isolates stale-DOM + loop fallback.
+3. **`taskflow_drag_and_edit`** — universal fail, isolates drag primitive gap.
+4. **`mapquest_nearby_pins`** — universal fail, isolates pixel-precise canvas targeting.
+5. **`vidhub_comment`** — 3.5-plus aces, other two lose 2pts on the same step — isolates feedback-perception on no-op clicks.
+
+Consider adding more tests in these patterns to the core benchmark.
+
+## 9. Summary recommendation (the "one thing if you had to pick")
+
+If the goal is the **largest single improvement** to OpenBrowser's benchmark pass rate, fix **T1 (missing drag primitive) + T7 (HTTP timeout)**. Together they account for 4 of the 9 failing tests (`taskflow_drag_and_edit`, `staybnb_book`×2, plus half the path in `taskflow_full_workflow`). Everything else is a deeper model/behaviour issue that requires prompt or training work.
+
+If the goal is the **highest-leverage agent-behaviour fix**, address **T4 (feedback perception)** — the blindness to no-op actions is upstream of the loop failures in gmail_inbox_cleanup, taskflow loops, vidhub volume clicks, and mapquest chip ping-pong. A single observation-layer hint ("you just clicked the same thing, nothing changed") would interrupt all of those loops.

--- a/eval/server.py
+++ b/eval/server.py
@@ -18,13 +18,14 @@ import http.server
 import json
 import os
 import socketserver
+import sys
 import threading
 from copy import deepcopy
 from datetime import datetime
 from urllib.parse import parse_qs, urlparse
 
 # Configuration
-PORT = 16605
+DEFAULT_PORT = 16605
 EVAL_DIR = os.path.dirname(os.path.abspath(__file__))
 
 # In-memory event storage
@@ -39,6 +40,11 @@ SITE_NAME_TO_BUCKET = {
     "finviz": "finviz",
     "bluebook.life": "bluebook",
     "northstaroutfitters.com": "northstar",
+    "mail.google.com": "gmail",
+    "drive.google.com": "drive",
+    "booking.com": "booking",
+    "github.com": "github",
+    "amazon.com": "amazon",
 }
 
 
@@ -339,6 +345,36 @@ class MockWebsiteHandler(http.server.SimpleHTTPRequestHandler):
                         "url": "/northstar/",
                         "description": "Apparel product page - test geometry-first scrolling, sticky UI, and drawer-scoped scrolling",
                     },
+                    {
+                        "name": "mail.google.com",
+                        "difficulty": "hard",
+                        "url": "/gmail/",
+                        "description": "Inbox triage mock - search operators, labels, drafts, and multi-step reply workflows",
+                    },
+                    {
+                        "name": "drive.google.com",
+                        "difficulty": "hard",
+                        "url": "/drive/",
+                        "description": "Drive file-management mock - nested folders, move/share flows, shortcuts, and uploads",
+                    },
+                    {
+                        "name": "booking.com",
+                        "difficulty": "hard",
+                        "url": "/booking/",
+                        "description": "Travel booking mock - filters, room policy discrimination, compare, and checkout",
+                    },
+                    {
+                        "name": "github.com",
+                        "difficulty": "hard",
+                        "url": "/github/",
+                        "description": "Repository workflow mock - issue triage, files changed review, labels, and review submission",
+                    },
+                    {
+                        "name": "amazon.com",
+                        "difficulty": "hard",
+                        "url": "/amazon/",
+                        "description": "Retail workflow mock - noisy search, variants, offers, cart recovery, and checkout",
+                    },
                 ]
             }
             self.send_json_response(sites)
@@ -360,6 +396,11 @@ class MockWebsiteHandler(http.server.SimpleHTTPRequestHandler):
                     "/finviz/": "Finviz stock screener mock (hard)",
                     "/bluebook/": "BlueBook lifestyle feed mock (hard)",
                     "/northstar/": "Northstar Outfitters product page mock (hard)",
+                    "/gmail/": "Gmail workflow mock (hard/very hard)",
+                    "/drive/": "Drive workflow mock (hard/very hard)",
+                    "/booking/": "Booking workflow mock (hard/very hard)",
+                    "/github/": "GitHub workflow mock (hard/very hard)",
+                    "/amazon/": "Amazon workflow mock (hard/very hard)",
                 },
             }
             self.send_json_response(help_text)
@@ -391,55 +432,31 @@ class MockWebsiteHandler(http.server.SimpleHTTPRequestHandler):
             self.send_file(file_path, content_type)
             return
 
+        full_path = os.path.join(EVAL_DIR, path.lstrip("/"))
+
         # Check for CSS files
-        if path.startswith("/css/") and path.endswith(".css"):
+        if path.endswith(".css") and os.path.exists(full_path):
             self.send_file(path, CSS_MIMETYPE)
             return
 
-        # Check for JS files (including site-specific JS folders)
-        if path.startswith("/js/") and path.endswith(".js"):
+        # Check for JS files (including site-specific folders)
+        if path.endswith(".js") and os.path.exists(full_path):
             self.send_file(path, JS_MIMETYPE)
             return
 
-        # Check for site-specific JS files (e.g., /techforum/js/, /gbr/js/, /cloudstack/js/)
-        for site in [
-            "techforum",
-            "gbr",
-            "cloudstack",
-            "dataflow",
-            "finviz",
-            "bluebook",
-            "northstar",
-        ]:
-            if path.startswith(f"/{site}/js/") and path.endswith(".js"):
-                self.send_file(path, JS_MIMETYPE)
-                return
-
-        # Check for site-specific CSS files
-        for site in [
-            "techforum",
-            "gbr",
-            "cloudstack",
-            "dataflow",
-            "finviz",
-            "bluebook",
-            "northstar",
-        ]:
-            if path.startswith(f"/{site}/css/") and path.endswith(".css"):
-                self.send_file(path, CSS_MIMETYPE)
-                return
-
         # Check for image files
-        if path.endswith(".svg"):
+        if path.endswith(".svg") and os.path.exists(full_path):
             self.send_file(path, SVG_MIMETYPE)
             return
-        elif path.endswith(".png"):
+        elif path.endswith(".png") and os.path.exists(full_path):
             self.send_file(path, PNG_MIMETYPE)
             return
-        elif path.endswith(".jpg") or path.endswith(".jpeg"):
+        elif (path.endswith(".jpg") or path.endswith(".jpeg")) and os.path.exists(
+            full_path
+        ):
             self.send_file(path, JPG_MIMETYPE)
             return
-        elif path.endswith(".gif"):
+        elif path.endswith(".gif") and os.path.exists(full_path):
             self.send_file(path, GIF_MIMETYPE)
             return
 
@@ -834,6 +851,10 @@ class MockWebsiteHandler(http.server.SimpleHTTPRequestHandler):
         print(f"[{datetime.now().strftime('%H:%M:%S')}] {args[0]}")
 
 
+class ReusableThreadingTCPServer(socketserver.ThreadingTCPServer):
+    allow_reuse_address = True
+
+
 def print_startup_info(port):
     """Print startup information"""
     print("\n" + "=" * 60)
@@ -847,6 +868,11 @@ def print_startup_info(port):
     print(f"  - DataFlow (Medium):  http://localhost:{port}/dataflow/")
     print(f"  - Finviz (Hard):  http://localhost:{port}/finviz/")
     print(f"  - BlueBook (Hard): http://localhost:{port}/bluebook/")
+    print(f"  - Gmail (Hard+): http://localhost:{port}/gmail/")
+    print(f"  - Drive (Hard+): http://localhost:{port}/drive/")
+    print(f"  - Booking (Hard+): http://localhost:{port}/booking/")
+    print(f"  - GitHub (Hard+): http://localhost:{port}/github/")
+    print(f"  - Amazon (Hard+): http://localhost:{port}/amazon/")
     print("\nAPI Endpoints:")
     print(
         f"  - GET  http://localhost:{port}/api/events       - Get tracked events (?site=gbr)"
@@ -863,10 +889,13 @@ def print_startup_info(port):
 
 def main():
     """Main entry point"""
-    with socketserver.ThreadingTCPServer(("", PORT), MockWebsiteHandler) as httpd:
-        httpd.allow_reuse_address = True
+    env_port = os.environ.get("MOCK_EVAL_PORT") or os.environ.get("PORT")
+    cli_port = sys.argv[1] if len(sys.argv) > 1 else None
+    port = int(cli_port or env_port or DEFAULT_PORT)
+
+    with ReusableThreadingTCPServer(("", port), MockWebsiteHandler) as httpd:
         httpd.daemon_threads = True
-        print_startup_info(PORT)
+        print_startup_info(port)
 
         try:
             httpd.serve_forever()

--- a/eval/server.py
+++ b/eval/server.py
@@ -521,7 +521,16 @@ class MockWebsiteHandler(http.server.SimpleHTTPRequestHandler):
 
     def send_file(self, file_path, content_type):
         """Send a file with appropriate headers"""
-        full_path = os.path.join(EVAL_DIR, file_path.lstrip("/"))
+        eval_root = os.path.abspath(EVAL_DIR)
+        full_path = os.path.abspath(os.path.join(eval_root, file_path.lstrip("/")))
+
+        try:
+            if os.path.commonpath([eval_root, full_path]) != eval_root:
+                self.send_error_response(403, f"Forbidden path: {file_path}")
+                return
+        except ValueError:
+            self.send_error_response(403, f"Forbidden path: {file_path}")
+            return
 
         if not os.path.exists(full_path):
             self.send_error_response(404, f"File not found: {file_path}")

--- a/eval/server.py
+++ b/eval/server.py
@@ -39,6 +39,10 @@ SITE_NAME_TO_BUCKET = {
     "finviz": "finviz",
     "bluebook.life": "bluebook",
     "northstaroutfitters.com": "northstar",
+    "mapquest.com": "mapquest",
+    "staybnb.com": "staybnb",
+    "taskflow.app": "taskflow",
+    "vidhub.com": "vidhub",
 }
 
 
@@ -253,6 +257,14 @@ URL_MAPPINGS = {
     "/bluebook/index.html": ("/bluebook/index.html", "text/html"),
     "/northstar/": ("/northstar/index.html", "text/html"),
     "/northstar/index.html": ("/northstar/index.html", "text/html"),
+    "/mapquest/": ("/mapquest/index.html", "text/html"),
+    "/mapquest/index.html": ("/mapquest/index.html", "text/html"),
+    "/staybnb/": ("/staybnb/index.html", "text/html"),
+    "/staybnb/index.html": ("/staybnb/index.html", "text/html"),
+    "/taskflow/": ("/taskflow/index.html", "text/html"),
+    "/taskflow/index.html": ("/taskflow/index.html", "text/html"),
+    "/vidhub/": ("/vidhub/index.html", "text/html"),
+    "/vidhub/index.html": ("/vidhub/index.html", "text/html"),
 }
 
 CSS_MIMETYPE = "text/css"
@@ -339,6 +351,30 @@ class MockWebsiteHandler(http.server.SimpleHTTPRequestHandler):
                         "url": "/northstar/",
                         "description": "Apparel product page - test geometry-first scrolling, sticky UI, and drawer-scoped scrolling",
                     },
+                    {
+                        "name": "mapquest.com",
+                        "difficulty": "hard",
+                        "url": "/mapquest/",
+                        "description": "Google Maps mock - test autocomplete timing, icon-only transport buttons, spatial pin clicks, panel-state transitions",
+                    },
+                    {
+                        "name": "staybnb.com",
+                        "difficulty": "hard",
+                        "url": "/staybnb/",
+                        "description": "Airbnb mock - test date-range calendar, dual-handle price slider drag, segmented search pill, multi-step booking",
+                    },
+                    {
+                        "name": "taskflow.app",
+                        "difficulty": "hard",
+                        "url": "/taskflow/",
+                        "description": "Trello mock - test drag-and-drop cards, hover-reveal pencil, color-only label picker, inline editing",
+                    },
+                    {
+                        "name": "vidhub.com",
+                        "difficulty": "hard",
+                        "url": "/vidhub/",
+                        "description": "YouTube mock - test auto-hide control bar, timeline scrub, nested settings popup, volume hover-reveal slider",
+                    },
                 ]
             }
             self.send_json_response(sites)
@@ -360,6 +396,10 @@ class MockWebsiteHandler(http.server.SimpleHTTPRequestHandler):
                     "/finviz/": "Finviz stock screener mock (hard)",
                     "/bluebook/": "BlueBook lifestyle feed mock (hard)",
                     "/northstar/": "Northstar Outfitters product page mock (hard)",
+                    "/mapquest/": "MapQuest Google Maps mock (hard)",
+                    "/staybnb/": "StayBnB Airbnb mock (hard)",
+                    "/taskflow/": "TaskFlow Trello mock (hard)",
+                    "/vidhub/": "VidHub YouTube mock (hard)",
                 },
             }
             self.send_json_response(help_text)
@@ -410,6 +450,10 @@ class MockWebsiteHandler(http.server.SimpleHTTPRequestHandler):
             "finviz",
             "bluebook",
             "northstar",
+            "mapquest",
+            "staybnb",
+            "taskflow",
+            "vidhub",
         ]:
             if path.startswith(f"/{site}/js/") and path.endswith(".js"):
                 self.send_file(path, JS_MIMETYPE)
@@ -424,6 +468,10 @@ class MockWebsiteHandler(http.server.SimpleHTTPRequestHandler):
             "finviz",
             "bluebook",
             "northstar",
+            "mapquest",
+            "staybnb",
+            "taskflow",
+            "vidhub",
         ]:
             if path.startswith(f"/{site}/css/") and path.endswith(".css"):
                 self.send_file(path, CSS_MIMETYPE)
@@ -847,6 +895,10 @@ def print_startup_info(port):
     print(f"  - DataFlow (Medium):  http://localhost:{port}/dataflow/")
     print(f"  - Finviz (Hard):  http://localhost:{port}/finviz/")
     print(f"  - BlueBook (Hard): http://localhost:{port}/bluebook/")
+    print(f"  - MapQuest (Hard): http://localhost:{port}/mapquest/")
+    print(f"  - StayBnB (Hard):  http://localhost:{port}/staybnb/")
+    print(f"  - TaskFlow (Hard): http://localhost:{port}/taskflow/")
+    print(f"  - VidHub (Hard):   http://localhost:{port}/vidhub/")
     print("\nAPI Endpoints:")
     print(
         f"  - GET  http://localhost:{port}/api/events       - Get tracked events (?site=gbr)"

--- a/eval/staybnb/css/staybnb.css
+++ b/eval/staybnb/css/staybnb.css
@@ -1,0 +1,642 @@
+/* StayBnB — Airbnb-like mock site for AI agent evaluation */
+
+/* ===== RESET & BASE ===== */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+:root {
+  --brand: #FF385C;
+  --brand-light: #FFE0E6;
+  --brand-hover: #E0294A;
+  --black: #222;
+  --gray-900: #333;
+  --gray-700: #555;
+  --gray-500: #888;
+  --gray-400: #aaa;
+  --gray-300: #ccc;
+  --gray-200: #e0e0e0;
+  --gray-100: #f5f5f5;
+  --white: #fff;
+  --shadow-sm: 0 1px 3px rgba(0,0,0,.08);
+  --shadow-md: 0 2px 8px rgba(0,0,0,.12);
+  --shadow-lg: 0 4px 16px rgba(0,0,0,.16);
+  --radius-sm: 8px;
+  --radius-md: 12px;
+  --radius-lg: 16px;
+  --radius-full: 9999px;
+  --transition: .2s ease;
+}
+
+html { font-size: 16px; }
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+  color: var(--black);
+  background: var(--white);
+  line-height: 1.5;
+  min-width: 1200px;
+  overflow-x: hidden;
+}
+
+a { text-decoration: none; color: inherit; }
+button { font: inherit; cursor: pointer; border: none; background: none; }
+input { font: inherit; border: none; outline: none; }
+ul { list-style: none; }
+
+/* ===== HEADER / TOP BAR ===== */
+.topbar {
+  position: sticky; top: 0; z-index: 300;
+  background: var(--white);
+  border-bottom: 1px solid var(--gray-200);
+  padding: 0 24px;
+}
+.topbar-inner {
+  max-width: 1760px; margin: 0 auto;
+  display: flex; align-items: center; justify-content: space-between;
+  height: 80px;
+}
+
+/* logo */
+.logo { display: flex; align-items: center; gap: 6px; font-size: 22px; font-weight: 700; color: var(--brand); cursor: pointer; user-select: none; }
+.logo svg { width: 32px; height: 32px; fill: var(--brand); }
+
+/* search pill */
+.search-pill-wrap { position: relative; }
+.search-pill {
+  display: flex; align-items: center;
+  border: 1px solid var(--gray-300);
+  border-radius: var(--radius-full);
+  box-shadow: var(--shadow-sm);
+  background: var(--white);
+  height: 48px;
+  transition: box-shadow var(--transition);
+}
+.search-pill:hover { box-shadow: var(--shadow-md); }
+
+.search-pill-seg {
+  display: flex; align-items: center; justify-content: center;
+  padding: 0 20px; height: 100%;
+  font-size: 14px; font-weight: 500; color: var(--gray-700);
+  cursor: pointer; position: relative;
+  white-space: nowrap; user-select: none;
+  border-right: 1px solid var(--gray-200);
+  transition: background var(--transition);
+}
+.search-pill-seg:hover { background: var(--gray-100); }
+.search-pill-seg.active { background: var(--gray-100); font-weight: 600; color: var(--black); }
+.search-pill-seg:first-child { border-radius: var(--radius-full) 0 0 var(--radius-full); padding-left: 24px; }
+
+.search-pill-seg .seg-label { font-size: 12px; color: var(--gray-500); margin-right: 6px; }
+.search-pill-seg .seg-value { font-size: 14px; color: var(--black); }
+
+.search-btn {
+  display: flex; align-items: center; justify-content: center;
+  width: 48px; height: 48px; min-width: 48px;
+  background: var(--brand); border-radius: 50%;
+  color: var(--white); margin-left: -1px;
+  transition: background var(--transition);
+}
+.search-btn:hover { background: var(--brand-hover); }
+.search-btn svg { width: 18px; height: 18px; }
+
+/* user menu */
+.user-area { display: flex; align-items: center; gap: 16px; }
+.user-area .host-link { font-size: 14px; font-weight: 500; padding: 8px 12px; border-radius: var(--radius-full); transition: background var(--transition); }
+.user-area .host-link:hover { background: var(--gray-100); }
+.user-area .globe-icon { width: 18px; height: 18px; cursor: pointer; }
+.user-menu-btn {
+  display: flex; align-items: center; gap: 8px;
+  border: 1px solid var(--gray-300); border-radius: var(--radius-full);
+  padding: 5px 5px 5px 12px; transition: box-shadow var(--transition);
+}
+.user-menu-btn:hover { box-shadow: var(--shadow-md); }
+.user-menu-btn .hamburger svg { width: 16px; height: 16px; }
+.user-avatar {
+  width: 32px; height: 32px; border-radius: 50%;
+  background: var(--gray-500); color: var(--white);
+  display: flex; align-items: center; justify-content: center;
+  font-size: 14px; font-weight: 600;
+}
+
+/* ===== CATEGORY TABS ===== */
+.category-tabs {
+  display: flex; gap: 32px; justify-content: center;
+  padding: 12px 24px 0;
+  border-bottom: 1px solid var(--gray-200);
+  max-width: 1760px; margin: 0 auto;
+}
+.cat-tab {
+  padding: 12px 4px; font-size: 13px; font-weight: 500; color: var(--gray-500);
+  border-bottom: 2px solid transparent; cursor: pointer;
+  transition: color var(--transition), border-color var(--transition);
+}
+.cat-tab:hover { color: var(--black); }
+.cat-tab.active { color: var(--black); border-bottom-color: var(--black); }
+
+/* ===== SEARCH POPOVERS ===== */
+.popover-anchor { position: absolute; top: 56px; left: 50%; transform: translateX(-50%); z-index: 200; }
+.popover {
+  display: none; position: absolute;
+  background: var(--white);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+  border: 1px solid var(--gray-200);
+  padding: 24px;
+  min-width: 420px;
+  animation: popIn .15s ease;
+}
+.popover.open { display: block; }
+@keyframes popIn { from { opacity: 0; transform: translateY(-6px); } to { opacity: 1; transform: translateY(0); } }
+
+/* where */
+.popover-where { left: -160px; transform: none; width: 480px; }
+.where-input {
+  width: 100%; padding: 12px 16px; font-size: 14px;
+  border: 1px solid var(--gray-300); border-radius: var(--radius-sm);
+  margin-bottom: 12px;
+}
+.where-input:focus { border-color: var(--black); }
+.autocomplete-list { margin-bottom: 16px; }
+.autocomplete-item {
+  display: flex; align-items: center; gap: 12px;
+  padding: 10px 12px; border-radius: var(--radius-sm);
+  cursor: pointer; font-size: 14px;
+  transition: background var(--transition);
+}
+.autocomplete-item:hover { background: var(--gray-100); }
+.autocomplete-item .ac-icon {
+  width: 40px; height: 40px; border-radius: var(--radius-sm);
+  background: var(--gray-100); display: flex; align-items: center; justify-content: center;
+  font-size: 18px;
+}
+.region-label { font-size: 12px; font-weight: 600; color: var(--gray-500); text-transform: uppercase; letter-spacing: .5px; margin: 8px 0; }
+.region-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; }
+.region-card {
+  border: 1px solid var(--gray-200); border-radius: var(--radius-sm);
+  padding: 12px; text-align: center; font-size: 13px; font-weight: 500;
+  cursor: pointer; transition: border-color var(--transition);
+}
+.region-card:hover { border-color: var(--black); }
+
+/* when / calendar */
+.popover-when { left: 50%; transform: translateX(-50%); width: 680px; }
+.when-subtabs { display: flex; gap: 0; margin-bottom: 16px; border: 1px solid var(--gray-300); border-radius: var(--radius-full); overflow: hidden; width: fit-content; margin-left: auto; margin-right: auto; }
+.when-subtab {
+  padding: 8px 20px; font-size: 13px; font-weight: 500; cursor: pointer;
+  background: var(--white); color: var(--gray-700);
+  transition: background var(--transition), color var(--transition);
+}
+.when-subtab.active { background: var(--black); color: var(--white); }
+.when-subtab:not(:last-child) { border-right: 1px solid var(--gray-300); }
+
+.calendar-wrap { display: flex; gap: 24px; }
+.cal-month { flex: 1; }
+.cal-header {
+  display: flex; align-items: center; justify-content: center;
+  margin-bottom: 12px; position: relative;
+}
+.cal-header .cal-title { font-size: 15px; font-weight: 600; }
+.cal-nav {
+  position: absolute; width: 32px; height: 32px;
+  display: flex; align-items: center; justify-content: center;
+  border-radius: 50%; border: 1px solid var(--gray-300);
+  background: var(--white); cursor: pointer; font-size: 14px;
+  transition: background var(--transition);
+}
+.cal-nav:hover { background: var(--gray-100); }
+.cal-nav.prev { left: 0; }
+.cal-nav.next { right: 0; }
+
+.cal-grid { display: grid; grid-template-columns: repeat(7, 1fr); text-align: center; }
+.cal-dow { font-size: 11px; font-weight: 600; color: var(--gray-500); padding: 4px 0; }
+.cal-day {
+  width: 100%; aspect-ratio: 1; display: flex; align-items: center; justify-content: center;
+  font-size: 13px; cursor: pointer; border-radius: 50%;
+  transition: background var(--transition), color var(--transition);
+  position: relative;
+}
+.cal-day:hover:not(.disabled):not(.empty) { background: var(--gray-100); }
+.cal-day.empty { cursor: default; }
+.cal-day.disabled { color: var(--gray-400); cursor: not-allowed; text-decoration: line-through; }
+.cal-day.selected { background: var(--brand); color: var(--white); font-weight: 600; }
+.cal-day.in-range { background: var(--brand-light); border-radius: 0; }
+.cal-day.range-start { border-radius: 50% 0 0 50%; background: var(--brand); color: var(--white); font-weight: 600; }
+.cal-day.range-end { border-radius: 0 50% 50% 0; background: var(--brand); color: var(--white); font-weight: 600; }
+.cal-day.range-hover { background: var(--brand-light); border-radius: 0; }
+.cal-day.range-hover-end { border-radius: 0 50% 50% 0; background: var(--brand-light); }
+
+/* who / guest steppers */
+.popover-who { right: 0; left: auto; transform: none; width: 380px; }
+.guest-row {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 16px 0; border-bottom: 1px solid var(--gray-200);
+}
+.guest-row:last-child { border-bottom: none; }
+.guest-info .guest-type { font-size: 15px; font-weight: 500; }
+.guest-info .guest-desc { font-size: 13px; color: var(--gray-500); }
+.stepper { display: flex; align-items: center; gap: 12px; }
+.stepper-btn {
+  width: 32px; height: 32px; border-radius: 50%;
+  border: 1px solid var(--gray-400);
+  display: flex; align-items: center; justify-content: center;
+  font-size: 18px; color: var(--gray-700);
+  transition: border-color var(--transition), color var(--transition);
+}
+.stepper-btn:hover:not(:disabled) { border-color: var(--black); color: var(--black); }
+.stepper-btn:disabled { border-color: var(--gray-200); color: var(--gray-300); cursor: not-allowed; }
+.stepper-count { width: 24px; text-align: center; font-size: 15px; font-weight: 500; }
+
+/* ===== HOMEPAGE PLACEHOLDER ===== */
+.homepage-content {
+  max-width: 1760px; margin: 0 auto; padding: 24px;
+}
+.home-heading { font-size: 28px; font-weight: 700; margin-bottom: 20px; }
+.home-cards { display: grid; grid-template-columns: repeat(4, 1fr); gap: 24px; }
+.home-card {
+  border-radius: var(--radius-md); overflow: hidden; cursor: pointer;
+  transition: transform var(--transition);
+}
+.home-card:hover { transform: translateY(-2px); }
+.home-card-img {
+  width: 100%; aspect-ratio: 4/3; border-radius: var(--radius-md);
+  object-fit: cover; display: block; background: #f0f0f0;
+}
+.home-card-title { font-size: 14px; font-weight: 600; margin-top: 8px; }
+.home-card-sub { font-size: 13px; color: var(--gray-500); }
+
+/* ===== SEARCH RESULTS VIEW ===== */
+.results-view { display: none; }
+.results-view.active { display: flex; }
+
+.results-layout {
+  display: flex; width: 100%; max-width: 1760px; margin: 0 auto;
+  height: calc(100vh - 140px);
+}
+
+/* filter bar */
+.filter-bar {
+  display: flex; align-items: center; gap: 8px;
+  padding: 12px 24px;
+  border-bottom: 1px solid var(--gray-200);
+  max-width: 1760px; margin: 0 auto;
+}
+.filter-pill {
+  padding: 8px 16px; border: 1px solid var(--gray-300);
+  border-radius: var(--radius-full); font-size: 13px; font-weight: 500;
+  cursor: pointer; white-space: nowrap;
+  transition: background var(--transition), border-color var(--transition);
+}
+.filter-pill:hover { border-color: var(--black); }
+.filter-pill.active { background: var(--black); color: var(--white); border-color: var(--black); }
+
+/* listings */
+.listings-col {
+  flex: 0 0 60%; padding: 24px; overflow-y: auto;
+}
+.listings-header { font-size: 14px; color: var(--gray-500); margin-bottom: 16px; }
+.listings-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 24px; }
+
+.listing-card {
+  border-radius: var(--radius-md); cursor: pointer;
+  transition: transform var(--transition);
+}
+.listing-card:hover { transform: translateY(-2px); }
+.listing-card-img-wrap {
+  position: relative; border-radius: var(--radius-md); overflow: hidden;
+  aspect-ratio: 4/3;
+}
+.listing-card-img {
+  width: 100%; height: 100%;
+  background-size: cover; background-position: center; background-repeat: no-repeat;
+  background-color: #f0f0f0;
+  transition: background-image var(--transition);
+}
+.listing-card-fav {
+  position: absolute; top: 10px; right: 10px;
+  width: 28px; height: 28px; display: flex; align-items: center; justify-content: center;
+  font-size: 18px; cursor: pointer; color: var(--white);
+  text-shadow: 0 1px 3px rgba(0,0,0,.4);
+  transition: transform var(--transition);
+}
+.listing-card-fav:hover { transform: scale(1.15); }
+.listing-card-fav.liked { color: var(--brand); }
+
+.carousel-dots {
+  position: absolute; bottom: 8px; left: 50%; transform: translateX(-50%);
+  display: flex; gap: 4px;
+}
+.carousel-dot {
+  width: 6px; height: 6px; border-radius: 50%; background: rgba(255,255,255,.5);
+  transition: background var(--transition);
+}
+.carousel-dot.active { background: var(--white); }
+.carousel-arrow {
+  position: absolute; top: 50%; transform: translateY(-50%);
+  width: 28px; height: 28px; border-radius: 50%;
+  background: rgba(255,255,255,.9); display: flex; align-items: center; justify-content: center;
+  font-size: 12px; cursor: pointer; opacity: 0;
+  transition: opacity var(--transition);
+  box-shadow: var(--shadow-sm);
+}
+.listing-card-img-wrap:hover .carousel-arrow { opacity: 1; }
+.carousel-arrow.left { left: 8px; }
+.carousel-arrow.right { right: 8px; }
+
+.listing-card-info { padding: 8px 0; }
+.listing-card-top { display: flex; justify-content: space-between; align-items: center; }
+.listing-card-title { font-size: 14px; font-weight: 600; }
+.listing-card-rating { font-size: 13px; font-weight: 500; }
+.listing-card-type { font-size: 13px; color: var(--gray-500); }
+.listing-card-price { font-size: 14px; margin-top: 2px; }
+.listing-card-price span { font-weight: 600; }
+
+/* map col */
+.map-col {
+  flex: 0 0 40%; position: sticky; top: 0; height: calc(100vh - 140px);
+  background: var(--gray-100); border-left: 1px solid var(--gray-200);
+  overflow: hidden;
+}
+.map-col svg { width: 100%; height: 100%; }
+.map-pin {
+  cursor: pointer; transition: transform .15s;
+}
+.map-pin:hover, .map-pin.highlight {
+  transform: scale(1.25);
+}
+.map-pin text { font-size: 10px; font-weight: 600; fill: var(--white); pointer-events: none; }
+.map-pin rect { fill: var(--black); rx: 12; transition: fill .15s; }
+.map-pin.highlight rect { fill: var(--brand); }
+
+/* ===== FILTER MODAL ===== */
+.filter-modal-overlay {
+  display: none; position: fixed; inset: 0; z-index: 500;
+  background: rgba(0,0,0,.4);
+  align-items: flex-end; justify-content: center;
+}
+.filter-modal-overlay.open { display: flex; }
+.filter-modal {
+  background: var(--white); border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+  width: 100%; max-width: 780px; max-height: 90vh; overflow-y: auto;
+  animation: slideUp .25s ease;
+  display: flex; flex-direction: column;
+}
+@keyframes slideUp { from { transform: translateY(100%); } to { transform: translateY(0); } }
+.filter-modal-header {
+  display: flex; align-items: center; justify-content: center;
+  padding: 16px 24px; border-bottom: 1px solid var(--gray-200); position: relative;
+  font-size: 15px; font-weight: 600;
+}
+.filter-modal-close {
+  position: absolute; left: 16px; width: 32px; height: 32px;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 18px; border-radius: 50%; cursor: pointer;
+  transition: background var(--transition);
+}
+.filter-modal-close:hover { background: var(--gray-100); }
+
+.filter-modal-body { padding: 24px; flex: 1; overflow-y: auto; }
+.filter-section { margin-bottom: 32px; }
+.filter-section-title { font-size: 18px; font-weight: 600; margin-bottom: 16px; }
+
+/* price slider */
+.price-slider-wrap { padding: 0 8px; }
+.price-labels { display: flex; justify-content: space-between; font-size: 14px; font-weight: 500; margin-bottom: 12px; }
+.price-slider {
+  position: relative; height: 40px; user-select: none;
+}
+.price-track {
+  position: absolute; top: 18px; left: 0; right: 0; height: 4px;
+  background: var(--gray-200); border-radius: 2px;
+}
+.price-fill {
+  position: absolute; top: 18px; height: 4px;
+  background: var(--brand); border-radius: 2px;
+}
+.price-handle {
+  position: absolute; top: 12px; width: 24px; height: 24px;
+  background: var(--white); border: 2px solid var(--brand);
+  border-radius: 50%; cursor: grab; z-index: 2;
+  transition: box-shadow var(--transition);
+  transform: translateX(-50%);
+}
+.price-handle:hover { box-shadow: 0 0 0 6px rgba(255,56,92,.15); }
+.price-handle.dragging { cursor: grabbing; box-shadow: 0 0 0 8px rgba(255,56,92,.2); }
+.price-handle-label {
+  position: absolute; bottom: 30px; left: 50%; transform: translateX(-50%);
+  background: var(--black); color: var(--white); font-size: 12px; font-weight: 600;
+  padding: 2px 8px; border-radius: 4px; white-space: nowrap;
+  pointer-events: none; opacity: 0; transition: opacity .15s;
+}
+.price-handle:hover .price-handle-label, .price-handle.dragging .price-handle-label { opacity: 1; }
+
+/* property type chips */
+.type-chips { display: flex; gap: 12px; flex-wrap: wrap; }
+.type-chip {
+  padding: 12px 20px; border: 1px solid var(--gray-300); border-radius: var(--radius-md);
+  font-size: 14px; font-weight: 500; cursor: pointer;
+  transition: border-color var(--transition), background var(--transition);
+}
+.type-chip:hover { border-color: var(--black); }
+.type-chip.active { background: var(--gray-100); border-color: var(--black); }
+
+/* amenity checkboxes */
+.amenity-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 12px; }
+.amenity-check {
+  display: flex; align-items: center; gap: 10px;
+  font-size: 14px; cursor: pointer; padding: 8px;
+  border-radius: var(--radius-sm);
+  transition: background var(--transition);
+}
+.amenity-check:hover { background: var(--gray-100); }
+.amenity-check input[type="checkbox"] {
+  width: 20px; height: 20px; accent-color: var(--brand);
+  cursor: pointer;
+}
+
+/* instant book toggle */
+.instant-book-row {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 16px 0; border-top: 1px solid var(--gray-200);
+}
+.toggle-switch {
+  position: relative; width: 48px; height: 28px; cursor: pointer;
+}
+.toggle-switch input { display: none; }
+.toggle-track {
+  position: absolute; inset: 0; background: var(--gray-300);
+  border-radius: 14px; transition: background var(--transition);
+}
+.toggle-switch input:checked + .toggle-track { background: var(--brand); }
+.toggle-knob {
+  position: absolute; top: 2px; left: 2px; width: 24px; height: 24px;
+  background: var(--white); border-radius: 50%; box-shadow: var(--shadow-sm);
+  transition: transform var(--transition);
+}
+.toggle-switch input:checked ~ .toggle-knob { transform: translateX(20px); }
+
+.filter-modal-footer {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 16px 24px; border-top: 1px solid var(--gray-200);
+}
+.filter-clear { font-size: 14px; font-weight: 600; text-decoration: underline; cursor: pointer; }
+.filter-apply-btn {
+  padding: 12px 24px; background: var(--black); color: var(--white);
+  border-radius: var(--radius-sm); font-size: 15px; font-weight: 600;
+  transition: background var(--transition);
+}
+.filter-apply-btn:hover { background: var(--gray-900); }
+
+/* ===== LISTING DETAIL VIEW ===== */
+.detail-view { display: none; max-width: 1120px; margin: 0 auto; padding: 24px; }
+.detail-view.active { display: block; }
+
+.detail-back {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-size: 14px; font-weight: 500; margin-bottom: 16px;
+  cursor: pointer; padding: 6px 12px; border-radius: var(--radius-full);
+  transition: background var(--transition);
+}
+.detail-back:hover { background: var(--gray-100); }
+
+/* photo grid */
+.photo-grid {
+  display: grid; grid-template-columns: 1fr 1fr; gap: 8px;
+  border-radius: var(--radius-md); overflow: hidden;
+  position: relative; margin-bottom: 32px;
+}
+.photo-main { grid-row: span 2; min-height: 400px; cursor: pointer; background-size: cover; background-position: center; background-color: #f0f0f0; }
+.photo-small { min-height: 196px; cursor: pointer; background-size: cover; background-position: center; background-color: #f0f0f0; }
+.photo-grid .show-all-btn {
+  position: absolute; bottom: 16px; right: 16px;
+  padding: 8px 16px; background: var(--white); border: 1px solid var(--black);
+  border-radius: var(--radius-sm); font-size: 13px; font-weight: 600;
+  cursor: pointer; transition: background var(--transition);
+}
+.photo-grid .show-all-btn:hover { background: var(--gray-100); }
+
+/* detail body */
+.detail-body { display: flex; gap: 48px; }
+.detail-main { flex: 1; }
+.detail-sidebar { flex: 0 0 360px; }
+
+.detail-title { font-size: 26px; font-weight: 700; margin-bottom: 4px; }
+.detail-subtitle { font-size: 15px; color: var(--gray-700); margin-bottom: 16px; }
+
+.detail-host {
+  display: flex; align-items: center; gap: 12px;
+  padding: 24px 0; border-top: 1px solid var(--gray-200); border-bottom: 1px solid var(--gray-200);
+}
+.detail-host-avatar {
+  width: 48px; height: 48px; border-radius: 50%; background: var(--gray-400);
+  display: flex; align-items: center; justify-content: center;
+  color: var(--white); font-size: 20px; font-weight: 600;
+}
+.detail-host-name { font-size: 15px; font-weight: 600; }
+.detail-host-tenure { font-size: 13px; color: var(--gray-500); }
+
+.detail-amenities { padding: 24px 0; border-bottom: 1px solid var(--gray-200); }
+.detail-amenities h3 { font-size: 20px; font-weight: 600; margin-bottom: 16px; }
+.amenities-list { display: grid; grid-template-columns: repeat(2, 1fr); gap: 12px; }
+.amenity-item { display: flex; align-items: center; gap: 10px; font-size: 14px; }
+.amenity-icon { font-size: 20px; }
+
+/* reviews */
+.detail-reviews { padding: 24px 0; border-bottom: 1px solid var(--gray-200); }
+.detail-reviews h3 { font-size: 20px; font-weight: 600; margin-bottom: 16px; }
+.review-card { margin-bottom: 20px; }
+.review-header { display: flex; align-items: center; gap: 10px; margin-bottom: 8px; }
+.review-avatar {
+  width: 40px; height: 40px; border-radius: 50%; background: var(--gray-300);
+  display: flex; align-items: center; justify-content: center;
+  font-size: 16px; font-weight: 600; color: var(--white);
+}
+.review-name { font-size: 14px; font-weight: 600; }
+.review-date { font-size: 12px; color: var(--gray-500); }
+.review-text { font-size: 14px; color: var(--gray-700); line-height: 1.6; }
+
+/* booking card */
+.booking-card {
+  position: sticky; top: 100px;
+  border: 1px solid var(--gray-200); border-radius: var(--radius-md);
+  padding: 24px; box-shadow: var(--shadow-md);
+}
+.booking-price { font-size: 20px; font-weight: 700; margin-bottom: 16px; }
+.booking-price .per-night { font-size: 14px; font-weight: 400; color: var(--gray-500); }
+.booking-dates {
+  display: grid; grid-template-columns: 1fr 1fr;
+  border: 1px solid var(--gray-300); border-radius: var(--radius-sm);
+  overflow: hidden; margin-bottom: 12px;
+}
+.booking-date-field {
+  padding: 10px 12px; font-size: 12px;
+}
+.booking-date-field:first-child { border-right: 1px solid var(--gray-300); }
+.booking-date-field label { display: block; font-weight: 700; font-size: 10px; text-transform: uppercase; letter-spacing: .5px; margin-bottom: 2px; }
+.booking-date-field span { font-size: 13px; color: var(--gray-700); }
+.booking-guests {
+  border: 1px solid var(--gray-300); border-radius: var(--radius-sm);
+  padding: 10px 12px; margin-bottom: 16px;
+}
+.booking-guests label { display: block; font-weight: 700; font-size: 10px; text-transform: uppercase; letter-spacing: .5px; margin-bottom: 2px; }
+.booking-guests span { font-size: 13px; }
+
+.reserve-btn {
+  width: 100%; padding: 14px; background: var(--brand); color: var(--white);
+  border-radius: var(--radius-sm); font-size: 16px; font-weight: 600;
+  text-align: center; cursor: pointer;
+  transition: background var(--transition);
+}
+.reserve-btn:hover { background: var(--brand-hover); }
+
+.price-breakdown { margin-top: 16px; }
+.price-row { display: flex; justify-content: space-between; font-size: 14px; padding: 4px 0; }
+.price-row.total { font-weight: 700; border-top: 1px solid var(--gray-200); padding-top: 12px; margin-top: 8px; }
+
+/* confirmation panel */
+.confirm-panel { display: none; margin-top: 20px; padding: 20px; border: 1px solid var(--gray-200); border-radius: var(--radius-md); background: var(--gray-100); }
+.confirm-panel.open { display: block; animation: popIn .2s ease; }
+.confirm-panel h4 { font-size: 16px; font-weight: 700; margin-bottom: 12px; }
+.confirm-btn {
+  width: 100%; padding: 14px; background: var(--brand); color: var(--white);
+  border-radius: var(--radius-sm); font-size: 16px; font-weight: 600;
+  text-align: center; cursor: pointer; margin-top: 12px;
+  transition: background var(--transition);
+}
+.confirm-btn:hover { background: var(--brand-hover); }
+.confirm-success { display: none; text-align: center; padding: 20px; font-size: 18px; font-weight: 600; color: #00a86b; }
+.confirm-success.show { display: block; }
+
+/* ===== GALLERY OVERLAY ===== */
+.gallery-overlay {
+  display: none; position: fixed; inset: 0; z-index: 600;
+  background: rgba(0,0,0,.92); overflow-y: auto;
+  padding: 40px 20px;
+}
+.gallery-overlay.open { display: block; }
+.gallery-close {
+  position: fixed; top: 16px; left: 16px; z-index: 601;
+  width: 36px; height: 36px; border-radius: 50%;
+  background: rgba(255,255,255,.15); color: var(--white);
+  display: flex; align-items: center; justify-content: center;
+  font-size: 20px; cursor: pointer;
+  transition: background var(--transition);
+}
+.gallery-close:hover { background: rgba(255,255,255,.3); }
+.gallery-grid {
+  max-width: 800px; margin: 0 auto;
+  display: flex; flex-direction: column; gap: 12px;
+}
+.gallery-img {
+  width: 100%; aspect-ratio: 16/9; border-radius: var(--radius-sm);
+  background-size: cover; background-position: center; background-repeat: no-repeat;
+  background-color: #f0f0f0;
+}
+
+/* ===== UTILITY ===== */
+.hidden { display: none !important; }
+.view { display: none; }
+.view.active { display: block; }
+
+/* popover backdrop click area */
+.popover-backdrop {
+  display: none; position: fixed; inset: 0; z-index: 150;
+}
+.popover-backdrop.open { display: block; }

--- a/eval/staybnb/index.html
+++ b/eval/staybnb/index.html
@@ -1,0 +1,395 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>StayBnB — Vacation Rentals, Homes, Experiences & Places</title>
+  <link rel="stylesheet" href="/staybnb/css/staybnb.css">
+</head>
+<body>
+
+<!-- ===== POPOVER BACKDROP ===== -->
+<div id="popover-backdrop" class="popover-backdrop"></div>
+
+<!-- ===== TOP BAR ===== -->
+<header class="topbar">
+  <div class="topbar-inner">
+
+    <!-- Logo -->
+    <div class="logo" id="logo">
+      <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><path d="M16 2C8.268 2 2 8.268 2 16s6.268 14 14 14 14-6.268 14-14S23.732 2 16 2zm0 5a3 3 0 110 6 3 3 0 010-6zm6.5 14.17c-.98 2.29-3.33 3.83-6.5 3.83s-5.52-1.54-6.5-3.83A1 1 0 0110.42 20h11.16a1 1 0 01.92 1.17z"/></svg>
+      StayBnB
+    </div>
+
+    <!-- Search Pill -->
+    <div class="search-pill-wrap">
+      <div class="search-pill">
+        <div class="search-pill-seg" data-seg="where">
+          <span class="seg-label">Where</span>
+          <span class="seg-value" id="seg-where-val">Search</span>
+        </div>
+        <div class="search-pill-seg" data-seg="when">
+          <span class="seg-label">When</span>
+          <span class="seg-value" id="seg-when-val">Add dates</span>
+        </div>
+        <div class="search-pill-seg" data-seg="who" style="border-right:none">
+          <span class="seg-label">Who</span>
+          <span class="seg-value" id="seg-who-val">1 guest</span>
+        </div>
+        <button class="search-btn" id="search-btn">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="11" cy="11" r="7"/>
+            <line x1="16.5" y1="16.5" x2="21" y2="21"/>
+          </svg>
+        </button>
+      </div>
+
+      <!-- Popover anchor -->
+      <div class="popover-anchor">
+
+        <!-- WHERE Popover -->
+        <div class="popover popover-where">
+          <input type="text" class="where-input" id="where-input" placeholder="Search destinations">
+          <div class="autocomplete-list" id="autocomplete-list"></div>
+          <div class="region-label">I'm flexible</div>
+          <div class="region-grid">
+            <div class="region-card">Asia</div>
+            <div class="region-card">Europe</div>
+            <div class="region-card">North America</div>
+            <div class="region-card">South America</div>
+            <div class="region-card">Africa</div>
+            <div class="region-card">Oceania</div>
+          </div>
+        </div>
+
+        <!-- WHEN Popover -->
+        <div class="popover popover-when" id="when-popover">
+          <div class="when-subtabs">
+            <div class="when-subtab active">Dates</div>
+            <div class="when-subtab">Flexible</div>
+            <div class="when-subtab">Months</div>
+          </div>
+          <div class="calendar-wrap" id="calendar-wrap"></div>
+        </div>
+
+        <!-- WHO Popover -->
+        <div class="popover popover-who" id="who-popover">
+          <div id="guest-rows"></div>
+        </div>
+
+      </div>
+    </div>
+
+    <!-- User Area -->
+    <div class="user-area">
+      <a href="#" class="host-link">Become a Host</a>
+      <svg class="globe-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="12" cy="12" r="10"/><path d="M2 12h20M12 2a15.3 15.3 0 014 10 15.3 15.3 0 01-4 10 15.3 15.3 0 01-4-10A15.3 15.3 0 0112 2z"/></svg>
+      <button class="user-menu-btn">
+        <span class="hamburger"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg></span>
+        <div class="user-avatar">U</div>
+      </button>
+    </div>
+  </div>
+</header>
+
+<!-- Category Tabs -->
+<div class="category-tabs" id="category-tabs">
+  <div class="cat-tab active">&#127968; Homes</div>
+  <div class="cat-tab">&#127775; Experiences</div>
+</div>
+
+<!-- ===== FILTER BAR (results only) ===== -->
+<div class="filter-bar" id="filter-bar" style="display:none">
+  <button class="filter-pill">Price</button>
+  <button class="filter-pill">Type of place</button>
+  <button class="filter-pill">Rooms and beds</button>
+  <button class="filter-pill" id="filter-btn" style="font-weight:600">&#9776; Filters</button>
+</div>
+
+<!-- ===== VIEW: HOME ===== -->
+<div id="view-home" class="view active">
+  <div class="homepage-content">
+    <h2 class="home-heading">Explore nearby</h2>
+    <div class="home-cards">
+      <div class="home-card">
+        <img class="home-card-img" src="https://picsum.photos/seed/staybnb-tokyo/480/360" alt="Tokyo" loading="lazy">
+        <div class="home-card-title">Tokyo</div>
+        <div class="home-card-sub">15 minute drive</div>
+      </div>
+      <div class="home-card">
+        <img class="home-card-img" src="https://picsum.photos/seed/staybnb-yokohama/480/360" alt="Yokohama" loading="lazy">
+        <div class="home-card-title">Yokohama</div>
+        <div class="home-card-sub">30 minute drive</div>
+      </div>
+      <div class="home-card">
+        <img class="home-card-img" src="https://picsum.photos/seed/staybnb-kamakura/480/360" alt="Kamakura" loading="lazy">
+        <div class="home-card-title">Kamakura</div>
+        <div class="home-card-sub">45 minute drive</div>
+      </div>
+      <div class="home-card">
+        <img class="home-card-img" src="https://picsum.photos/seed/staybnb-hakone/480/360" alt="Hakone" loading="lazy">
+        <div class="home-card-title">Hakone</div>
+        <div class="home-card-sub">1 hour drive</div>
+      </div>
+      <div class="home-card">
+        <img class="home-card-img" src="https://picsum.photos/seed/staybnb-nikko/480/360" alt="Nikko" loading="lazy">
+        <div class="home-card-title">Nikko</div>
+        <div class="home-card-sub">2 hour drive</div>
+      </div>
+      <div class="home-card">
+        <img class="home-card-img" src="https://picsum.photos/seed/staybnb-kawaguchiko/480/360" alt="Kawaguchiko" loading="lazy">
+        <div class="home-card-title">Kawaguchiko</div>
+        <div class="home-card-sub">1.5 hour drive</div>
+      </div>
+      <div class="home-card">
+        <img class="home-card-img" src="https://picsum.photos/seed/staybnb-chiba/480/360" alt="Chiba" loading="lazy">
+        <div class="home-card-title">Chiba</div>
+        <div class="home-card-sub">40 minute drive</div>
+      </div>
+      <div class="home-card">
+        <img class="home-card-img" src="https://picsum.photos/seed/staybnb-enoshima/480/360" alt="Enoshima" loading="lazy">
+        <div class="home-card-title">Enoshima</div>
+        <div class="home-card-sub">50 minute drive</div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- ===== VIEW: RESULTS ===== -->
+<div id="view-results" class="view">
+  <div class="results-layout">
+    <!-- Listings column -->
+    <div class="listings-col">
+      <div class="listings-header" id="listings-header">20+ stays</div>
+      <div class="listings-grid" id="listings-grid"></div>
+    </div>
+    <!-- Map column -->
+    <div class="map-col">
+      <svg id="map-svg" xmlns="http://www.w3.org/2000/svg"></svg>
+    </div>
+  </div>
+</div>
+
+<!-- ===== VIEW: DETAIL ===== -->
+<div id="view-detail" class="view">
+  <div class="detail-back" id="detail-back">&#8592; Back to results</div>
+
+  <!-- Photo grid -->
+  <div class="photo-grid">
+    <div class="photo-main" style="background:#5B8FB9"></div>
+    <div class="photo-small" style="background:#FFD1DC"></div>
+    <div class="photo-small" style="background:#D4F1F4"></div>
+    <div class="photo-small" style="background:#E8D5B7"></div>
+    <div class="photo-small" style="background:#D5E8D4"></div>
+    <button class="show-all-btn" id="show-all-photos">&#9783; Show all photos</button>
+  </div>
+
+  <!-- Detail body -->
+  <div class="detail-body">
+    <div class="detail-main">
+      <h1 class="detail-title">Listing Title</h1>
+      <p class="detail-subtitle">Entire apartment · Shibuya, Tokyo</p>
+
+      <div class="detail-host">
+        <div class="detail-host-avatar">Y</div>
+        <div>
+          <div class="detail-host-name">Hosted by Yuki</div>
+          <div class="detail-host-tenure">Superhost · 4 years hosting</div>
+        </div>
+      </div>
+
+      <!-- Amenities -->
+      <div class="detail-amenities">
+        <h3>What this place offers</h3>
+        <div class="amenities-list">
+          <div class="amenity-item"><span class="amenity-icon">&#128246;</span> Wifi</div>
+          <div class="amenity-item"><span class="amenity-icon">&#127859;</span> Kitchen</div>
+          <div class="amenity-item"><span class="amenity-icon">&#128663;</span> Free parking</div>
+          <div class="amenity-item"><span class="amenity-icon">&#10052;</span> Air conditioning</div>
+          <div class="amenity-item"><span class="amenity-icon">&#128250;</span> TV</div>
+          <div class="amenity-item"><span class="amenity-icon">&#129529;</span> Washer</div>
+          <div class="amenity-item"><span class="amenity-icon">&#128187;</span> Dedicated workspace</div>
+          <div class="amenity-item"><span class="amenity-icon">&#9832;</span> Heating</div>
+        </div>
+      </div>
+
+      <!-- Reviews -->
+      <div class="detail-reviews">
+        <h3>&#9733; 4.92 · 128 reviews</h3>
+        <div class="review-card">
+          <div class="review-header">
+            <div class="review-avatar" style="background:#5B8FB9">A</div>
+            <div>
+              <div class="review-name">Alex</div>
+              <div class="review-date">March 2026</div>
+            </div>
+          </div>
+          <div class="review-text">Amazing location with a stunning view of the Tokyo skyline. The host was incredibly responsive and the apartment was spotlessly clean. Would definitely stay again!</div>
+        </div>
+        <div class="review-card">
+          <div class="review-header">
+            <div class="review-avatar" style="background:#9B72AA">S</div>
+            <div>
+              <div class="review-name">Sarah</div>
+              <div class="review-date">February 2026</div>
+            </div>
+          </div>
+          <div class="review-text">Perfect for exploring Tokyo. Walking distance to the station and so many great restaurants nearby. The apartment had everything we needed.</div>
+        </div>
+        <div class="review-card">
+          <div class="review-header">
+            <div class="review-avatar" style="background:#D4A574">M</div>
+            <div>
+              <div class="review-name">Marco</div>
+              <div class="review-date">January 2026</div>
+            </div>
+          </div>
+          <div class="review-text">Great value for the area. Modern, well-equipped, and the neighborhood is fantastic. Yuki was a wonderful host who went above and beyond.</div>
+        </div>
+        <div class="review-card">
+          <div class="review-header">
+            <div class="review-avatar" style="background:#7EC8E3">L</div>
+            <div>
+              <div class="review-name">Lisa</div>
+              <div class="review-date">December 2025</div>
+            </div>
+          </div>
+          <div class="review-text">Exactly as described. Beautiful apartment with all the amenities you need. The check-in process was seamless. Highly recommended!</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Booking card -->
+    <div class="detail-sidebar">
+      <div class="booking-card">
+        <div class="booking-price">
+          <span class="booking-price-val">¥18,500</span>
+          <span class="per-night"> / night</span>
+        </div>
+        <div class="booking-dates">
+          <div class="booking-date-field">
+            <label>CHECK-IN</label>
+            <span id="booking-checkin">Add date</span>
+          </div>
+          <div class="booking-date-field">
+            <label>CHECKOUT</label>
+            <span id="booking-checkout">Add date</span>
+          </div>
+        </div>
+        <div class="booking-guests">
+          <label>GUESTS</label>
+          <span id="booking-guests-val">1 guest</span>
+        </div>
+        <button class="reserve-btn" id="reserve-btn">Reserve</button>
+        <div class="price-breakdown">
+          <div class="price-row"><span id="pb-nights">¥18,500 × 1 night</span><span id="pb-subtotal">¥18,500</span></div>
+          <div class="price-row"><span>Cleaning fee</span><span id="pb-cleaning">¥5,000</span></div>
+          <div class="price-row"><span>Service fee</span><span id="pb-service">¥2,220</span></div>
+          <div class="price-row total"><span>Total</span><span id="pb-total">¥25,720</span></div>
+        </div>
+
+        <!-- Confirmation Panel -->
+        <div class="confirm-panel">
+          <h4>Confirm your booking</h4>
+          <p style="font-size:14px;color:var(--gray-700);margin-bottom:8px">Review the details above and confirm to complete your reservation.</p>
+          <button class="confirm-btn" id="confirm-btn">Confirm and pay</button>
+          <div class="confirm-success">&#10003; Booking confirmed! See you in Tokyo.</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- ===== FILTER MODAL ===== -->
+<div class="filter-modal-overlay" id="filter-modal">
+  <div class="filter-modal">
+    <div class="filter-modal-header">
+      <button class="filter-modal-close" id="filter-modal-close">&#10005;</button>
+      Filters
+    </div>
+    <div class="filter-modal-body">
+
+      <!-- Price Range -->
+      <div class="filter-section">
+        <div class="filter-section-title">Price range</div>
+        <div class="price-labels">
+          <span id="price-display-min">$10</span>
+          <span id="price-display-max">$500</span>
+        </div>
+        <div class="price-slider-wrap">
+          <div class="price-slider">
+            <div class="price-track" id="price-track"></div>
+            <div class="price-fill" id="price-fill"></div>
+            <div class="price-handle" id="price-handle-min" style="left:0%">
+              <div class="price-handle-label" id="price-label-min">$10</div>
+            </div>
+            <div class="price-handle" id="price-handle-max" style="left:100%">
+              <div class="price-handle-label" id="price-label-max">$500</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Property Type -->
+      <div class="filter-section">
+        <div class="filter-section-title">Type of place</div>
+        <div class="type-chips">
+          <button class="type-chip" data-type="Entire place">Entire place</button>
+          <button class="type-chip" data-type="Private room">Private room</button>
+          <button class="type-chip" data-type="Shared room">Shared room</button>
+        </div>
+      </div>
+
+      <!-- Amenities -->
+      <div class="filter-section">
+        <div class="filter-section-title">Amenities</div>
+        <div class="amenity-grid">
+          <label class="amenity-check"><input type="checkbox" data-amenity="Wifi"> Wifi</label>
+          <label class="amenity-check"><input type="checkbox" data-amenity="Kitchen"> Kitchen</label>
+          <label class="amenity-check"><input type="checkbox" data-amenity="Washer"> Washer</label>
+          <label class="amenity-check"><input type="checkbox" data-amenity="Air conditioning"> Air conditioning</label>
+          <label class="amenity-check"><input type="checkbox" data-amenity="Heating"> Heating</label>
+          <label class="amenity-check"><input type="checkbox" data-amenity="TV"> TV</label>
+          <label class="amenity-check"><input type="checkbox" data-amenity="Iron"> Iron</label>
+          <label class="amenity-check"><input type="checkbox" data-amenity="Hair dryer"> Hair dryer</label>
+          <label class="amenity-check"><input type="checkbox" data-amenity="Workspace"> Workspace</label>
+          <label class="amenity-check"><input type="checkbox" data-amenity="Pool"> Pool</label>
+          <label class="amenity-check"><input type="checkbox" data-amenity="Hot tub"> Hot tub</label>
+          <label class="amenity-check"><input type="checkbox" data-amenity="Free parking"> Free parking</label>
+        </div>
+      </div>
+
+      <!-- Instant Book -->
+      <div class="filter-section">
+        <div class="instant-book-row">
+          <div>
+            <div style="font-size:15px;font-weight:500">Instant Book</div>
+            <div style="font-size:13px;color:var(--gray-500)">Listings you can book without waiting for host approval</div>
+          </div>
+          <label class="toggle-switch">
+            <input type="checkbox" id="instant-book-toggle">
+            <div class="toggle-track"></div>
+            <div class="toggle-knob"></div>
+          </label>
+        </div>
+      </div>
+
+    </div>
+    <div class="filter-modal-footer">
+      <button class="filter-clear">Clear all</button>
+      <button class="filter-apply-btn" id="filter-apply-btn">Show 22 stays</button>
+    </div>
+  </div>
+</div>
+
+<!-- ===== GALLERY OVERLAY ===== -->
+<div class="gallery-overlay" id="gallery-overlay">
+  <button class="gallery-close" id="gallery-close-btn">&#10005;</button>
+  <div class="gallery-grid"></div>
+</div>
+
+<!-- Scripts -->
+<script src="/js/tracker.js"></script>
+<script src="/staybnb/js/staybnb.js"></script>
+</body>
+</html>

--- a/eval/staybnb/js/staybnb.js
+++ b/eval/staybnb/js/staybnb.js
@@ -1,0 +1,847 @@
+/* StayBnB — Airbnb-like mock site JS */
+(function () {
+  'use strict';
+
+  // ── Tracker ──────────────────────────────────────────────
+  const tracker = new AgentTracker('staybnb.com', 'hard');
+  window.tracker = tracker;
+
+  // ── State ────────────────────────────────────────────────
+  const state = {
+    view: 'home',        // home | results | detail
+    where: '',
+    checkin: null,        // Date
+    checkout: null,       // Date
+    adults: 1,
+    children: 0,
+    infants: 0,
+    pets: 0,
+    activePopover: null,  // 'where' | 'when' | 'who' | null
+    calMonth: new Date(2026, 3, 1), // April 2026
+    hoverDate: null,
+    currentListing: null,
+    // filter state
+    priceMin: 10,
+    priceMax: 500,
+    propertyTypes: [],
+    amenities: [],
+    instantBook: false
+  };
+
+  // ── Listings data ────────────────────────────────────────
+  const LISTINGS = [
+    { id:'shibuya-loft', title:'Shibuya Loft with Skyline View', type:'Entire apartment', area:'Shibuya', priceJPY:18500, priceUSD:125, rating:4.92, color:'#5B8FB9' },
+    { id:'shinjuku-studio', title:'Shinjuku Cozy Studio', type:'Entire apartment', area:'Shinjuku', priceJPY:12000, priceUSD:80, rating:4.85, color:'#9B72AA' },
+    { id:'asakusa-house', title:'Asakusa Traditional House', type:'Entire home', area:'Asakusa', priceJPY:25000, priceUSD:170, rating:4.95, color:'#D4A574' },
+    { id:'roppongi-suite', title:'Roppongi Modern Suite', type:'Entire apartment', area:'Roppongi', priceJPY:22000, priceUSD:150, rating:4.78, color:'#7EC8E3' },
+    { id:'ginza-penthouse', title:'Ginza Luxury Penthouse', type:'Entire apartment', area:'Ginza', priceJPY:45000, priceUSD:300, rating:4.97, color:'#C9B1FF' },
+    { id:'harajuku-flat', title:'Harajuku Trendy Flat', type:'Private room', area:'Harajuku', priceJPY:15000, priceUSD:100, rating:4.88, color:'#FFB5A7' },
+    { id:'akihabara-hub', title:'Akihabara Tech Hub', type:'Private room', area:'Akihabara', priceJPY:9500, priceUSD:65, rating:4.72, color:'#A8D8EA' },
+    { id:'nakameguro-river', title:'Nakameguro Riverside', type:'Entire apartment', area:'Nakameguro', priceJPY:20000, priceUSD:135, rating:4.90, color:'#98D8C8' },
+    { id:'ueno-park', title:'Ueno Park View', type:'Private room', area:'Ueno', priceJPY:11000, priceUSD:75, rating:4.83, color:'#F7DC6F' },
+    { id:'ikebukuro-family', title:'Ikebukuro Family Space', type:'Entire home', area:'Ikebukuro', priceJPY:28000, priceUSD:190, rating:4.91, color:'#82E0AA' },
+    { id:'shimokita-artist', title:'Shimokitazawa Artist Loft', type:'Private room', area:'Shimokitazawa', priceJPY:8000, priceUSD:55, rating:4.76, color:'#F1948A' },
+    { id:'daikanyama-pent', title:'Daikanyama Designer Penthouse', type:'Entire apartment', area:'Daikanyama', priceJPY:55000, priceUSD:370, rating:4.98, color:'#BB8FCE' },
+    { id:'odaiba-bay', title:'Odaiba Bayview Suite', type:'Entire apartment', area:'Odaiba', priceJPY:32000, priceUSD:215, rating:4.89, color:'#85C1E9' },
+    { id:'koenji-retro', title:'Koenji Retro Studio', type:'Private room', area:'Koenji', priceJPY:6000, priceUSD:40, rating:4.68, color:'#F0B27A' },
+    { id:'meguro-garden', title:'Meguro Garden Flat', type:'Entire apartment', area:'Meguro', priceJPY:19000, priceUSD:128, rating:4.86, color:'#ABEBC6' },
+    { id:'ebisu-chic', title:'Ebisu Chic Apartment', type:'Entire apartment', area:'Ebisu', priceJPY:24000, priceUSD:162, rating:4.93, color:'#D7BDE2' },
+    { id:'yanaka-heritage', title:'Yanaka Heritage Room', type:'Private room', area:'Yanaka', priceJPY:7500, priceUSD:50, rating:4.79, color:'#E59866' },
+    { id:'azabu-luxury', title:'Azabu-Juban Luxury Villa', type:'Entire home', area:'Azabu-Juban', priceJPY:60000, priceUSD:400, rating:4.99, color:'#AED6F1' },
+    { id:'nihonbashi-exec', title:'Nihonbashi Executive Suite', type:'Entire apartment', area:'Nihonbashi', priceJPY:35000, priceUSD:235, rating:4.94, color:'#A9CCE3' },
+    { id:'kichijoji-cozy', title:'Kichijoji Cozy Hideaway', type:'Shared room', area:'Kichijoji', priceJPY:5000, priceUSD:35, rating:4.65, color:'#F9E79F' },
+    { id:'tsukiji-market', title:'Tsukiji Market Flat', type:'Entire apartment', area:'Tsukiji', priceJPY:16000, priceUSD:108, rating:4.81, color:'#FADBD8' },
+    { id:'shinagawa-biz', title:'Shinagawa Business Hotel Room', type:'Private room', area:'Shinagawa', priceJPY:10000, priceUSD:68, rating:4.70, color:'#D5F5E3' }
+  ];
+
+  // Disabled dates per month (YYYY-MM -> array of day numbers)
+  const DISABLED_DATES = {
+    '2026-04': [5, 11, 18, 23, 29],
+    '2026-05': [2, 9, 14, 21, 27],
+    '2026-06': [3, 8, 12, 22, 28],
+    '2026-07': [4, 10, 16, 24, 30],
+    '2026-08': [1, 7, 15, 20, 26],
+    '2026-09': [3, 11, 17, 22, 28],
+    '2026-10': [2, 8, 14, 21, 27],
+    '2026-11': [5, 11, 16, 23, 29],
+    '2026-12': [3, 9, 15, 22, 28]
+  };
+
+  const MONTH_NAMES = ['January','February','March','April','May','June','July','August','September','October','November','December'];
+  const DOW = ['Su','Mo','Tu','We','Th','Fr','Sa'];
+
+  const AUTOCOMPLETE = [
+    { name: 'Tokyo, Japan', icon: '🗼' },
+    { name: 'Paris, France', icon: '🗼' },
+    { name: 'New York, United States', icon: '🗽' },
+    { name: 'London, United Kingdom', icon: '🇬🇧' },
+    { name: 'Bali, Indonesia', icon: '🏝' },
+    { name: 'Barcelona, Spain', icon: '🇪🇸' }
+  ];
+
+  const REGIONS = ['Asia','Europe','North America','South America','Africa','Oceania'];
+
+  const AMENITIES_LIST = ['Wifi','Kitchen','Washer','Air conditioning','Heating','TV','Iron','Hair dryer','Workspace','Pool','Hot tub','Free parking'];
+
+  // ── Helpers ──────────────────────────────────────────────
+  const $ = s => document.querySelector(s);
+  const $$ = s => document.querySelectorAll(s);
+
+  function fmtDate(d) {
+    if (!d) return '—';
+    const mm = String(d.getMonth()+1).padStart(2,'0');
+    const dd = String(d.getDate()).padStart(2,'0');
+    return `${d.getFullYear()}-${mm}-${dd}`;
+  }
+  function fmtDateShort(d) {
+    if (!d) return 'Add dates';
+    return `${MONTH_NAMES[d.getMonth()].slice(0,3)} ${d.getDate()}`;
+  }
+  function sameDay(a,b) { return a && b && a.getFullYear()===b.getFullYear() && a.getMonth()===b.getMonth() && a.getDate()===b.getDate(); }
+  function dateKey(y,m) { return `${y}-${String(m+1).padStart(2,'0')}`; }
+
+  const pastelColors = ['#FFD1DC','#FFE4B5','#D4F1F4','#E8D5B7','#D5E8D4','#E6E6FA','#FFDAB9','#C1E1C1'];
+  function randomColor(i) { return pastelColors[i % pastelColors.length]; }
+
+  // ── Render helpers ───────────────────────────────────────
+
+  // View switching
+  function showView(name) {
+    state.view = name;
+    ['home','results','detail'].forEach(v => {
+      const el = $(`#view-${v}`);
+      if (el) el.classList.toggle('active', v === name);
+    });
+    // Show/hide filter bar
+    const fb = $('#filter-bar');
+    if (fb) fb.style.display = name === 'results' ? 'flex' : 'none';
+    // Close popovers
+    closePopovers();
+  }
+
+  // ── Popovers ─────────────────────────────────────────────
+  function openPopover(which) {
+    closePopovers();
+    state.activePopover = which;
+    const pop = $(`.popover-${which}`);
+    if (pop) pop.classList.add('open');
+    $$('.search-pill-seg').forEach(s => s.classList.toggle('active', s.dataset.seg === which));
+    $('#popover-backdrop').classList.add('open');
+    tracker.track('search_section_click', { section: which });
+  }
+  function closePopovers() {
+    state.activePopover = null;
+    $$('.popover').forEach(p => p.classList.remove('open'));
+    $$('.search-pill-seg').forEach(s => s.classList.remove('active'));
+    const bd = $('#popover-backdrop');
+    if (bd) bd.classList.remove('open');
+  }
+
+  // ── Search pill text ─────────────────────────────────────
+  function updatePillText() {
+    const wv = $('#seg-where-val');
+    const wnv = $('#seg-when-val');
+    const whv = $('#seg-who-val');
+    if (wv) wv.textContent = state.where || 'Search';
+    if (wnv) wnv.textContent = (state.checkin && state.checkout)
+      ? `${fmtDateShort(state.checkin)} – ${fmtDateShort(state.checkout)}`
+      : 'Add dates';
+    if (whv) {
+      const total = state.adults + state.children;
+      let txt = `${total} guest${total !== 1 ? 's' : ''}`;
+      if (state.infants) txt += `, ${state.infants} infant${state.infants !== 1 ? 's' : ''}`;
+      whv.textContent = txt;
+    }
+  }
+
+  // ── WHERE popover ────────────────────────────────────────
+  function initWhere() {
+    const input = $('#where-input');
+    const list = $('#autocomplete-list');
+    if (!input || !list) return;
+
+    function renderAC(filter) {
+      const items = filter
+        ? AUTOCOMPLETE.filter(a => a.name.toLowerCase().includes(filter.toLowerCase()))
+        : AUTOCOMPLETE;
+      list.innerHTML = items.map(a => `
+        <div class="autocomplete-item" data-value="${a.name}">
+          <div class="ac-icon">${a.icon}</div>
+          <span>${a.name}</span>
+        </div>`).join('');
+    }
+    renderAC('');
+    input.addEventListener('input', () => renderAC(input.value));
+    list.addEventListener('click', e => {
+      const item = e.target.closest('.autocomplete-item');
+      if (!item) return;
+      state.where = item.dataset.value;
+      input.value = item.dataset.value;
+      tracker.track('autocomplete_select', { value: item.dataset.value });
+      updatePillText();
+    });
+  }
+
+  // ── WHEN / Calendar ──────────────────────────────────────
+  function renderCalendar() {
+    const wrap = $('#calendar-wrap');
+    if (!wrap) return;
+
+    const m1 = new Date(state.calMonth);
+    const m2 = new Date(m1.getFullYear(), m1.getMonth() + 1, 1);
+
+    wrap.innerHTML = `
+      <div class="cal-month" data-idx="0">
+        <div class="cal-header">
+          <button class="cal-nav prev" id="cal-prev">&lsaquo;</button>
+          <span class="cal-title">${MONTH_NAMES[m1.getMonth()]} ${m1.getFullYear()}</span>
+        </div>
+        ${buildMonthGrid(m1)}
+      </div>
+      <div class="cal-month" data-idx="1">
+        <div class="cal-header">
+          <span class="cal-title">${MONTH_NAMES[m2.getMonth()]} ${m2.getFullYear()}</span>
+          <button class="cal-nav next" id="cal-next">&rsaquo;</button>
+        </div>
+        ${buildMonthGrid(m2)}
+      </div>`;
+
+    // nav
+    $('#cal-prev').addEventListener('click', () => {
+      state.calMonth = new Date(state.calMonth.getFullYear(), state.calMonth.getMonth() - 1, 1);
+      const nm = new Date(state.calMonth);
+      const nm2 = new Date(nm.getFullYear(), nm.getMonth() + 1, 1);
+      tracker.track('calendar_month_nav', { direction: 'back', count: 1, targetMonths: `${MONTH_NAMES[nm.getMonth()]} ${nm.getFullYear()} / ${MONTH_NAMES[nm2.getMonth()]} ${nm2.getFullYear()}` });
+      renderCalendar();
+    });
+    $('#cal-next').addEventListener('click', () => {
+      state.calMonth = new Date(state.calMonth.getFullYear(), state.calMonth.getMonth() + 1, 1);
+      const nm = new Date(state.calMonth);
+      const nm2 = new Date(nm.getFullYear(), nm.getMonth() + 1, 1);
+      tracker.track('calendar_month_nav', { direction: 'forward', count: 1, targetMonths: `${MONTH_NAMES[nm.getMonth()]} ${nm.getFullYear()} / ${MONTH_NAMES[nm2.getMonth()]} ${nm2.getFullYear()}` });
+      renderCalendar();
+    });
+
+    // day clicks & hover
+    wrap.querySelectorAll('.cal-day[data-date]').forEach(el => {
+      if (el.classList.contains('disabled') || el.classList.contains('empty')) return;
+      el.addEventListener('click', () => {
+        const d = new Date(el.dataset.date + 'T00:00:00');
+        if (!state.checkin || (state.checkin && state.checkout)) {
+          state.checkin = d;
+          state.checkout = null;
+          tracker.track('date_select', { role: 'checkin', date: fmtDate(d) });
+        } else {
+          if (d <= state.checkin) {
+            state.checkin = d;
+            state.checkout = null;
+            tracker.track('date_select', { role: 'checkin', date: fmtDate(d) });
+          } else {
+            state.checkout = d;
+            tracker.track('date_select', { role: 'checkout', date: fmtDate(d) });
+          }
+        }
+        state.hoverDate = null;
+        updatePillText();
+        renderCalendar();
+      });
+      el.addEventListener('mouseenter', () => {
+        if (state.checkin && !state.checkout) {
+          state.hoverDate = new Date(el.dataset.date + 'T00:00:00');
+          applyHoverRange();
+        }
+      });
+    });
+    wrap.addEventListener('mouseleave', () => {
+      state.hoverDate = null;
+      clearHoverRange();
+    });
+  }
+
+  function buildMonthGrid(d) {
+    const y = d.getFullYear();
+    const m = d.getMonth();
+    const firstDow = new Date(y, m, 1).getDay();
+    const daysInMonth = new Date(y, m + 1, 0).getDate();
+    const dk = dateKey(y, m);
+    const disabled = DISABLED_DATES[dk] || [];
+
+    let html = '<div class="cal-grid">';
+    DOW.forEach(w => { html += `<div class="cal-dow">${w}</div>`; });
+    for (let i = 0; i < firstDow; i++) html += '<div class="cal-day empty"></div>';
+    for (let day = 1; day <= daysInMonth; day++) {
+      const iso = `${y}-${String(m+1).padStart(2,'0')}-${String(day).padStart(2,'0')}`;
+      const dt = new Date(y, m, day);
+      const dis = disabled.includes(day);
+      let cls = 'cal-day';
+      if (dis) cls += ' disabled';
+      else {
+        if (state.checkin && state.checkout) {
+          if (sameDay(dt, state.checkin)) cls += ' range-start';
+          else if (sameDay(dt, state.checkout)) cls += ' range-end';
+          else if (dt > state.checkin && dt < state.checkout) cls += ' in-range';
+        } else if (state.checkin && sameDay(dt, state.checkin)) {
+          cls += ' selected';
+        }
+      }
+      html += `<div class="${cls}" data-date="${iso}">${day}</div>`;
+    }
+    html += '</div>';
+    return html;
+  }
+
+  function applyHoverRange() {
+    if (!state.checkin || !state.hoverDate) return;
+    const start = state.checkin;
+    const end = state.hoverDate;
+    if (end <= start) return;
+    document.querySelectorAll('.cal-day[data-date]').forEach(el => {
+      if (el.classList.contains('disabled')) return;
+      const d = new Date(el.dataset.date + 'T00:00:00');
+      el.classList.remove('range-hover', 'range-hover-end');
+      if (d > start && d < end) el.classList.add('range-hover');
+      if (sameDay(d, end)) el.classList.add('range-hover-end');
+    });
+  }
+  function clearHoverRange() {
+    document.querySelectorAll('.cal-day').forEach(el => {
+      el.classList.remove('range-hover', 'range-hover-end');
+    });
+  }
+
+  // ── WHO / Guest stepper ──────────────────────────────────
+  function initWho() {
+    const wrap = $('#who-popover');
+    if (!wrap) return;
+    renderGuestRows();
+  }
+  function renderGuestRows() {
+    const wrap = $('#guest-rows');
+    if (!wrap) return;
+    const rows = [
+      { key: 'adults', label: 'Adults', desc: 'Age 13+', min: 1 },
+      { key: 'children', label: 'Children', desc: 'Ages 2–12', min: 0 },
+      { key: 'infants', label: 'Infants', desc: 'Under 2', min: 0 },
+      { key: 'pets', label: 'Pets', desc: '', min: 0 }
+    ];
+    wrap.innerHTML = rows.map(r => {
+      const val = state[r.key];
+      return `<div class="guest-row">
+        <div class="guest-info">
+          <div class="guest-type">${r.label}</div>
+          ${r.desc ? `<div class="guest-desc">${r.desc}</div>` : ''}
+        </div>
+        <div class="stepper">
+          <button class="stepper-btn" data-guest="${r.key}" data-action="decrement" ${val <= r.min ? 'disabled' : ''}>−</button>
+          <span class="stepper-count" id="count-${r.key}">${val}</span>
+          <button class="stepper-btn" data-guest="${r.key}" data-action="increment">+</button>
+        </div>
+      </div>`;
+    }).join('');
+
+    wrap.querySelectorAll('.stepper-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const key = btn.dataset.guest;
+        const action = btn.dataset.action;
+        const min = key === 'adults' ? 1 : 0;
+        if (action === 'increment') state[key]++;
+        else if (action === 'decrement' && state[key] > min) state[key]--;
+        tracker.track('guest_stepper_click', { guestType: key, action, finalCount: state[key] });
+        renderGuestRows();
+        updatePillText();
+      });
+    });
+  }
+
+  // ── Search submit ────────────────────────────────────────
+  function doSearch() {
+    tracker.track('search_submit', {
+      where: state.where,
+      checkin: fmtDate(state.checkin),
+      checkout: fmtDate(state.checkout),
+      adults: state.adults,
+      children: state.children,
+      infants: state.infants
+    });
+    closePopovers();
+    renderResults();
+    showView('results');
+  }
+
+  // ── Results view ─────────────────────────────────────────
+  function renderResults() {
+    const grid = $('#listings-grid');
+    const mapSvg = $('#map-svg');
+    if (!grid) return;
+
+    // Filter listings by price
+    let filtered = LISTINGS.filter(l => l.priceUSD >= state.priceMin && l.priceUSD <= state.priceMax);
+    // Filter by property type
+    if (state.propertyTypes.length) {
+      filtered = filtered.filter(l => {
+        return state.propertyTypes.some(t => {
+          if (t === 'Entire place') return l.type.startsWith('Entire');
+          return l.type === t;
+        });
+      });
+    }
+    // Filter by amenities — for demo we skip actual amenity data; always pass
+    // Filter by instant book — skip for demo
+
+    const count = filtered.length;
+    const header = $('#listings-header');
+    if (header) header.textContent = `${count} stays${state.where ? ' in ' + state.where : ''}`;
+
+    grid.innerHTML = filtered.map((l, i) => {
+      const imgs = [0,1,2,3].map(k => `https://picsum.photos/seed/staybnb-${l.id}-${k}/640/480`);
+      return `<div class="listing-card" data-id="${l.id}">
+        <div class="listing-card-img-wrap">
+          <div class="listing-card-img" style="background-image:url('${imgs[0]}')" data-imgs='${JSON.stringify(imgs)}' data-ci="0"></div>
+          <div class="listing-card-fav" data-liked="false">&#9825;</div>
+          <div class="carousel-dots">${imgs.map((_,j) => `<div class="carousel-dot${j===0?' active':''}" data-dot="${j}"></div>`).join('')}</div>
+          <div class="carousel-arrow left" data-dir="prev">&#8249;</div>
+          <div class="carousel-arrow right" data-dir="next">&#8250;</div>
+        </div>
+        <div class="listing-card-info">
+          <div class="listing-card-top">
+            <div class="listing-card-title">${l.title}</div>
+            <div class="listing-card-rating">&#9733; ${l.rating}</div>
+          </div>
+          <div class="listing-card-type">${l.type} · ${l.area}</div>
+          <div class="listing-card-price"><span>¥${l.priceJPY.toLocaleString()}</span> / night <span style="color:var(--gray-500);font-weight:400;font-size:12px">(≈$${l.priceUSD})</span></div>
+        </div>
+      </div>`;
+    }).join('');
+
+    // Card interactions
+    grid.querySelectorAll('.listing-card').forEach(card => {
+      const id = card.dataset.id;
+      // click -> detail
+      card.addEventListener('click', e => {
+        if (e.target.closest('.carousel-arrow') || e.target.closest('.listing-card-fav')) return;
+        openDetail(id);
+      });
+      // hover -> highlight map
+      card.addEventListener('mouseenter', () => {
+        const pin = document.querySelector(`.map-pin[data-id="${id}"]`);
+        if (pin) pin.classList.add('highlight');
+      });
+      card.addEventListener('mouseleave', () => {
+        const pin = document.querySelector(`.map-pin[data-id="${id}"]`);
+        if (pin) pin.classList.remove('highlight');
+      });
+    });
+
+    // Carousel arrows
+    grid.querySelectorAll('.carousel-arrow').forEach(btn => {
+      btn.addEventListener('click', e => {
+        e.stopPropagation();
+        const wrap = btn.closest('.listing-card-img-wrap');
+        const img = wrap.querySelector('.listing-card-img');
+        const imgs = JSON.parse(img.dataset.imgs);
+        let ci = parseInt(img.dataset.ci);
+        if (btn.dataset.dir === 'next') ci = (ci + 1) % imgs.length;
+        else ci = (ci - 1 + imgs.length) % imgs.length;
+        img.style.backgroundImage = `url('${imgs[ci]}')`;
+        img.dataset.ci = ci;
+        wrap.querySelectorAll('.carousel-dot').forEach((d,j) => d.classList.toggle('active', j === ci));
+      });
+    });
+
+    // Favorite hearts
+    grid.querySelectorAll('.listing-card-fav').forEach(fav => {
+      fav.addEventListener('click', e => {
+        e.stopPropagation();
+        const liked = fav.dataset.liked === 'true';
+        fav.dataset.liked = String(!liked);
+        fav.classList.toggle('liked', !liked);
+        fav.innerHTML = liked ? '&#9825;' : '&#9829;';
+      });
+    });
+
+    // Map
+    renderMap(filtered);
+  }
+
+  function renderMap(listings) {
+    const svg = $('#map-svg');
+    if (!svg) return;
+    // Simple scatter map
+    const w = 500, h = 600;
+    // deterministic positions based on index
+    const positions = listings.map((l, i) => {
+      const angle = (i / listings.length) * Math.PI * 2;
+      const r = 120 + (i % 3) * 50;
+      const x = w/2 + Math.cos(angle) * r + (i * 7 % 40);
+      const y = h/2 + Math.sin(angle) * r + (i * 13 % 30);
+      return { x: Math.max(40, Math.min(w-40, x)), y: Math.max(30, Math.min(h-30, y)) };
+    });
+
+    svg.setAttribute('viewBox', `0 0 ${w} ${h}`);
+    svg.innerHTML = `<rect width="${w}" height="${h}" fill="#f0f0f0"/>` +
+      listings.map((l, i) => {
+        const p = positions[i];
+        const label = `$${l.priceUSD}`;
+        const tw = label.length * 7 + 12;
+        return `<g class="map-pin" data-id="${l.id}" transform="translate(${p.x},${p.y})">
+          <rect x="${-tw/2}" y="-12" width="${tw}" height="24" rx="12"/>
+          <text text-anchor="middle" dy="4">${label}</text>
+        </g>`;
+      }).join('');
+
+    // Pin hover -> highlight card
+    svg.querySelectorAll('.map-pin').forEach(pin => {
+      pin.addEventListener('mouseenter', () => {
+        const card = document.querySelector(`.listing-card[data-id="${pin.dataset.id}"]`);
+        if (card) card.style.boxShadow = '0 4px 16px rgba(255,56,92,.3)';
+      });
+      pin.addEventListener('mouseleave', () => {
+        const card = document.querySelector(`.listing-card[data-id="${pin.dataset.id}"]`);
+        if (card) card.style.boxShadow = '';
+      });
+    });
+  }
+
+  // ── Filter modal ─────────────────────────────────────────
+  function openFilterModal() {
+    tracker.track('filter_modal_open', {});
+    $('#filter-modal').classList.add('open');
+    renderFilterModal();
+  }
+  function closeFilterModal() {
+    tracker.track('filter_modal_close', {});
+    $('#filter-modal').classList.remove('open');
+  }
+  function renderFilterModal() {
+    // Price slider values are maintained via state
+    updateSliderUI();
+    // Property type chips
+    $$('.type-chip').forEach(c => {
+      c.classList.toggle('active', state.propertyTypes.includes(c.dataset.type));
+    });
+    // Amenity checkboxes
+    $$('.amenity-check input').forEach(cb => {
+      cb.checked = state.amenities.includes(cb.dataset.amenity);
+    });
+    // Instant book
+    const ib = $('#instant-book-toggle');
+    if (ib) ib.checked = state.instantBook;
+    // Count
+    updateFilterCount();
+  }
+
+  function updateFilterCount() {
+    let filtered = LISTINGS.filter(l => l.priceUSD >= state.priceMin && l.priceUSD <= state.priceMax);
+    if (state.propertyTypes.length) {
+      filtered = filtered.filter(l => state.propertyTypes.some(t => {
+        if (t === 'Entire place') return l.type.startsWith('Entire');
+        return l.type === t;
+      }));
+    }
+    const btn = $('#filter-apply-btn');
+    if (btn) btn.textContent = `Show ${filtered.length} stays`;
+  }
+
+  // ── Price slider (dual handle) ───────────────────────────
+  function initPriceSlider() {
+    const track = $('#price-track');
+    const fill = $('#price-fill');
+    const minHandle = $('#price-handle-min');
+    const maxHandle = $('#price-handle-max');
+    const minLabel = $('#price-label-min');
+    const maxLabel = $('#price-label-max');
+    if (!track) return;
+
+    const PRICE_MIN = 10, PRICE_MAX = 500;
+
+    function getTrackRect() { return track.getBoundingClientRect(); }
+
+    function valToPercent(v) { return (v - PRICE_MIN) / (PRICE_MAX - PRICE_MIN) * 100; }
+    function percentToVal(p) { return Math.round(PRICE_MIN + (p / 100) * (PRICE_MAX - PRICE_MIN)); }
+
+    function updateSlider() {
+      const pMin = valToPercent(state.priceMin);
+      const pMax = valToPercent(state.priceMax);
+      minHandle.style.left = pMin + '%';
+      maxHandle.style.left = pMax + '%';
+      fill.style.left = pMin + '%';
+      fill.style.width = (pMax - pMin) + '%';
+      if (minLabel) minLabel.textContent = '$' + state.priceMin;
+      if (maxLabel) maxLabel.textContent = '$' + state.priceMax;
+      const dl = $('#price-display-min');
+      const dr = $('#price-display-max');
+      if (dl) dl.textContent = '$' + state.priceMin;
+      if (dr) dr.textContent = '$' + state.priceMax;
+    }
+
+    window._updateSliderUI = updateSlider;
+
+    function startDrag(handle, which) {
+      handle.addEventListener('mousedown', e => {
+        e.preventDefault();
+        handle.classList.add('dragging');
+        const onMove = ev => {
+          const rect = getTrackRect();
+          let pct = ((ev.clientX - rect.left) / rect.width) * 100;
+          pct = Math.max(0, Math.min(100, pct));
+          let val = percentToVal(pct);
+          if (which === 'min') {
+            val = Math.min(val, state.priceMax - 5);
+            state.priceMin = Math.max(PRICE_MIN, val);
+          } else {
+            val = Math.max(val, state.priceMin + 5);
+            state.priceMax = Math.min(PRICE_MAX, val);
+          }
+          tracker.track('price_slider_change', { handle: which, value: state[which === 'min' ? 'priceMin' : 'priceMax'] });
+          updateSlider();
+          updateFilterCount();
+        };
+        const onUp = () => {
+          handle.classList.remove('dragging');
+          document.removeEventListener('mousemove', onMove);
+          document.removeEventListener('mouseup', onUp);
+        };
+        document.addEventListener('mousemove', onMove);
+        document.addEventListener('mouseup', onUp);
+      });
+    }
+    startDrag(minHandle, 'min');
+    startDrag(maxHandle, 'max');
+    updateSlider();
+  }
+
+  function updateSliderUI() {
+    if (window._updateSliderUI) window._updateSliderUI();
+  }
+
+  // ── Detail view ──────────────────────────────────────────
+  function openDetail(id) {
+    const listing = LISTINGS.find(l => l.id === id);
+    if (!listing) return;
+    state.currentListing = listing;
+    tracker.track('listing_open', { listingId: id });
+
+    const view = $('#view-detail');
+    // Photo grid — real images via Lorem Picsum (seeded for stability)
+    const detailImgs = [0,1,2,3,4].map(k => `https://picsum.photos/seed/staybnb-${id}-d${k}/1200/800`);
+    const allGalleryImgs = [...detailImgs, ...[5,6,7].map(k => `https://picsum.photos/seed/staybnb-${id}-d${k}/1200/800`)];
+
+    view.querySelector('.photo-main').style.backgroundImage = `url('${detailImgs[0]}')`;
+    view.querySelectorAll('.photo-small').forEach((el, i) => {
+      el.style.backgroundImage = `url('${detailImgs[i + 1] || detailImgs[0]}')`;
+    });
+
+    // Title etc
+    view.querySelector('.detail-title').textContent = listing.title;
+    view.querySelector('.detail-subtitle').textContent = `${listing.type} · ${listing.area}, Tokyo`;
+    view.querySelector('.detail-host-name').textContent = 'Hosted by Yuki';
+    view.querySelector('.detail-host-tenure').textContent = 'Superhost · 4 years hosting';
+
+    // Booking card
+    view.querySelector('.booking-price-val').textContent = `¥${listing.priceJPY.toLocaleString()}`;
+    view.querySelector('#booking-checkin').textContent = state.checkin ? fmtDate(state.checkin) : 'Add date';
+    view.querySelector('#booking-checkout').textContent = state.checkout ? fmtDate(state.checkout) : 'Add date';
+    const totalGuests = state.adults + state.children;
+    view.querySelector('#booking-guests-val').textContent = `${totalGuests} guest${totalGuests !== 1 ? 's' : ''}`;
+
+    // Price breakdown
+    const nights = (state.checkin && state.checkout)
+      ? Math.max(1, Math.round((state.checkout - state.checkin) / 86400000))
+      : 1;
+    const subtotal = listing.priceJPY * nights;
+    const cleaning = 5000;
+    const service = Math.round(subtotal * 0.12);
+    const total = subtotal + cleaning + service;
+    view.querySelector('#pb-nights').textContent = `¥${listing.priceJPY.toLocaleString()} × ${nights} night${nights !== 1 ? 's' : ''}`;
+    view.querySelector('#pb-subtotal').textContent = `¥${subtotal.toLocaleString()}`;
+    view.querySelector('#pb-cleaning').textContent = `¥${cleaning.toLocaleString()}`;
+    view.querySelector('#pb-service').textContent = `¥${service.toLocaleString()}`;
+    view.querySelector('#pb-total').textContent = `¥${total.toLocaleString()}`;
+
+    // Gallery data
+    view.dataset.galleryImgs = JSON.stringify(allGalleryImgs);
+
+    // Reset confirm panel
+    const cp = view.querySelector('.confirm-panel');
+    if (cp) { cp.classList.remove('open'); cp.querySelector('.confirm-success').classList.remove('show'); }
+
+    showView('detail');
+  }
+
+  // ── Gallery ──────────────────────────────────────────────
+  function openGallery() {
+    const view = $('#view-detail');
+    const imgs = JSON.parse(view.dataset.galleryImgs || '[]');
+    const overlay = $('#gallery-overlay');
+    const grid = overlay.querySelector('.gallery-grid');
+    grid.innerHTML = imgs.map((u, i) => `<div class="gallery-img" data-idx="${i}" style="background-image:url('${u}')"></div>`).join('');
+    overlay.classList.add('open');
+    tracker.track('gallery_open', { listingId: state.currentListing?.id });
+
+    // Intersection observer for scroll tracking
+    let viewed = new Set();
+    const io = new IntersectionObserver(entries => {
+      entries.forEach(e => {
+        if (e.isIntersecting) viewed.add(e.target.dataset.idx);
+      });
+      tracker.track('gallery_scroll', { photos_viewed: viewed.size });
+    }, { root: overlay, threshold: 0.5 });
+    grid.querySelectorAll('.gallery-img').forEach(img => io.observe(img));
+
+    overlay.dataset.io = 'active'; // just a flag
+  }
+  function closeGallery() {
+    $('#gallery-overlay').classList.remove('open');
+    tracker.track('gallery_close', {});
+  }
+
+  // ── Reserve & Confirm ────────────────────────────────────
+  function doReserve() {
+    if (!state.currentListing) return;
+    tracker.track('reserve_click', { listingId: state.currentListing.id });
+    const cp = $('#view-detail').querySelector('.confirm-panel');
+    if (cp) cp.classList.add('open');
+  }
+  function doConfirm() {
+    if (!state.currentListing) return;
+    tracker.track('booking_confirm', { listingId: state.currentListing.id });
+    const cp = $('#view-detail').querySelector('.confirm-panel');
+    if (cp) cp.querySelector('.confirm-success').classList.add('show');
+  }
+
+  // ── Init ─────────────────────────────────────────────────
+  function init() {
+    // Pill segments
+    $$('.search-pill-seg').forEach(seg => {
+      seg.addEventListener('click', () => {
+        const which = seg.dataset.seg;
+        if (state.activePopover === which) closePopovers();
+        else openPopover(which);
+      });
+    });
+
+    // Backdrop
+    const bd = $('#popover-backdrop');
+    if (bd) bd.addEventListener('click', closePopovers);
+
+    // Search button
+    const searchBtn = $('#search-btn');
+    if (searchBtn) searchBtn.addEventListener('click', doSearch);
+
+    // When subtabs (only Dates works)
+    $$('.when-subtab').forEach(tab => {
+      tab.addEventListener('click', () => {
+        $$('.when-subtab').forEach(t => t.classList.remove('active'));
+        tab.classList.add('active');
+      });
+    });
+
+    // Init popovers
+    initWhere();
+    initWho();
+    renderCalendar();
+    updatePillText();
+
+    // Filter bar pills
+    const filterBtn = $('#filter-btn');
+    if (filterBtn) filterBtn.addEventListener('click', openFilterModal);
+
+    // Filter modal close
+    const fmClose = $('#filter-modal-close');
+    if (fmClose) fmClose.addEventListener('click', closeFilterModal);
+
+    // Filter modal overlay click
+    const fmOverlay = $('#filter-modal');
+    if (fmOverlay) fmOverlay.addEventListener('click', e => { if (e.target === fmOverlay) closeFilterModal(); });
+
+    // Property type chips
+    $$('.type-chip').forEach(chip => {
+      chip.addEventListener('click', () => {
+        const t = chip.dataset.type;
+        if (state.propertyTypes.includes(t)) state.propertyTypes = state.propertyTypes.filter(x => x !== t);
+        else state.propertyTypes.push(t);
+        chip.classList.toggle('active');
+        updateFilterCount();
+      });
+    });
+
+    // Amenity checkboxes
+    $$('.amenity-check input').forEach(cb => {
+      cb.addEventListener('change', () => {
+        const a = cb.dataset.amenity;
+        if (cb.checked) { if (!state.amenities.includes(a)) state.amenities.push(a); }
+        else { state.amenities = state.amenities.filter(x => x !== a); }
+        tracker.track('amenity_toggle', { amenity: a.toLowerCase(), checked: cb.checked });
+        updateFilterCount();
+      });
+    });
+
+    // Instant book
+    const ibToggle = $('#instant-book-toggle');
+    if (ibToggle) ibToggle.addEventListener('change', () => {
+      state.instantBook = ibToggle.checked;
+      tracker.track('instant_book_toggle', { checked: ibToggle.checked });
+      updateFilterCount();
+    });
+
+    // Filter apply
+    const applyBtn = $('#filter-apply-btn');
+    if (applyBtn) applyBtn.addEventListener('click', () => {
+      tracker.track('filter_apply', {
+        priceMin: state.priceMin,
+        priceMax: state.priceMax,
+        amenities: state.amenities,
+        instantBook: state.instantBook
+      });
+      closeFilterModal();
+      renderResults();
+    });
+
+    // Init price slider
+    initPriceSlider();
+
+    // Detail view events
+    const showAllBtn = $('#show-all-photos');
+    if (showAllBtn) showAllBtn.addEventListener('click', openGallery);
+
+    const galleryCloseBtn = $('#gallery-close-btn');
+    if (galleryCloseBtn) galleryCloseBtn.addEventListener('click', closeGallery);
+
+    const reserveBtn = $('#reserve-btn');
+    if (reserveBtn) reserveBtn.addEventListener('click', doReserve);
+
+    const confirmBtn = $('#confirm-btn');
+    if (confirmBtn) confirmBtn.addEventListener('click', doConfirm);
+
+    // Detail back button
+    const backBtn = $('#detail-back');
+    if (backBtn) backBtn.addEventListener('click', () => showView('results'));
+
+    // Photo grid click -> gallery
+    $$('.photo-main, .photo-small').forEach(el => {
+      el.addEventListener('click', openGallery);
+    });
+
+    // Category tabs
+    $$('.cat-tab').forEach(tab => {
+      tab.addEventListener('click', () => {
+        $$('.cat-tab').forEach(t => t.classList.remove('active'));
+        tab.classList.add('active');
+      });
+    });
+
+    // Logo -> home
+    const logo = $('#logo');
+    if (logo) logo.addEventListener('click', () => showView('home'));
+
+    // Start view — respect URL hash (#results / #detail) for deep-linking
+    if (location.hash === '#results') {
+      renderResults();
+      showView('results');
+    } else {
+      showView('home');
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', init);
+})();

--- a/eval/taskflow/css/taskflow.css
+++ b/eval/taskflow/css/taskflow.css
@@ -1,0 +1,1161 @@
+/* ===== Reset & Base ===== */
+*, *::before, *::after {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+html, body {
+    height: 100%;
+    overflow: hidden;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+    font-size: 14px;
+    color: #172b4d;
+    background: linear-gradient(135deg, #0079bf 0%, #5067c5 50%, #4a5889 100%);
+}
+
+button {
+    cursor: pointer;
+    border: none;
+    background: none;
+    font-family: inherit;
+    font-size: inherit;
+    color: inherit;
+}
+
+input, textarea {
+    font-family: inherit;
+    font-size: inherit;
+}
+
+/* ===== Global Header ===== */
+.global-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    height: 44px;
+    padding: 0 8px;
+    background: rgba(0, 0, 0, 0.32);
+    color: #fff;
+}
+
+.header-left {
+    display: flex;
+    align-items: center;
+    flex: 1;
+}
+
+.app-logo {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-weight: 700;
+    font-size: 18px;
+    letter-spacing: -0.5px;
+    padding: 4px 8px;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+.app-logo:hover {
+    background: rgba(255,255,255,0.15);
+}
+
+.logo-icon {
+    color: #fff;
+}
+
+.header-center {
+    flex: 2;
+    display: flex;
+    justify-content: center;
+}
+
+.search-box {
+    position: relative;
+    width: 100%;
+    max-width: 400px;
+}
+
+.search-icon {
+    position: absolute;
+    left: 10px;
+    top: 50%;
+    transform: translateY(-50%);
+    color: rgba(255,255,255,0.7);
+}
+
+.search-input {
+    width: 100%;
+    padding: 6px 10px 6px 32px;
+    border: none;
+    border-radius: 4px;
+    background: rgba(255,255,255,0.2);
+    color: #fff;
+    outline: none;
+    font-size: 14px;
+    transition: background 0.2s;
+}
+
+.search-input::placeholder {
+    color: rgba(255,255,255,0.6);
+}
+
+.search-input:focus {
+    background: rgba(255,255,255,0.95);
+    color: #172b4d;
+}
+
+.search-input:focus::placeholder {
+    color: #999;
+}
+
+.header-right {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 6px;
+}
+
+.header-btn {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 6px 10px;
+    border-radius: 4px;
+    color: #fff;
+    font-size: 14px;
+    transition: background 0.15s;
+}
+
+.header-btn:hover {
+    background: rgba(255,255,255,0.2);
+}
+
+.create-btn {
+    background: rgba(255,255,255,0.2);
+    font-weight: 600;
+}
+
+.create-btn:hover {
+    background: rgba(255,255,255,0.35);
+}
+
+.icon-btn {
+    position: relative;
+    padding: 6px 8px;
+}
+
+.notification-badge {
+    position: absolute;
+    top: 2px;
+    right: 2px;
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    background: #eb5a46;
+    color: #fff;
+    font-size: 10px;
+    font-weight: 700;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    line-height: 1;
+}
+
+.user-avatar {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    background: #dfe1e6;
+    color: #172b4d;
+    font-weight: 700;
+    font-size: 12px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: opacity 0.15s;
+}
+
+.user-avatar:hover {
+    opacity: 0.85;
+}
+
+/* ===== Board Header ===== */
+.board-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 8px 10px;
+    color: #fff;
+    min-height: 44px;
+}
+
+.board-header-left {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.board-name {
+    font-size: 18px;
+    font-weight: 700;
+    padding: 4px 8px;
+    border-radius: 4px;
+    cursor: pointer;
+    white-space: nowrap;
+}
+
+.board-name:hover {
+    background: rgba(255,255,255,0.2);
+}
+
+.board-name-input {
+    font-size: 18px;
+    font-weight: 700;
+    padding: 4px 8px;
+    border-radius: 4px;
+    border: 2px solid #fff;
+    background: #fff;
+    color: #172b4d;
+    outline: none;
+}
+
+.star-toggle {
+    padding: 4px;
+    border-radius: 4px;
+    color: rgba(255,255,255,0.7);
+    transition: color 0.15s;
+}
+
+.star-toggle:hover, .star-toggle.starred {
+    color: #f2d600;
+}
+
+.star-toggle.starred svg {
+    fill: #f2d600;
+}
+
+.visibility-badge {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 4px 8px;
+    border-radius: 4px;
+    background: rgba(255,255,255,0.2);
+    font-size: 13px;
+    color: rgba(255,255,255,0.9);
+}
+
+.board-header-right {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.board-members {
+    display: flex;
+    gap: -4px;
+}
+
+.member-avatar {
+    width: 30px;
+    height: 30px;
+    border-radius: 50%;
+    color: #fff;
+    font-size: 11px;
+    font-weight: 700;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: 2px solid rgba(0,0,0,0.1);
+    margin-left: -4px;
+    cursor: pointer;
+    transition: transform 0.15s;
+}
+
+.member-avatar:first-child {
+    margin-left: 0;
+}
+
+.member-avatar:hover {
+    transform: translateY(-2px);
+}
+
+.board-action-btn {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 6px 12px;
+    border-radius: 4px;
+    color: #fff;
+    background: rgba(255,255,255,0.2);
+    font-size: 14px;
+    transition: background 0.15s;
+}
+
+.board-action-btn:hover {
+    background: rgba(255,255,255,0.35);
+}
+
+/* ===== Board Wrapper & Body ===== */
+.board-wrapper {
+    display: flex;
+    flex: 1;
+    height: calc(100vh - 88px);
+    overflow: hidden;
+    transition: padding-right 0.25s ease;
+}
+
+.board {
+    flex: 1;
+    display: flex;
+    gap: 12px;
+    padding: 0 10px 10px;
+    overflow-x: auto;
+    overflow-y: hidden;
+    align-items: flex-start;
+    min-width: 0;
+    scroll-behavior: smooth;
+}
+
+.board::-webkit-scrollbar {
+    height: 10px;
+}
+
+.board::-webkit-scrollbar-track {
+    background: rgba(0,0,0,0.1);
+    border-radius: 5px;
+}
+
+.board::-webkit-scrollbar-thumb {
+    background: rgba(255,255,255,0.3);
+    border-radius: 5px;
+}
+
+/* ===== Column / List ===== */
+.column {
+    flex: 0 0 280px;
+    min-width: 280px;
+    max-height: calc(100vh - 110px);
+    background: #ebecf0;
+    border-radius: 8px;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+.column-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 10px 10px 6px;
+}
+
+.column-name {
+    font-weight: 700;
+    font-size: 14px;
+    color: #172b4d;
+    padding: 2px 4px;
+}
+
+.column-menu-btn {
+    padding: 4px;
+    border-radius: 4px;
+    color: #6b778c;
+    transition: background 0.15s, color 0.15s;
+}
+
+.column-menu-btn:hover {
+    background: rgba(0,0,0,0.08);
+    color: #172b4d;
+}
+
+.column-cards {
+    flex: 1;
+    overflow-y: auto;
+    padding: 0 8px 4px;
+    min-height: 20px;
+}
+
+.column-cards::-webkit-scrollbar {
+    width: 6px;
+}
+
+.column-cards::-webkit-scrollbar-thumb {
+    background: #c1c7d0;
+    border-radius: 3px;
+}
+
+/* ===== Card ===== */
+.card {
+    position: relative;
+    background: #fff;
+    border-radius: 8px;
+    box-shadow: 0 1px 2px rgba(0,0,0,0.12);
+    padding: 8px 10px;
+    margin-bottom: 8px;
+    cursor: pointer;
+    transition: box-shadow 0.15s, transform 0.1s, opacity 0.15s;
+    user-select: none;
+}
+
+.card:hover {
+    box-shadow: 0 2px 6px rgba(0,0,0,0.18);
+}
+
+.card.dragging {
+    opacity: 0.65;
+    box-shadow: 0 8px 24px rgba(0,0,0,0.25);
+    transform: rotate(3deg);
+    z-index: 1000;
+    pointer-events: none;
+}
+
+.card.drag-ghost {
+    position: fixed;
+    z-index: 9999;
+    width: 280px;
+    pointer-events: none;
+    opacity: 0.85;
+    box-shadow: 0 12px 32px rgba(0,0,0,0.3);
+    transform: rotate(4deg);
+}
+
+.card-placeholder {
+    background: rgba(0,0,0,0.06);
+    border-radius: 8px;
+    margin-bottom: 8px;
+    border: 2px dashed #c1c7d0;
+    min-height: 40px;
+    transition: height 0.15s;
+}
+
+.card-labels {
+    display: flex;
+    gap: 4px;
+    margin-bottom: 6px;
+    flex-wrap: wrap;
+}
+
+.card-label {
+    width: 40px;
+    height: 8px;
+    border-radius: 4px;
+}
+
+.card-label-green { background: #61bd4f; }
+.card-label-yellow { background: #f2d600; }
+.card-label-orange { background: #ff9f1a; }
+.card-label-red { background: #eb5a46; }
+.card-label-purple { background: #c377e0; }
+.card-label-blue { background: #0079bf; }
+
+.card-title {
+    font-size: 14px;
+    line-height: 1.4;
+    color: #172b4d;
+    word-wrap: break-word;
+}
+
+.card-badges {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-top: 6px;
+    font-size: 12px;
+    color: #5e6c84;
+}
+
+.card-badge {
+    display: flex;
+    align-items: center;
+    gap: 3px;
+}
+
+.card-badge svg {
+    width: 14px;
+    height: 14px;
+}
+
+.card-badge-due {
+    padding: 2px 6px;
+    border-radius: 3px;
+    background: #fce8e6;
+    color: #eb5a46;
+    font-size: 11px;
+    font-weight: 600;
+}
+
+/* Pencil / Quick Edit Icon */
+.card-edit-btn {
+    position: absolute;
+    top: 4px;
+    right: 4px;
+    width: 28px;
+    height: 28px;
+    border-radius: 4px;
+    background: #f4f5f7;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 0;
+    transition: opacity 0.15s, background 0.15s;
+    z-index: 2;
+}
+
+.card:hover .card-edit-btn {
+    opacity: 1;
+}
+
+.card-edit-btn:hover {
+    background: #dfe1e6;
+}
+
+/* Quick Edit Inline */
+.quick-edit-container {
+    position: relative;
+    z-index: 5;
+}
+
+.quick-edit-input {
+    width: 100%;
+    padding: 6px 8px;
+    border: 2px solid #0079bf;
+    border-radius: 4px;
+    outline: none;
+    font-size: 14px;
+    resize: none;
+    min-height: 60px;
+}
+
+.quick-edit-save {
+    margin-top: 6px;
+    padding: 6px 16px;
+    background: #0079bf;
+    color: #fff;
+    border-radius: 4px;
+    font-weight: 600;
+    font-size: 14px;
+    transition: background 0.15s;
+}
+
+.quick-edit-save:hover {
+    background: #026aa7;
+}
+
+/* Dimmed cards (for label filtering) */
+.card.dimmed {
+    opacity: 0.2;
+    pointer-events: none;
+    transition: opacity 0.3s;
+}
+
+/* ===== Add Card ===== */
+.column-footer {
+    padding: 6px 8px 8px;
+}
+
+.add-card-btn {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    width: 100%;
+    padding: 8px 8px;
+    border-radius: 6px;
+    color: #5e6c84;
+    font-size: 14px;
+    transition: background 0.15s, color 0.15s;
+}
+
+.add-card-btn:hover {
+    background: rgba(0,0,0,0.06);
+    color: #172b4d;
+}
+
+.add-card-form {
+    display: none;
+}
+
+.add-card-form.active {
+    display: block;
+}
+
+.add-card-textarea {
+    width: 100%;
+    padding: 8px;
+    border: none;
+    border-radius: 6px;
+    box-shadow: 0 1px 2px rgba(0,0,0,0.12);
+    outline: none;
+    resize: none;
+    min-height: 54px;
+    font-size: 14px;
+    line-height: 1.4;
+    color: #172b4d;
+}
+
+.add-card-actions {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-top: 6px;
+}
+
+.add-card-submit {
+    padding: 6px 16px;
+    background: #0079bf;
+    color: #fff;
+    border-radius: 4px;
+    font-weight: 600;
+    font-size: 14px;
+    transition: background 0.15s;
+}
+
+.add-card-submit:hover {
+    background: #026aa7;
+}
+
+.add-card-cancel {
+    padding: 6px;
+    color: #6b778c;
+    font-size: 18px;
+    line-height: 1;
+}
+
+.add-card-cancel:hover {
+    color: #172b4d;
+}
+
+/* ===== Board Menu Side Panel ===== */
+.board-menu-panel {
+    width: 0;
+    min-width: 0;
+    overflow: hidden;
+    background: #f4f5f7;
+    border-left: 1px solid #dfe1e6;
+    transition: width 0.25s ease, min-width 0.25s ease;
+    display: flex;
+    flex-direction: column;
+    flex-shrink: 0;
+}
+
+.board-menu-panel.open {
+    width: 320px;
+    min-width: 320px;
+}
+
+.panel-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 14px 16px;
+    border-bottom: 1px solid #dfe1e6;
+}
+
+.panel-header h3 {
+    font-size: 16px;
+    font-weight: 700;
+    color: #172b4d;
+}
+
+.panel-close-btn {
+    padding: 4px;
+    border-radius: 4px;
+    color: #6b778c;
+    transition: background 0.15s;
+}
+
+.panel-close-btn:hover {
+    background: rgba(0,0,0,0.08);
+}
+
+.panel-body {
+    padding: 16px;
+    overflow-y: auto;
+    flex: 1;
+}
+
+.panel-section {
+    margin-bottom: 20px;
+}
+
+.panel-section h4 {
+    font-size: 13px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: #5e6c84;
+    margin-bottom: 8px;
+}
+
+.panel-desc {
+    font-size: 13px;
+    line-height: 1.5;
+    color: #5e6c84;
+}
+
+.bg-swatches {
+    display: flex;
+    gap: 8px;
+}
+
+.bg-swatch {
+    width: 48px;
+    height: 32px;
+    border-radius: 6px;
+    border: 2px solid transparent;
+    cursor: pointer;
+    transition: border-color 0.15s, transform 0.1s;
+}
+
+.bg-swatch:hover {
+    transform: scale(1.1);
+    border-color: rgba(0,0,0,0.2);
+}
+
+.filter-labels {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+}
+
+.filter-label-btn {
+    width: 48px;
+    height: 32px;
+    border-radius: 6px;
+    border: 3px solid transparent;
+    cursor: pointer;
+    transition: border-color 0.15s, transform 0.1s;
+}
+
+.filter-label-btn:hover {
+    transform: scale(1.1);
+}
+
+.filter-label-btn.active {
+    border-color: #172b4d;
+    box-shadow: 0 0 0 1px #172b4d;
+}
+
+.clear-filter-btn {
+    margin-top: 12px;
+    padding: 6px 14px;
+    background: #dfe1e6;
+    border-radius: 4px;
+    color: #172b4d;
+    font-size: 13px;
+    font-weight: 600;
+    transition: background 0.15s;
+}
+
+.clear-filter-btn:hover {
+    background: #c1c7d0;
+}
+
+/* ===== Card Modal ===== */
+.modal-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0,0,0,0.55);
+    z-index: 5000;
+    display: none;
+    align-items: flex-start;
+    justify-content: center;
+    padding: 48px 16px;
+    overflow-y: auto;
+}
+
+.modal-overlay.active {
+    display: flex;
+}
+
+.card-modal {
+    position: relative;
+    background: #f4f5f7;
+    border-radius: 8px;
+    width: 100%;
+    max-width: 768px;
+    display: flex;
+    flex-wrap: wrap;
+    padding: 20px 20px 20px 24px;
+    gap: 16px;
+    box-shadow: 0 16px 48px rgba(0,0,0,0.3);
+}
+
+.modal-close-btn {
+    position: absolute;
+    top: 12px;
+    right: 12px;
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #6b778c;
+    transition: background 0.15s, color 0.15s;
+    z-index: 2;
+}
+
+.modal-close-btn:hover {
+    background: rgba(0,0,0,0.08);
+    color: #172b4d;
+}
+
+.modal-main {
+    flex: 1;
+    min-width: 0;
+}
+
+.modal-labels {
+    display: flex;
+    gap: 4px;
+    flex-wrap: wrap;
+    margin-bottom: 8px;
+}
+
+.modal-label {
+    width: 48px;
+    height: 8px;
+    border-radius: 4px;
+}
+
+.modal-title-section {
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+    margin-bottom: 4px;
+    padding-right: 40px;
+}
+
+.modal-section-icon {
+    flex-shrink: 0;
+    color: #6b778c;
+    margin-top: 2px;
+}
+
+.modal-title {
+    font-size: 20px;
+    font-weight: 700;
+    color: #172b4d;
+    cursor: pointer;
+    padding: 2px 4px;
+    border-radius: 4px;
+    word-break: break-word;
+    line-height: 1.3;
+}
+
+.modal-title:hover {
+    background: rgba(0,0,0,0.06);
+}
+
+.modal-title-input {
+    font-size: 20px;
+    font-weight: 700;
+    color: #172b4d;
+    padding: 2px 4px;
+    border: 2px solid #0079bf;
+    border-radius: 4px;
+    outline: none;
+    width: 100%;
+    background: #fff;
+}
+
+.modal-column-info {
+    font-size: 13px;
+    color: #5e6c84;
+    margin-left: 28px;
+    margin-bottom: 16px;
+}
+
+.modal-column-info span {
+    text-decoration: underline;
+}
+
+.modal-section {
+    margin-bottom: 20px;
+}
+
+.modal-section-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 8px;
+}
+
+.modal-section-header h3 {
+    font-size: 16px;
+    font-weight: 700;
+    color: #172b4d;
+}
+
+/* Description */
+.description-placeholder {
+    padding: 10px 12px;
+    background: rgba(0,0,0,0.04);
+    border-radius: 4px;
+    color: #5e6c84;
+    cursor: pointer;
+    min-height: 56px;
+    font-size: 14px;
+    transition: background 0.15s;
+}
+
+.description-placeholder:hover {
+    background: rgba(0,0,0,0.08);
+}
+
+.description-textarea {
+    width: 100%;
+    min-height: 100px;
+    padding: 10px 12px;
+    border: none;
+    border-radius: 4px;
+    outline: none;
+    resize: vertical;
+    font-size: 14px;
+    line-height: 1.5;
+    background: #fff;
+    box-shadow: 0 0 0 2px #0079bf;
+}
+
+.description-actions {
+    display: flex;
+    gap: 8px;
+    margin-top: 8px;
+}
+
+/* Checklist */
+.checklist-progress {
+    font-size: 12px;
+    color: #5e6c84;
+    font-weight: 600;
+    margin-left: auto;
+}
+
+.checklist-progress-bar-wrapper {
+    height: 8px;
+    background: #dfe1e6;
+    border-radius: 4px;
+    margin-bottom: 10px;
+    overflow: hidden;
+}
+
+.checklist-progress-bar {
+    height: 100%;
+    background: #61bd4f;
+    border-radius: 4px;
+    transition: width 0.3s ease;
+    width: 0%;
+}
+
+.checklist-items {
+    margin-bottom: 8px;
+}
+
+.checklist-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 4px;
+    border-radius: 4px;
+    transition: background 0.15s;
+}
+
+.checklist-item:hover {
+    background: rgba(0,0,0,0.04);
+}
+
+.checklist-item input[type="checkbox"] {
+    width: 16px;
+    height: 16px;
+    cursor: pointer;
+    accent-color: #0079bf;
+}
+
+.checklist-item label {
+    font-size: 14px;
+    color: #172b4d;
+    cursor: pointer;
+    flex: 1;
+}
+
+.checklist-item.checked label {
+    text-decoration: line-through;
+    color: #5e6c84;
+}
+
+.checklist-add {
+    display: flex;
+    gap: 6px;
+    margin-top: 4px;
+}
+
+.checklist-add-input {
+    flex: 1;
+    padding: 6px 10px;
+    border: 1px solid #dfe1e6;
+    border-radius: 4px;
+    outline: none;
+    font-size: 13px;
+    transition: border-color 0.15s;
+}
+
+.checklist-add-input:focus {
+    border-color: #0079bf;
+    box-shadow: 0 0 0 1px #0079bf;
+}
+
+/* Modal Sidebar */
+.modal-sidebar {
+    width: 170px;
+    flex-shrink: 0;
+}
+
+.sidebar-heading {
+    font-size: 11px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: #5e6c84;
+    margin-bottom: 6px;
+}
+
+.sidebar-btn {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    width: 100%;
+    padding: 7px 10px;
+    border-radius: 4px;
+    background: rgba(0,0,0,0.06);
+    color: #172b4d;
+    font-size: 14px;
+    margin-bottom: 4px;
+    transition: background 0.15s;
+}
+
+.sidebar-btn:hover {
+    background: rgba(0,0,0,0.12);
+}
+
+/* Label Picker Popover */
+.label-picker-popover {
+    position: absolute;
+    top: 60px;
+    right: 20px;
+    width: 280px;
+    background: #fff;
+    border-radius: 8px;
+    box-shadow: 0 8px 24px rgba(0,0,0,0.2);
+    z-index: 10;
+    padding: 12px;
+}
+
+.popover-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 12px;
+}
+
+.popover-header h4 {
+    font-size: 14px;
+    font-weight: 700;
+    color: #172b4d;
+}
+
+.popover-close-btn {
+    padding: 2px;
+    border-radius: 4px;
+    color: #6b778c;
+}
+
+.popover-close-btn:hover {
+    background: rgba(0,0,0,0.06);
+}
+
+.label-swatches {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+    justify-content: flex-start;
+}
+
+.label-swatch {
+    width: 40px;
+    height: 30px;
+    border-radius: 4px;
+    border: 2px solid transparent;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: transform 0.1s, border-color 0.15s;
+}
+
+.label-swatch:hover {
+    transform: scale(1.12);
+}
+
+.swatch-check {
+    display: none;
+}
+
+.label-swatch.selected .swatch-check {
+    display: block;
+}
+
+/* ===== Buttons ===== */
+.btn-primary {
+    padding: 6px 16px;
+    background: #0079bf;
+    color: #fff;
+    border: none;
+    border-radius: 4px;
+    font-weight: 600;
+    font-size: 14px;
+    cursor: pointer;
+    transition: background 0.15s;
+}
+
+.btn-primary:hover {
+    background: #026aa7;
+}
+
+.btn-small {
+    padding: 4px 12px;
+    font-size: 13px;
+}
+
+.btn-cancel {
+    padding: 6px 12px;
+    background: none;
+    border: none;
+    color: #6b778c;
+    font-size: 14px;
+    cursor: pointer;
+    border-radius: 4px;
+    transition: background 0.15s;
+}
+
+.btn-cancel:hover {
+    background: rgba(0,0,0,0.06);
+}
+
+/* ===== Responsive tweaks ===== */
+@media (max-width: 640px) {
+    .board-members, .visibility-badge {
+        display: none;
+    }
+    .modal-sidebar {
+        width: 100%;
+        order: 2;
+    }
+    .card-modal {
+        flex-direction: column;
+    }
+}

--- a/eval/taskflow/index.html
+++ b/eval/taskflow/index.html
@@ -1,0 +1,275 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>TaskFlow - Sprint Board</title>
+    <link rel="stylesheet" href="/taskflow/css/taskflow.css">
+</head>
+<body>
+
+    <!-- ===== Global Header ===== -->
+    <header class="global-header">
+        <div class="header-left">
+            <div class="app-logo">
+                <svg class="logo-icon" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2">
+                    <rect x="3" y="3" width="7" height="7" rx="1"/>
+                    <rect x="14" y="3" width="7" height="7" rx="1"/>
+                    <rect x="3" y="14" width="7" height="7" rx="1"/>
+                    <rect x="14" y="14" width="7" height="7" rx="1"/>
+                </svg>
+                <span class="logo-text">TaskFlow</span>
+            </div>
+        </div>
+        <div class="header-center">
+            <div class="search-box">
+                <svg class="search-icon" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2">
+                    <circle cx="11" cy="11" r="8"/>
+                    <line x1="21" y1="21" x2="16.65" y2="16.65"/>
+                </svg>
+                <input type="text" class="search-input" placeholder="Search cards, boards...">
+            </div>
+        </div>
+        <div class="header-right">
+            <button class="header-btn create-btn" id="create-btn">
+                <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.5">
+                    <line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/>
+                </svg>
+                Create
+            </button>
+            <button class="header-btn icon-btn" id="notifications-btn" aria-label="Notifications">
+                <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2">
+                    <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/>
+                    <path d="M13.73 21a2 2 0 0 1-3.46 0"/>
+                </svg>
+                <span class="notification-badge">3</span>
+            </button>
+            <div class="user-avatar" id="user-avatar" title="Alex Morgan">AM</div>
+        </div>
+    </header>
+
+    <!-- ===== Board Header ===== -->
+    <div class="board-header">
+        <div class="board-header-left">
+            <h1 class="board-name" id="board-name">Sprint Board</h1>
+            <button class="star-toggle" id="star-toggle" aria-label="Star board">
+                <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2">
+                    <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/>
+                </svg>
+            </button>
+            <span class="visibility-badge">
+                <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2">
+                    <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/>
+                    <circle cx="9" cy="7" r="4"/>
+                    <path d="M23 21v-2a4 4 0 0 0-3-3.87"/>
+                    <path d="M16 3.13a4 4 0 0 1 0 7.75"/>
+                </svg>
+                Team Visible
+            </span>
+        </div>
+        <div class="board-header-right">
+            <div class="board-members">
+                <div class="member-avatar" style="background-color:#e74c3c;" title="Sarah Chen">SC</div>
+                <div class="member-avatar" style="background-color:#3498db;" title="James Wilson">JW</div>
+                <div class="member-avatar" style="background-color:#2ecc71;" title="Maria Garcia">MG</div>
+                <div class="member-avatar" style="background-color:#9b59b6;" title="David Kim">DK</div>
+            </div>
+            <button class="board-action-btn" id="filter-btn">
+                <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2">
+                    <polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"/>
+                </svg>
+                Filter
+            </button>
+            <button class="board-action-btn" id="board-menu-btn" aria-label="Board menu">
+                <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2">
+                    <circle cx="12" cy="5" r="1"/><circle cx="12" cy="12" r="1"/><circle cx="12" cy="19" r="1"/>
+                </svg>
+            </button>
+        </div>
+    </div>
+
+    <!-- ===== Board Container ===== -->
+    <div class="board-wrapper" id="board-wrapper">
+        <div class="board" id="board">
+            <!-- Columns will be rendered by JS -->
+        </div>
+
+        <!-- ===== Board Menu Side Panel ===== -->
+        <div class="board-menu-panel" id="board-menu-panel">
+            <div class="panel-header">
+                <h3>Menu</h3>
+                <button class="panel-close-btn" id="panel-close-btn" aria-label="Close menu">
+                    <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2">
+                        <line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="panel-body">
+                <div class="panel-section">
+                    <h4>About this board</h4>
+                    <p class="panel-desc">Sprint Board for Q2 2026 development cycle. Tracks all current sprint tasks and their progress.</p>
+                </div>
+                <div class="panel-section">
+                    <h4>Background</h4>
+                    <div class="bg-swatches">
+                        <button class="bg-swatch" style="background:#0079bf;" aria-label="Blue background"></button>
+                        <button class="bg-swatch" style="background:#519839;" aria-label="Green background"></button>
+                        <button class="bg-swatch" style="background:#b04632;" aria-label="Red background"></button>
+                        <button class="bg-swatch" style="background:#89609e;" aria-label="Purple background"></button>
+                    </div>
+                </div>
+                <div class="panel-section">
+                    <h4>Filter by Label</h4>
+                    <div class="filter-labels" id="filter-labels">
+                        <button class="filter-label-btn" data-color="green" style="background:#61bd4f;" aria-label="Green label"></button>
+                        <button class="filter-label-btn" data-color="yellow" style="background:#f2d600;" aria-label="Yellow label"></button>
+                        <button class="filter-label-btn" data-color="orange" style="background:#ff9f1a;" aria-label="Orange label"></button>
+                        <button class="filter-label-btn" data-color="red" style="background:#eb5a46;" aria-label="Red label"></button>
+                        <button class="filter-label-btn" data-color="purple" style="background:#c377e0;" aria-label="Purple label"></button>
+                        <button class="filter-label-btn" data-color="blue" style="background:#0079bf;" aria-label="Blue label"></button>
+                    </div>
+                    <button class="clear-filter-btn" id="clear-filter-btn">Clear filter</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- ===== Card Modal ===== -->
+    <div class="modal-overlay" id="card-modal-overlay">
+        <div class="card-modal" id="card-modal">
+            <button class="modal-close-btn" id="modal-close-btn" aria-label="Close">
+                <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2">
+                    <line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>
+                </svg>
+            </button>
+
+            <div class="modal-main">
+                <!-- Labels row -->
+                <div class="modal-labels" id="modal-labels"></div>
+
+                <!-- Title -->
+                <div class="modal-title-section">
+                    <svg class="modal-section-icon" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2">
+                        <rect x="3" y="3" width="18" height="18" rx="2" ry="2"/>
+                        <line x1="3" y1="9" x2="21" y2="9"/>
+                        <line x1="9" y1="21" x2="9" y2="9"/>
+                    </svg>
+                    <h2 class="modal-title" id="modal-title"></h2>
+                    <input type="text" class="modal-title-input" id="modal-title-input" style="display:none;">
+                </div>
+
+                <p class="modal-column-info" id="modal-column-info">in list <span id="modal-column-name"></span></p>
+
+                <!-- Description -->
+                <div class="modal-section">
+                    <div class="modal-section-header">
+                        <svg class="modal-section-icon" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2">
+                            <line x1="17" y1="10" x2="3" y2="10"/><line x1="21" y1="6" x2="3" y2="6"/><line x1="21" y1="14" x2="3" y2="14"/><line x1="17" y1="18" x2="3" y2="18"/>
+                        </svg>
+                        <h3>Description</h3>
+                    </div>
+                    <div class="modal-description" id="modal-description">
+                        <p class="description-placeholder" id="description-placeholder">Add a more detailed description...</p>
+                        <textarea class="description-textarea" id="description-textarea" style="display:none;" placeholder="Add a more detailed description..."></textarea>
+                        <div class="description-actions" id="description-actions" style="display:none;">
+                            <button class="btn-primary" id="desc-save-btn">Save</button>
+                            <button class="btn-cancel" id="desc-cancel-btn">Cancel</button>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Checklist -->
+                <div class="modal-section" id="checklist-section" style="display:none;">
+                    <div class="modal-section-header">
+                        <svg class="modal-section-icon" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2">
+                            <polyline points="9 11 12 14 22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/>
+                        </svg>
+                        <h3>Checklist</h3>
+                        <span class="checklist-progress" id="checklist-progress"></span>
+                    </div>
+                    <div class="checklist-progress-bar-wrapper">
+                        <div class="checklist-progress-bar" id="checklist-progress-bar"></div>
+                    </div>
+                    <div class="checklist-items" id="checklist-items"></div>
+                    <div class="checklist-add">
+                        <input type="text" class="checklist-add-input" id="checklist-add-input" placeholder="Add an item...">
+                        <button class="btn-primary btn-small" id="checklist-add-btn">Add</button>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Right sidebar -->
+            <div class="modal-sidebar">
+                <h4 class="sidebar-heading">Add to card</h4>
+                <button class="sidebar-btn" id="sidebar-labels-btn">
+                    <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2">
+                        <path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z"/><line x1="7" y1="7" x2="7.01" y2="7"/>
+                    </svg>
+                    Labels
+                </button>
+                <button class="sidebar-btn" id="sidebar-members-btn">
+                    <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2">
+                        <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/>
+                    </svg>
+                    Members
+                </button>
+                <button class="sidebar-btn" id="sidebar-checklist-btn">
+                    <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2">
+                        <polyline points="9 11 12 14 22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/>
+                    </svg>
+                    Checklist
+                </button>
+                <button class="sidebar-btn" id="sidebar-dates-btn">
+                    <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2">
+                        <rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/>
+                    </svg>
+                    Dates
+                </button>
+                <h4 class="sidebar-heading" style="margin-top:16px;">Actions</h4>
+                <button class="sidebar-btn" id="sidebar-archive-btn">
+                    <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2">
+                        <polyline points="21 8 21 21 3 21 3 8"/><rect x="1" y="3" width="22" height="5"/><line x1="10" y1="12" x2="14" y2="12"/>
+                    </svg>
+                    Archive
+                </button>
+            </div>
+
+            <!-- Label Picker Popover -->
+            <div class="label-picker-popover" id="label-picker-popover" style="display:none;">
+                <div class="popover-header">
+                    <h4>Labels</h4>
+                    <button class="popover-close-btn" id="label-picker-close">
+                        <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2">
+                            <line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>
+                        </svg>
+                    </button>
+                </div>
+                <div class="label-swatches" id="label-swatches">
+                    <button class="label-swatch" data-color="green" style="background:#61bd4f;" aria-label="Green">
+                        <svg class="swatch-check" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="white" stroke-width="3"><polyline points="20 6 9 17 4 12"/></svg>
+                    </button>
+                    <button class="label-swatch" data-color="yellow" style="background:#f2d600;" aria-label="Yellow">
+                        <svg class="swatch-check" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="white" stroke-width="3"><polyline points="20 6 9 17 4 12"/></svg>
+                    </button>
+                    <button class="label-swatch" data-color="orange" style="background:#ff9f1a;" aria-label="Orange">
+                        <svg class="swatch-check" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="white" stroke-width="3"><polyline points="20 6 9 17 4 12"/></svg>
+                    </button>
+                    <button class="label-swatch" data-color="red" style="background:#eb5a46;" aria-label="Red">
+                        <svg class="swatch-check" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="white" stroke-width="3"><polyline points="20 6 9 17 4 12"/></svg>
+                    </button>
+                    <button class="label-swatch" data-color="purple" style="background:#c377e0;" aria-label="Purple">
+                        <svg class="swatch-check" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="white" stroke-width="3"><polyline points="20 6 9 17 4 12"/></svg>
+                    </button>
+                    <button class="label-swatch" data-color="blue" style="background:#0079bf;" aria-label="Blue">
+                        <svg class="swatch-check" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="white" stroke-width="3"><polyline points="20 6 9 17 4 12"/></svg>
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Tracker MUST load before site JS -->
+    <script src="/js/tracker.js"></script>
+    <script src="/taskflow/js/taskflow.js"></script>
+</body>
+</html>

--- a/eval/taskflow/js/taskflow.js
+++ b/eval/taskflow/js/taskflow.js
@@ -1,0 +1,1100 @@
+/* ===================================================================
+   TaskFlow – Trello-like board for AI agent evaluation
+   =================================================================== */
+
+// Tracker init
+window.tracker = new AgentTracker('taskflow.app', 'hard');
+
+/* ---------- Data Model ---------- */
+
+const LABEL_COLORS = {
+    green:  '#61bd4f',
+    yellow: '#f2d600',
+    orange: '#ff9f1a',
+    red:    '#eb5a46',
+    purple: '#c377e0',
+    blue:   '#0079bf'
+};
+
+// Board state – mutable
+const boardData = {
+    columns: [
+        {
+            id: 'todo',
+            name: 'To Do',
+            cards: [
+                {
+                    id: 'c1',
+                    title: 'Write unit tests',
+                    labels: ['blue'],
+                    checklist: [
+                        { text: 'Test auth flow', checked: false },
+                        { text: 'Test API endpoints', checked: false },
+                        { text: 'Test UI components', checked: false }
+                    ],
+                    due: null,
+                    description: ''
+                },
+                {
+                    id: 'c2',
+                    title: 'Update documentation',
+                    labels: ['green'],
+                    checklist: [],
+                    due: null,
+                    description: ''
+                },
+                {
+                    id: 'c3',
+                    title: 'Fix login bug',
+                    labels: ['red'],
+                    checklist: [],
+                    due: 'Apr 15',
+                    description: ''
+                },
+                {
+                    id: 'c4',
+                    title: 'Refactor auth module',
+                    labels: [],
+                    checklist: [],
+                    due: null,
+                    description: ''
+                }
+            ]
+        },
+        {
+            id: 'inprogress',
+            name: 'In Progress',
+            cards: [
+                {
+                    id: 'c5',
+                    title: 'Design API schema',
+                    labels: ['yellow'],
+                    checklist: [
+                        { text: 'Define endpoints', checked: false },
+                        { text: 'Set up auth', checked: true },
+                        { text: 'Write schemas', checked: false },
+                        { text: 'Document API', checked: false }
+                    ],
+                    due: null,
+                    description: ''
+                },
+                {
+                    id: 'c6',
+                    title: 'Build search feature',
+                    labels: ['blue'],
+                    checklist: [],
+                    due: null,
+                    description: ''
+                },
+                {
+                    id: 'c7',
+                    title: 'Create dashboard',
+                    labels: ['purple'],
+                    checklist: [],
+                    due: 'Apr 20',
+                    description: ''
+                },
+                {
+                    id: 'c8',
+                    title: 'Set up CI/CD',
+                    labels: [],
+                    checklist: [],
+                    due: null,
+                    description: ''
+                }
+            ]
+        },
+        {
+            id: 'review',
+            name: 'Review',
+            cards: [
+                {
+                    id: 'c9',
+                    title: 'Deploy staging build',
+                    labels: ['green'],
+                    checklist: [
+                        { text: 'Run tests', checked: true },
+                        { text: 'Deploy to staging', checked: false }
+                    ],
+                    due: null,
+                    description: ''
+                },
+                {
+                    id: 'c10',
+                    title: 'Code review: payments',
+                    labels: ['red'],
+                    checklist: [],
+                    due: null,
+                    description: ''
+                },
+                {
+                    id: 'c11',
+                    title: 'Update user permissions',
+                    labels: ['yellow'],
+                    checklist: [],
+                    due: null,
+                    description: ''
+                },
+                {
+                    id: 'c12',
+                    title: 'Performance optimization',
+                    labels: [],
+                    checklist: [],
+                    due: null,
+                    description: ''
+                }
+            ]
+        },
+        {
+            id: 'done',
+            name: 'Done',
+            cards: [
+                {
+                    id: 'c13',
+                    title: 'Set up project repo',
+                    labels: ['green'],
+                    checklist: [],
+                    due: null,
+                    description: ''
+                },
+                {
+                    id: 'c14',
+                    title: 'Design mockups',
+                    labels: ['purple'],
+                    checklist: [],
+                    due: null,
+                    description: ''
+                },
+                {
+                    id: 'c15',
+                    title: 'Create database schema',
+                    labels: ['blue'],
+                    checklist: [],
+                    due: null,
+                    description: ''
+                },
+                {
+                    id: 'c16',
+                    title: 'Sprint planning meeting',
+                    labels: [],
+                    checklist: [],
+                    due: null,
+                    description: ''
+                }
+            ]
+        }
+    ]
+};
+
+let nextCardId = 17;
+let activeFilter = null; // null or a label color string
+
+/* ---------- Helpers ---------- */
+
+function findCard(cardId) {
+    for (const col of boardData.columns) {
+        const card = col.cards.find(c => c.id === cardId);
+        if (card) return { card, column: col };
+    }
+    return null;
+}
+
+function getColumnName(columnId) {
+    const col = boardData.columns.find(c => c.id === columnId);
+    return col ? col.name : columnId;
+}
+
+/* ---------- Render Board ---------- */
+
+function renderBoard() {
+    const board = document.getElementById('board');
+    board.innerHTML = '';
+
+    boardData.columns.forEach(col => {
+        const colEl = document.createElement('div');
+        colEl.className = 'column';
+        colEl.dataset.columnId = col.id;
+
+        // Header
+        const header = document.createElement('div');
+        header.className = 'column-header';
+        header.innerHTML = `
+            <span class="column-name">${col.name}</span>
+            <button class="column-menu-btn" aria-label="List menu">
+                <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2">
+                    <circle cx="12" cy="5" r="1"/><circle cx="12" cy="12" r="1"/><circle cx="12" cy="19" r="1"/>
+                </svg>
+            </button>
+        `;
+        colEl.appendChild(header);
+
+        // Cards area
+        const cardsContainer = document.createElement('div');
+        cardsContainer.className = 'column-cards';
+        cardsContainer.dataset.columnId = col.id;
+
+        col.cards.forEach(card => {
+            cardsContainer.appendChild(createCardElement(card, col.id));
+        });
+
+        colEl.appendChild(cardsContainer);
+
+        // Footer: Add a card
+        const footer = document.createElement('div');
+        footer.className = 'column-footer';
+        footer.innerHTML = `
+            <button class="add-card-btn" data-column="${col.id}">
+                <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2">
+                    <line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/>
+                </svg>
+                Add a card
+            </button>
+            <div class="add-card-form" data-column="${col.id}">
+                <textarea class="add-card-textarea" placeholder="Enter a title for this card..." data-column="${col.id}"></textarea>
+                <div class="add-card-actions">
+                    <button class="add-card-submit" data-column="${col.id}">Add Card</button>
+                    <button class="add-card-cancel" data-column="${col.id}">&times;</button>
+                </div>
+            </div>
+        `;
+        colEl.appendChild(footer);
+
+        board.appendChild(colEl);
+    });
+
+    applyLabelFilter();
+}
+
+function createCardElement(card, columnId) {
+    const el = document.createElement('div');
+    el.className = 'card';
+    el.dataset.cardId = card.id;
+    el.dataset.columnId = columnId;
+
+    // Labels
+    if (card.labels && card.labels.length > 0) {
+        const labelsDiv = document.createElement('div');
+        labelsDiv.className = 'card-labels';
+        card.labels.forEach(color => {
+            const chip = document.createElement('span');
+            chip.className = `card-label card-label-${color}`;
+            chip.dataset.labelColor = color;
+            labelsDiv.appendChild(chip);
+        });
+        el.appendChild(labelsDiv);
+    }
+
+    // Title
+    const titleDiv = document.createElement('div');
+    titleDiv.className = 'card-title';
+    titleDiv.textContent = card.title;
+    el.appendChild(titleDiv);
+
+    // Badges
+    const badges = [];
+    if (card.due) {
+        badges.push(`<span class="card-badge card-badge-due">
+            <svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
+            ${card.due}
+        </span>`);
+    }
+    if (card.checklist && card.checklist.length > 0) {
+        const done = card.checklist.filter(i => i.checked).length;
+        const total = card.checklist.length;
+        badges.push(`<span class="card-badge">
+            <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 11 12 14 22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>
+            ${done}/${total}
+        </span>`);
+    }
+    if (badges.length > 0) {
+        const badgesDiv = document.createElement('div');
+        badgesDiv.className = 'card-badges';
+        badgesDiv.innerHTML = badges.join('');
+        el.appendChild(badgesDiv);
+    }
+
+    // Pencil (quick edit) button — hidden by default, shown on hover via CSS
+    const editBtn = document.createElement('button');
+    editBtn.className = 'card-edit-btn';
+    editBtn.setAttribute('aria-label', 'Quick edit');
+    editBtn.innerHTML = `<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2">
+        <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/>
+        <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/>
+    </svg>`;
+    el.appendChild(editBtn);
+
+    return el;
+}
+
+/* ---------- Drag and Drop ---------- */
+
+let dragState = null; // { cardId, ghost, placeholder, startX, startY, originalColumn }
+
+function initDrag(e, cardEl) {
+    // Don't start drag on edit button click
+    if (e.target.closest('.card-edit-btn')) return;
+
+    const cardId = cardEl.dataset.cardId;
+    const result = findCard(cardId);
+    if (!result) return;
+
+    const rect = cardEl.getBoundingClientRect();
+
+    // Create ghost
+    const ghost = cardEl.cloneNode(true);
+    ghost.classList.add('card', 'drag-ghost');
+    ghost.style.width = rect.width + 'px';
+    ghost.style.left = rect.left + 'px';
+    ghost.style.top = rect.top + 'px';
+    document.body.appendChild(ghost);
+
+    // Create placeholder
+    const placeholder = document.createElement('div');
+    placeholder.className = 'card-placeholder';
+    placeholder.style.height = rect.height + 'px';
+
+    // Replace card with placeholder
+    cardEl.parentNode.insertBefore(placeholder, cardEl);
+    cardEl.style.display = 'none';
+
+    dragState = {
+        cardId,
+        cardEl,
+        ghost,
+        placeholder,
+        offsetX: e.clientX - rect.left,
+        offsetY: e.clientY - rect.top,
+        originalColumn: cardEl.dataset.columnId
+    };
+
+    tracker.track('card_drag_start', {
+        cardTitle: result.card.title,
+        fromColumn: result.column.name
+    });
+}
+
+function moveDrag(e) {
+    if (!dragState) return;
+
+    const { ghost, placeholder, offsetX, offsetY } = dragState;
+    ghost.style.left = (e.clientX - offsetX) + 'px';
+    ghost.style.top = (e.clientY - offsetY) + 'px';
+
+    // Find target column cards container
+    const targetEl = document.elementFromPoint(e.clientX, e.clientY);
+    if (!targetEl) return;
+
+    const targetCardsContainer = targetEl.closest('.column-cards');
+    if (!targetCardsContainer) return;
+
+    // Move placeholder to target column
+    const cards = Array.from(targetCardsContainer.querySelectorAll('.card:not([style*="display: none"]), .card-placeholder'));
+    let inserted = false;
+
+    for (const child of cards) {
+        if (child === placeholder) continue;
+        const childRect = child.getBoundingClientRect();
+        if (e.clientY < childRect.top + childRect.height / 2) {
+            targetCardsContainer.insertBefore(placeholder, child);
+            inserted = true;
+            break;
+        }
+    }
+
+    if (!inserted) {
+        targetCardsContainer.appendChild(placeholder);
+    }
+}
+
+function endDrag(e) {
+    if (!dragState) return;
+
+    const { cardId, cardEl, ghost, placeholder } = dragState;
+    const result = findCard(cardId);
+    if (!result) {
+        cleanup();
+        return;
+    }
+
+    // Figure out new column and position
+    const newContainer = placeholder.closest('.column-cards');
+    const newColumnId = newContainer ? newContainer.dataset.columnId : dragState.originalColumn;
+    const newColumn = boardData.columns.find(c => c.id === newColumnId);
+    const oldColumn = result.column;
+
+    // Position among siblings
+    const siblings = Array.from(newContainer.querySelectorAll('.card, .card-placeholder'));
+    let newIndex = siblings.indexOf(placeholder);
+
+    // Remove card from old column data
+    const oldIdx = oldColumn.cards.indexOf(result.card);
+    if (oldIdx !== -1) oldColumn.cards.splice(oldIdx, 1);
+
+    // If same column and the placeholder is after the original position, adjust
+    if (oldColumn === newColumn && newIndex > oldIdx) {
+        newIndex = Math.max(0, newIndex - 1);
+    }
+
+    // Insert into new column data
+    newColumn.cards.splice(newIndex, 0, result.card);
+
+    tracker.track('card_drop', {
+        cardTitle: result.card.title,
+        toColumn: newColumn.name,
+        position: newIndex
+    });
+
+    cleanup();
+    renderBoard();
+
+    function cleanup() {
+        ghost.remove();
+        placeholder.remove();
+        cardEl.style.display = '';
+        dragState = null;
+    }
+}
+
+/* ---------- Hover Reveal Pencil ---------- */
+
+document.addEventListener('mouseenter', function(e) {
+    const card = e.target.closest ? e.target.closest('.card') : null;
+    if (!card || card.classList.contains('drag-ghost')) return;
+    const cardId = card.dataset.cardId;
+    const result = findCard(cardId);
+    if (result) {
+        tracker.track('card_hover_edit_reveal', { cardTitle: result.card.title });
+    }
+}, true);
+
+/* ---------- Quick Edit (Pencil click) ---------- */
+
+function openQuickEdit(cardEl) {
+    const cardId = cardEl.dataset.cardId;
+    const result = findCard(cardId);
+    if (!result) return;
+
+    tracker.track('card_quick_edit_open', { cardTitle: result.card.title });
+
+    // Replace card content with inline edit
+    const origContent = cardEl.innerHTML;
+    const origTitle = result.card.title;
+
+    cardEl.innerHTML = `
+        <div class="quick-edit-container">
+            <textarea class="quick-edit-input">${origTitle}</textarea>
+            <button class="quick-edit-save">Save</button>
+        </div>
+    `;
+
+    const textarea = cardEl.querySelector('.quick-edit-input');
+    textarea.focus();
+    textarea.select();
+
+    function save() {
+        const newTitle = textarea.value.trim();
+        if (newTitle && newTitle !== origTitle) {
+            result.card.title = newTitle;
+            tracker.track('card_quick_edit_save', { newTitle });
+        }
+        renderBoard();
+    }
+
+    cardEl.querySelector('.quick-edit-save').addEventListener('click', function(e) {
+        e.stopPropagation();
+        save();
+    });
+
+    textarea.addEventListener('keydown', function(e) {
+        if (e.key === 'Enter' && !e.shiftKey) {
+            e.preventDefault();
+            save();
+        }
+        if (e.key === 'Escape') {
+            renderBoard();
+        }
+    });
+
+    // Prevent card click from opening modal
+    cardEl.addEventListener('click', function(e) {
+        e.stopPropagation();
+    }, { once: true });
+}
+
+/* ---------- Card Modal ---------- */
+
+let currentModalCardId = null;
+
+function openCardModal(cardId) {
+    const result = findCard(cardId);
+    if (!result) return;
+
+    currentModalCardId = cardId;
+    const { card, column } = result;
+
+    tracker.track('card_modal_open', { cardTitle: card.title });
+
+    // Populate modal
+    const overlay = document.getElementById('card-modal-overlay');
+    document.getElementById('modal-title').textContent = card.title;
+    document.getElementById('modal-title').style.display = '';
+    document.getElementById('modal-title-input').style.display = 'none';
+    document.getElementById('modal-column-name').textContent = column.name;
+
+    // Labels in modal
+    const labelsEl = document.getElementById('modal-labels');
+    labelsEl.innerHTML = '';
+    if (card.labels && card.labels.length > 0) {
+        card.labels.forEach(color => {
+            const chip = document.createElement('span');
+            chip.className = `modal-label card-label-${color}`;
+            labelsEl.appendChild(chip);
+        });
+    }
+
+    // Description
+    const descPlaceholder = document.getElementById('description-placeholder');
+    const descTextarea = document.getElementById('description-textarea');
+    const descActions = document.getElementById('description-actions');
+    descPlaceholder.style.display = card.description ? 'none' : '';
+    descPlaceholder.textContent = card.description || 'Add a more detailed description...';
+    descTextarea.style.display = 'none';
+    descTextarea.value = card.description || '';
+    descActions.style.display = 'none';
+
+    // Checklist
+    const checklistSection = document.getElementById('checklist-section');
+    if (card.checklist && card.checklist.length > 0) {
+        checklistSection.style.display = '';
+        renderChecklist(card);
+    } else {
+        checklistSection.style.display = 'none';
+    }
+
+    // Reset label picker
+    document.getElementById('label-picker-popover').style.display = 'none';
+
+    // Show modal
+    overlay.classList.add('active');
+}
+
+function closeCardModal() {
+    document.getElementById('card-modal-overlay').classList.remove('active');
+    document.getElementById('label-picker-popover').style.display = 'none';
+    tracker.track('card_modal_close', {});
+    currentModalCardId = null;
+    renderBoard(); // refresh cards in case labels/checklist changed
+}
+
+function renderChecklist(card) {
+    const itemsEl = document.getElementById('checklist-items');
+    itemsEl.innerHTML = '';
+
+    const checked = card.checklist.filter(i => i.checked).length;
+    const total = card.checklist.length;
+    document.getElementById('checklist-progress').textContent = `${checked}/${total}`;
+
+    const pct = total > 0 ? (checked / total * 100) : 0;
+    document.getElementById('checklist-progress-bar').style.width = pct + '%';
+
+    card.checklist.forEach((item, idx) => {
+        const div = document.createElement('div');
+        div.className = 'checklist-item' + (item.checked ? ' checked' : '');
+        div.innerHTML = `
+            <input type="checkbox" id="cl-item-${idx}" ${item.checked ? 'checked' : ''}>
+            <label for="cl-item-${idx}">${item.text}</label>
+        `;
+        div.querySelector('input').addEventListener('change', function() {
+            item.checked = this.checked;
+            div.classList.toggle('checked', item.checked);
+            tracker.track('checklist_check', { itemText: item.text, checked: item.checked });
+            renderChecklist(card);
+        });
+        itemsEl.appendChild(div);
+    });
+}
+
+/* ---------- Label Picker ---------- */
+
+function openLabelPicker() {
+    const popover = document.getElementById('label-picker-popover');
+    popover.style.display = popover.style.display === 'none' ? '' : 'none';
+
+    if (popover.style.display !== 'none') {
+        tracker.track('label_picker_open', {});
+        updateLabelPickerState();
+    }
+}
+
+function updateLabelPickerState() {
+    const result = findCard(currentModalCardId);
+    if (!result) return;
+
+    const swatches = document.querySelectorAll('#label-swatches .label-swatch');
+    swatches.forEach(swatch => {
+        const color = swatch.dataset.color;
+        if (result.card.labels.includes(color)) {
+            swatch.classList.add('selected');
+        } else {
+            swatch.classList.remove('selected');
+        }
+    });
+}
+
+function toggleLabel(color) {
+    const result = findCard(currentModalCardId);
+    if (!result) return;
+
+    const idx = result.card.labels.indexOf(color);
+    if (idx !== -1) {
+        result.card.labels.splice(idx, 1);
+        tracker.track('label_remove', { color });
+    } else {
+        result.card.labels.push(color);
+        tracker.track('label_assign', { color });
+    }
+
+    updateLabelPickerState();
+
+    // Update modal labels display
+    const labelsEl = document.getElementById('modal-labels');
+    labelsEl.innerHTML = '';
+    result.card.labels.forEach(c => {
+        const chip = document.createElement('span');
+        chip.className = `modal-label card-label-${c}`;
+        labelsEl.appendChild(chip);
+    });
+}
+
+/* ---------- Add Card Inline ---------- */
+
+function showAddCardForm(columnId) {
+    tracker.track('add_card_click', { column: getColumnName(columnId) });
+
+    const form = document.querySelector(`.add-card-form[data-column="${columnId}"]`);
+    const btn = document.querySelector(`.add-card-btn[data-column="${columnId}"]`);
+    if (form && btn) {
+        form.classList.add('active');
+        btn.style.display = 'none';
+        const textarea = form.querySelector('.add-card-textarea');
+        textarea.value = '';
+        textarea.focus();
+    }
+}
+
+function hideAddCardForm(columnId) {
+    const form = document.querySelector(`.add-card-form[data-column="${columnId}"]`);
+    const btn = document.querySelector(`.add-card-btn[data-column="${columnId}"]`);
+    if (form && btn) {
+        form.classList.remove('active');
+        btn.style.display = '';
+    }
+}
+
+function submitAddCard(columnId) {
+    const textarea = document.querySelector(`.add-card-textarea[data-column="${columnId}"]`);
+    const title = textarea.value.trim();
+    if (!title) return;
+
+    const col = boardData.columns.find(c => c.id === columnId);
+    if (!col) return;
+
+    const newCard = {
+        id: 'c' + (nextCardId++),
+        title,
+        labels: [],
+        checklist: [],
+        due: null,
+        description: ''
+    };
+
+    col.cards.push(newCard);
+
+    tracker.track('card_create_submit', { cardTitle: title, column: col.name });
+
+    renderBoard();
+}
+
+/* ---------- Board Menu Side Panel ---------- */
+
+function openBoardMenu() {
+    const panel = document.getElementById('board-menu-panel');
+    panel.classList.add('open');
+    tracker.track('board_menu_open', {});
+    tracker.track('board_layout_shift', {});
+}
+
+function closeBoardMenu() {
+    const panel = document.getElementById('board-menu-panel');
+    panel.classList.remove('open');
+    activeFilter = null;
+    document.querySelectorAll('.filter-label-btn').forEach(b => b.classList.remove('active'));
+    applyLabelFilter();
+    tracker.track('board_menu_close', {});
+    tracker.track('board_layout_shift', {});
+}
+
+function applyLabelFilter() {
+    const allCards = document.querySelectorAll('.card');
+    let matchCount = 0;
+
+    allCards.forEach(cardEl => {
+        if (!activeFilter) {
+            cardEl.classList.remove('dimmed');
+            return;
+        }
+        const labelChips = cardEl.querySelectorAll('.card-label');
+        let hasLabel = false;
+        labelChips.forEach(chip => {
+            if (chip.dataset.labelColor === activeFilter) hasLabel = true;
+        });
+        if (hasLabel) {
+            cardEl.classList.remove('dimmed');
+            matchCount++;
+        } else {
+            cardEl.classList.add('dimmed');
+        }
+    });
+
+    if (activeFilter) {
+        tracker.track('board_filter_active', { matchingCards: matchCount });
+    }
+}
+
+/* ---------- Board Name Edit ---------- */
+
+function startBoardNameEdit() {
+    const nameEl = document.getElementById('board-name');
+    const current = nameEl.textContent;
+
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.value = current;
+    input.className = 'board-name-input';
+
+    nameEl.replaceWith(input);
+    input.focus();
+    input.select();
+
+    function save() {
+        const val = input.value.trim() || current;
+        const h1 = document.createElement('h1');
+        h1.className = 'board-name';
+        h1.id = 'board-name';
+        h1.textContent = val;
+        input.replaceWith(h1);
+        h1.addEventListener('click', startBoardNameEdit);
+    }
+
+    input.addEventListener('blur', save);
+    input.addEventListener('keydown', function(e) {
+        if (e.key === 'Enter') { e.preventDefault(); input.blur(); }
+        if (e.key === 'Escape') { input.value = current; input.blur(); }
+    });
+}
+
+/* ---------- Description Edit ---------- */
+
+function startDescriptionEdit() {
+    const result = findCard(currentModalCardId);
+    if (!result) return;
+
+    document.getElementById('description-placeholder').style.display = 'none';
+    const textarea = document.getElementById('description-textarea');
+    const actions = document.getElementById('description-actions');
+    textarea.style.display = '';
+    textarea.value = result.card.description || '';
+    actions.style.display = '';
+    textarea.focus();
+}
+
+function saveDescription() {
+    const result = findCard(currentModalCardId);
+    if (!result) return;
+
+    const textarea = document.getElementById('description-textarea');
+    result.card.description = textarea.value.trim();
+
+    textarea.style.display = 'none';
+    document.getElementById('description-actions').style.display = 'none';
+    const placeholder = document.getElementById('description-placeholder');
+    placeholder.style.display = '';
+    placeholder.textContent = result.card.description || 'Add a more detailed description...';
+}
+
+function cancelDescription() {
+    document.getElementById('description-textarea').style.display = 'none';
+    document.getElementById('description-actions').style.display = 'none';
+    document.getElementById('description-placeholder').style.display = '';
+}
+
+/* ---------- Card Title Edit in Modal ---------- */
+
+function startModalTitleEdit() {
+    const result = findCard(currentModalCardId);
+    if (!result) return;
+
+    const titleEl = document.getElementById('modal-title');
+    const inputEl = document.getElementById('modal-title-input');
+    const oldTitle = result.card.title;
+
+    titleEl.style.display = 'none';
+    inputEl.style.display = '';
+    inputEl.value = oldTitle;
+    inputEl.focus();
+    inputEl.select();
+
+    function save() {
+        const newTitle = inputEl.value.trim();
+        if (newTitle && newTitle !== oldTitle) {
+            result.card.title = newTitle;
+            tracker.track('card_title_edit', { oldTitle, newTitle });
+        }
+        titleEl.textContent = result.card.title;
+        titleEl.style.display = '';
+        inputEl.style.display = 'none';
+    }
+
+    inputEl.onblur = save;
+    inputEl.onkeydown = function(e) {
+        if (e.key === 'Enter') { e.preventDefault(); inputEl.blur(); }
+        if (e.key === 'Escape') { inputEl.value = oldTitle; inputEl.blur(); }
+    };
+}
+
+/* ---------- Event Delegation ---------- */
+
+document.addEventListener('mousedown', function(e) {
+    const cardEl = e.target.closest('.card');
+    if (!cardEl) return;
+    if (cardEl.classList.contains('drag-ghost')) return;
+    if (e.target.closest('.card-edit-btn')) return;
+    if (e.target.closest('.quick-edit-container')) return;
+
+    // Delay drag start to distinguish from click
+    const startX = e.clientX;
+    const startY = e.clientY;
+    let moved = false;
+
+    function onMove(ev) {
+        const dx = ev.clientX - startX;
+        const dy = ev.clientY - startY;
+        if (Math.abs(dx) > 5 || Math.abs(dy) > 5) {
+            moved = true;
+            document.removeEventListener('mousemove', onMove);
+            initDrag(e, cardEl);
+        }
+    }
+
+    function onUp() {
+        document.removeEventListener('mousemove', onMove);
+        document.removeEventListener('mouseup', onUp);
+        if (!moved) {
+            // It was a click, not a drag
+            openCardModal(cardEl.dataset.cardId);
+        }
+    }
+
+    document.addEventListener('mousemove', onMove);
+    document.addEventListener('mouseup', onUp);
+});
+
+document.addEventListener('mousemove', moveDrag);
+document.addEventListener('mouseup', endDrag);
+
+// Click delegation
+document.addEventListener('click', function(e) {
+    // Quick edit pencil
+    const editBtn = e.target.closest('.card-edit-btn');
+    if (editBtn) {
+        e.stopPropagation();
+        const cardEl = editBtn.closest('.card');
+        if (cardEl) openQuickEdit(cardEl);
+        return;
+    }
+
+    // Add card button
+    const addBtn = e.target.closest('.add-card-btn');
+    if (addBtn) {
+        showAddCardForm(addBtn.dataset.column);
+        return;
+    }
+
+    // Add card submit
+    const submitBtn = e.target.closest('.add-card-submit');
+    if (submitBtn) {
+        submitAddCard(submitBtn.dataset.column);
+        return;
+    }
+
+    // Add card cancel
+    const cancelBtn = e.target.closest('.add-card-cancel');
+    if (cancelBtn) {
+        hideAddCardForm(cancelBtn.dataset.column);
+        return;
+    }
+
+    // Board menu open
+    if (e.target.closest('#board-menu-btn')) {
+        openBoardMenu();
+        return;
+    }
+
+    // Board menu close
+    if (e.target.closest('#panel-close-btn')) {
+        closeBoardMenu();
+        return;
+    }
+
+    // Star toggle
+    if (e.target.closest('#star-toggle')) {
+        document.getElementById('star-toggle').classList.toggle('starred');
+        return;
+    }
+
+    // Board name edit
+    if (e.target.closest('#board-name')) {
+        startBoardNameEdit();
+        return;
+    }
+
+    // Modal close
+    if (e.target.closest('#modal-close-btn') || e.target === document.getElementById('card-modal-overlay')) {
+        closeCardModal();
+        return;
+    }
+
+    // Modal title edit
+    if (e.target.closest('#modal-title')) {
+        startModalTitleEdit();
+        return;
+    }
+
+    // Description edit
+    if (e.target.closest('#description-placeholder')) {
+        startDescriptionEdit();
+        return;
+    }
+
+    // Description save
+    if (e.target.closest('#desc-save-btn')) {
+        saveDescription();
+        return;
+    }
+
+    // Description cancel
+    if (e.target.closest('#desc-cancel-btn')) {
+        cancelDescription();
+        return;
+    }
+
+    // Labels button in sidebar
+    if (e.target.closest('#sidebar-labels-btn')) {
+        openLabelPicker();
+        return;
+    }
+
+    // Checklist button in sidebar — reveal hidden section and focus the add input
+    if (e.target.closest('#sidebar-checklist-btn')) {
+        const section = document.getElementById('checklist-section');
+        if (section) section.style.display = '';
+        const input = document.getElementById('checklist-add-input');
+        if (input) {
+            input.focus();
+            input.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+        }
+        tracker.track('checklist_section_reveal', {
+            cardId: currentModalCardId,
+        });
+        return;
+    }
+
+    // Label picker close
+    if (e.target.closest('#label-picker-close')) {
+        document.getElementById('label-picker-popover').style.display = 'none';
+        return;
+    }
+
+    // Label swatch click
+    const swatch = e.target.closest('.label-swatch');
+    if (swatch && swatch.closest('#label-swatches')) {
+        toggleLabel(swatch.dataset.color);
+        return;
+    }
+
+    // Filter label btn
+    const filterBtn = e.target.closest('.filter-label-btn');
+    if (filterBtn) {
+        const color = filterBtn.dataset.color;
+        const wasActive = filterBtn.classList.contains('active');
+
+        // Deactivate all
+        document.querySelectorAll('.filter-label-btn').forEach(b => b.classList.remove('active'));
+
+        if (wasActive) {
+            activeFilter = null;
+        } else {
+            filterBtn.classList.add('active');
+            activeFilter = color;
+            tracker.track('board_filter_apply', { filterType: 'label', color });
+        }
+        applyLabelFilter();
+        return;
+    }
+
+    // Clear filter
+    if (e.target.closest('#clear-filter-btn')) {
+        activeFilter = null;
+        document.querySelectorAll('.filter-label-btn').forEach(b => b.classList.remove('active'));
+        applyLabelFilter();
+        return;
+    }
+});
+
+// Add card textarea Enter key
+document.addEventListener('keydown', function(e) {
+    if (e.key === 'Enter' && !e.shiftKey && e.target.classList.contains('add-card-textarea')) {
+        e.preventDefault();
+        submitAddCard(e.target.dataset.column);
+    }
+});
+
+// Checklist add item
+document.addEventListener('click', function(e) {
+    if (e.target.closest('#checklist-add-btn')) {
+        const input = document.getElementById('checklist-add-input');
+        const text = input.value.trim();
+        if (!text) return;
+
+        const result = findCard(currentModalCardId);
+        if (!result) return;
+
+        result.card.checklist.push({ text, checked: false });
+        tracker.track('checklist_add_submit', { itemText: text });
+        input.value = '';
+        renderChecklist(result.card);
+
+        // Also show checklist section if it was hidden
+        document.getElementById('checklist-section').style.display = '';
+    }
+});
+
+// Checklist add via Enter
+document.addEventListener('keydown', function(e) {
+    if (e.key === 'Enter' && e.target.id === 'checklist-add-input') {
+        e.preventDefault();
+        document.getElementById('checklist-add-btn').click();
+    }
+});
+
+// ESC to close modal
+document.addEventListener('keydown', function(e) {
+    if (e.key === 'Escape') {
+        if (document.getElementById('card-modal-overlay').classList.contains('active')) {
+            closeCardModal();
+        }
+    }
+});
+
+/* ---------- Init ---------- */
+renderBoard();

--- a/eval/vidhub/css/vidhub.css
+++ b/eval/vidhub/css/vidhub.css
@@ -1,0 +1,462 @@
+/* ==============================
+   VidHub — YouTube-like Mock Site
+   ============================== */
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+:root {
+    --red: #FF0000;
+    --dark-red: #CC0000;
+    --bg: #fff;
+    --text: #0f0f0f;
+    --text-secondary: #606060;
+    --border: #e5e5e5;
+    --hover-bg: #f2f2f2;
+    --control-bg: rgba(0,0,0,0.85);
+    --masthead-h: 56px;
+}
+
+html { scroll-behavior: smooth; }
+
+body {
+    font-family: "Roboto", Arial, Helvetica, sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    line-height: 1.4;
+}
+
+/* ---- Utility ---- */
+.avatar-circle {
+    width: 36px; height: 36px; border-radius: 50%;
+    display: inline-flex; align-items: center; justify-content: center;
+    font-weight: 600; font-size: 14px; color: #fff; flex-shrink: 0;
+}
+
+/* ==================== MASTHEAD ==================== */
+.masthead {
+    position: fixed; top: 0; left: 0; right: 0; height: var(--masthead-h);
+    background: #fff; display: flex; align-items: center;
+    padding: 0 16px; z-index: 1000;
+    border-bottom: 1px solid var(--border);
+}
+.masthead-left { display: flex; align-items: center; gap: 16px; min-width: 180px; }
+.masthead-center { flex: 1; display: flex; align-items: center; justify-content: center; max-width: 640px; margin: 0 auto; gap: 8px; }
+.masthead-right { display: flex; align-items: center; gap: 8px; min-width: 180px; justify-content: flex-end; }
+
+.masthead-icon {
+    background: none; border: none; cursor: pointer; color: #606060;
+    width: 40px; height: 40px; border-radius: 50%; display: flex; align-items: center; justify-content: center;
+}
+.masthead-icon:hover { background: var(--hover-bg); }
+
+.logo {
+    text-decoration: none; color: var(--text); font-size: 20px; font-weight: 700;
+    display: flex; align-items: center; gap: 2px; white-space: nowrap;
+}
+.logo-icon {
+    display: inline-flex; align-items: center; justify-content: center;
+    background: var(--red); color: #fff; border-radius: 6px;
+    width: 28px; height: 20px; font-size: 12px; margin-right: 4px;
+}
+
+.search-wrapper {
+    display: flex; flex: 1; max-width: 540px;
+}
+.search-input {
+    flex: 1; height: 40px; padding: 0 16px; font-size: 16px;
+    border: 1px solid #ccc; border-right: none; border-radius: 40px 0 0 40px;
+    outline: none;
+}
+.search-input:focus { border-color: #1c62b9; }
+.search-btn {
+    width: 64px; height: 40px; border: 1px solid #ccc; border-left: none;
+    border-radius: 0 40px 40px 0; background: var(--hover-bg); cursor: pointer;
+    display: flex; align-items: center; justify-content: center;
+}
+.search-btn:hover { background: #e0e0e0; }
+
+.masthead-avatar { background: #7c4dff; font-size: 14px; width: 32px; height: 32px; }
+
+/* ==================== HOME FEED ==================== */
+.home-view {
+    padding: calc(var(--masthead-h) + 16px) 32px 32px;
+}
+.feed-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    gap: 40px 16px;
+}
+
+/* Card */
+.video-card {
+    cursor: pointer; text-decoration: none; color: inherit;
+}
+.video-card:hover .card-thumb { border-radius: 0; }
+.card-thumb {
+    position: relative; width: 100%; padding-top: 56.25%;
+    border-radius: 12px; overflow: hidden; background: #ddd;
+    transition: border-radius .15s;
+}
+.card-thumb-color {
+    position: absolute; inset: 0;
+}
+.card-thumb-img {
+    position: absolute; inset: 0;
+    width: 100%; height: 100%;
+    object-fit: cover;
+    display: block;
+}
+.search-thumb-img,
+.up-next-thumb-img {
+    position: absolute; inset: 0;
+    width: 100%; height: 100%;
+    object-fit: cover;
+    display: block;
+}
+.card-duration {
+    position: absolute; bottom: 6px; right: 6px;
+    background: rgba(0,0,0,.8); color: #fff; font-size: 12px; font-weight: 500;
+    padding: 2px 4px; border-radius: 4px; line-height: 1;
+}
+.card-body { display: flex; gap: 12px; padding-top: 12px; }
+.card-avatar { background: #888; width: 36px; height: 36px; font-size: 13px; }
+.card-meta { flex: 1; min-width: 0; }
+.card-title {
+    font-size: 14px; font-weight: 500; line-height: 1.4;
+    display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+.card-channel { font-size: 12px; color: var(--text-secondary); margin-top: 4px; }
+.card-stats { font-size: 12px; color: var(--text-secondary); }
+
+/* ==================== SEARCH RESULTS ==================== */
+.search-view {
+    padding: calc(var(--masthead-h) + 16px) 32px 32px;
+    max-width: 1100px; margin: 0 auto;
+}
+.search-filters { display: flex; gap: 8px; margin-bottom: 20px; }
+.filter-chip {
+    padding: 6px 14px; border-radius: 8px; border: 1px solid var(--border);
+    background: #fff; cursor: pointer; font-size: 14px;
+}
+.filter-chip:hover, .filter-chip.active { background: var(--text); color: #fff; border-color: var(--text); }
+
+.search-result-card {
+    display: flex; gap: 16px; margin-bottom: 16px; cursor: pointer;
+}
+.search-thumb {
+    position: relative; width: 360px; min-width: 360px; aspect-ratio: 16/9;
+    border-radius: 12px; overflow: hidden;
+}
+.search-thumb-color { position: absolute; inset: 0; }
+.search-result-meta { flex: 1; }
+.search-result-meta h3 { font-size: 18px; font-weight: 500; margin-bottom: 6px; }
+.search-result-meta .meta-line { font-size: 12px; color: var(--text-secondary); margin-bottom: 4px; }
+
+/* ==================== WATCH VIEW ==================== */
+.watch-view {
+    padding-top: var(--masthead-h);
+}
+.watch-columns {
+    display: flex; max-width: 1700px; margin: 0 auto; padding: 24px 24px 60px;
+    gap: 24px;
+}
+.watch-left { flex: 7; min-width: 0; }
+.watch-right { flex: 3; min-width: 300px; }
+
+/* --- Player --- */
+.player-wrapper { margin-bottom: 12px; }
+.player-area {
+    position: relative; width: 100%; padding-top: 56.25%;
+    background: #000; border-radius: 12px; overflow: hidden; cursor: pointer;
+    user-select: none;
+}
+.player-surface { position: absolute; inset: 0; }
+
+/* Control Bar */
+.control-bar {
+    position: absolute; bottom: 0; left: 0; right: 0;
+    height: 48px; background: var(--control-bg);
+    display: flex; align-items: center; padding: 0 12px; gap: 6px;
+    opacity: 0; transform: translateY(8px);
+    transition: opacity .25s, transform .25s;
+    z-index: 5;
+}
+.player-area.controls-visible .control-bar {
+    opacity: 1; transform: translateY(0);
+}
+
+.ctrl-btn {
+    background: none; border: none; color: #fff; cursor: pointer;
+    display: flex; align-items: center; justify-content: center;
+    width: 36px; height: 36px; border-radius: 50%; flex-shrink: 0;
+}
+.ctrl-btn:hover { background: rgba(255,255,255,.15); }
+.cc-btn { font-size: 12px; font-weight: 700; letter-spacing: .5px; }
+
+.time-display { color: #ddd; font-size: 13px; white-space: nowrap; margin: 0 6px; flex-shrink: 0; }
+
+/* Progress */
+.progress-area {
+    flex: 1; position: relative; height: 36px;
+    display: flex; align-items: center; cursor: pointer;
+}
+.progress-track {
+    position: relative; width: 100%; height: 4px; background: rgba(255,255,255,.2);
+    border-radius: 2px; transition: height .15s;
+}
+.progress-area:hover .progress-track { height: 8px; }
+.progress-buffered {
+    position: absolute; top: 0; left: 0; width: 40%; height: 100%;
+    background: rgba(255,255,255,.3); border-radius: 2px;
+}
+.progress-played {
+    position: absolute; top: 0; left: 0; width: 0%; height: 100%;
+    background: var(--red); border-radius: 2px; pointer-events: none;
+}
+.progress-scrubber {
+    position: absolute; top: 50%; left: 0%; width: 14px; height: 14px;
+    background: var(--red); border-radius: 50%; transform: translate(-50%, -50%);
+    opacity: 0; transition: opacity .15s; pointer-events: none;
+}
+.progress-area:hover .progress-scrubber { opacity: 1; }
+.progress-tooltip {
+    position: absolute; bottom: calc(100% + 6px); left: 0;
+    background: rgba(0,0,0,.8); color: #fff; font-size: 12px;
+    padding: 4px 8px; border-radius: 4px; white-space: nowrap;
+    pointer-events: none; opacity: 0; transition: opacity .15s;
+    transform: translateX(-50%);
+}
+.progress-area:hover .progress-tooltip { opacity: 1; }
+
+/* Volume */
+.volume-area { display: flex; align-items: center; position: relative; }
+.volume-slider-wrap {
+    width: 0; overflow: hidden; transition: width .2s ease;
+}
+.volume-area.slider-visible .volume-slider-wrap { width: 80px; }
+.volume-slider {
+    -webkit-appearance: none; appearance: none;
+    width: 70px; height: 4px; background: #555; border-radius: 2px; outline: none;
+    margin: 0 4px; cursor: pointer;
+}
+.volume-slider::-webkit-slider-thumb {
+    -webkit-appearance: none; appearance: none;
+    width: 14px; height: 14px; background: #fff; border-radius: 50%; cursor: pointer;
+}
+
+/* Settings Popup */
+.settings-popup {
+    position: absolute; bottom: 56px; right: 12px;
+    background: var(--control-bg); border-radius: 12px; padding: 8px 0;
+    min-width: 250px; z-index: 10; color: #eee; font-size: 14px;
+    overflow: hidden;
+}
+.settings-popup .sp-item {
+    display: flex; align-items: center; justify-content: space-between;
+    padding: 10px 16px; cursor: pointer;
+}
+.settings-popup .sp-item:hover { background: rgba(255,255,255,.1); }
+.settings-popup .sp-back {
+    display: flex; align-items: center; gap: 8px;
+    padding: 10px 16px; cursor: pointer; border-bottom: 1px solid rgba(255,255,255,.15);
+    font-weight: 500;
+}
+.settings-popup .sp-back:hover { background: rgba(255,255,255,.1); }
+.settings-popup .sp-option {
+    display: flex; align-items: center; gap: 10px;
+    padding: 8px 16px; cursor: pointer;
+}
+.settings-popup .sp-option:hover { background: rgba(255,255,255,.1); }
+.settings-popup .sp-option.active::before {
+    content: "✓"; font-size: 14px;
+}
+.settings-popup .sp-option:not(.active)::before {
+    content: ""; display: inline-block; width: 14px;
+}
+
+/* Autoplay row */
+.autoplay-row {
+    display: flex; align-items: center; justify-content: flex-end;
+    gap: 10px; padding: 8px 0; font-size: 14px; color: var(--text-secondary);
+}
+.toggle-switch { position: relative; width: 36px; height: 20px; display: inline-block; }
+.toggle-switch input { opacity: 0; width: 0; height: 0; }
+.toggle-slider {
+    position: absolute; inset: 0; background: #ccc; border-radius: 20px;
+    cursor: pointer; transition: background .2s;
+}
+.toggle-slider::before {
+    content: ""; position: absolute; top: 2px; left: 2px;
+    width: 16px; height: 16px; background: #fff; border-radius: 50%;
+    transition: transform .2s;
+}
+.toggle-switch input:checked + .toggle-slider { background: #065fd4; }
+.toggle-switch input:checked + .toggle-slider::before { transform: translateX(16px); }
+
+/* ---- Video Info ---- */
+.video-info { padding: 12px 0; }
+.video-title { font-size: 20px; font-weight: 600; margin-bottom: 12px; }
+.channel-row {
+    display: flex; align-items: center; justify-content: space-between;
+    flex-wrap: wrap; gap: 12px;
+}
+.channel-left { display: flex; align-items: center; gap: 12px; }
+.channel-avatar { background: #888; }
+.channel-meta { display: flex; flex-direction: column; }
+.channel-name { font-size: 16px; font-weight: 500; }
+.channel-subs { font-size: 12px; color: var(--text-secondary); }
+
+.subscribe-btn {
+    background: var(--text); color: #fff; border: none; border-radius: 20px;
+    padding: 10px 16px; font-size: 14px; font-weight: 500; cursor: pointer;
+}
+.subscribe-btn:hover { opacity: .85; }
+.subscribe-btn.subscribed { background: #e5e5e5; color: var(--text); }
+
+.bell-btn {
+    background: none; border: none; cursor: pointer; color: var(--text);
+    width: 36px; height: 36px; border-radius: 50%;
+    display: flex; align-items: center; justify-content: center;
+}
+.bell-btn:hover { background: var(--hover-bg); }
+
+.action-buttons { display: flex; align-items: center; gap: 2px; }
+.action-btn {
+    display: flex; align-items: center; gap: 6px;
+    background: var(--hover-bg); border: none; border-radius: 20px;
+    padding: 8px 14px; font-size: 14px; cursor: pointer; color: var(--text);
+}
+.action-btn:hover { background: #e0e0e0; }
+.action-btn.active { color: var(--red); }
+.like-btn { border-radius: 20px 0 0 20px; padding-right: 12px; }
+.dislike-btn { border-radius: 0 20px 20px 0; padding-left: 10px; border-left: 1px solid #ccc; }
+.more-btn { font-size: 20px; }
+
+/* Description */
+.description-box {
+    background: var(--hover-bg); border-radius: 12px; padding: 12px 16px;
+    margin-top: 16px; font-size: 14px; cursor: pointer;
+}
+.description-box:hover { background: #e5e5e5; }
+.desc-stats { font-weight: 500; margin-bottom: 8px; }
+.desc-text { white-space: pre-line; }
+.desc-text.collapsed {
+    display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+.desc-toggle {
+    background: none; border: none; cursor: pointer;
+    font-weight: 600; font-size: 14px; margin-top: 4px; color: var(--text);
+}
+
+/* ---- Comments ---- */
+.comments-section { padding: 24px 0 40px; }
+.comments-header {
+    display: flex; align-items: center; gap: 24px; margin-bottom: 24px;
+}
+.comments-header h3 { font-size: 16px; font-weight: 600; }
+
+.sort-dropdown { position: relative; }
+.sort-btn {
+    display: flex; align-items: center; gap: 6px;
+    background: none; border: none; cursor: pointer; font-size: 14px; font-weight: 500;
+    color: var(--text);
+}
+.sort-menu {
+    position: absolute; top: 100%; left: 0; background: #fff;
+    border-radius: 8px; box-shadow: 0 4px 32px rgba(0,0,0,.15);
+    min-width: 180px; z-index: 20; overflow: hidden;
+}
+.sort-option {
+    display: block; width: 100%; text-align: left;
+    padding: 10px 16px; border: none; background: none; cursor: pointer;
+    font-size: 14px;
+}
+.sort-option:hover { background: var(--hover-bg); }
+
+.comment-input-row { display: flex; align-items: flex-start; gap: 12px; margin-bottom: 24px; }
+.comment-input {
+    flex: 1; border: none; border-bottom: 1px solid #ccc;
+    padding: 8px 0; font-size: 14px; outline: none; background: transparent;
+}
+.comment-input:focus { border-bottom-color: var(--text); }
+
+.comment-item { display: flex; gap: 12px; margin-bottom: 20px; }
+.comment-avatar { width: 40px; height: 40px; font-size: 14px; }
+.comment-body { flex: 1; min-width: 0; }
+.comment-author { font-size: 13px; font-weight: 500; }
+.comment-time { font-size: 12px; color: var(--text-secondary); margin-left: 6px; font-weight: 400; }
+.comment-text { font-size: 14px; margin: 6px 0; line-height: 1.5; }
+.comment-actions { display: flex; align-items: center; gap: 8px; }
+.comment-actions button {
+    background: none; border: none; cursor: pointer; display: flex;
+    align-items: center; gap: 4px; color: var(--text-secondary); font-size: 13px;
+}
+.comment-actions button:hover { color: var(--text); }
+
+.reply-toggle {
+    background: none; border: none; cursor: pointer;
+    color: #065fd4; font-size: 14px; font-weight: 500;
+    margin-top: 8px; padding: 6px 12px; border-radius: 20px;
+}
+.reply-toggle:hover { background: rgba(6,95,212,.1); }
+
+.replies-container { margin-left: 52px; margin-top: 4px; }
+.replies-container .comment-item { margin-bottom: 16px; }
+.replies-container .comment-avatar { width: 28px; height: 28px; font-size: 11px; }
+
+.reply-input-row {
+    display: flex; gap: 10px; align-items: flex-start; margin-top: 8px;
+}
+.reply-input-row .comment-avatar { width: 28px; height: 28px; font-size: 11px; }
+.reply-input {
+    display: block; width: 100%; box-sizing: border-box;
+    border: none; border-bottom: 1px solid #ccc;
+    padding: 6px 0; font-size: 13px; outline: none; background: transparent;
+}
+.reply-input:focus { border-bottom-color: var(--text); }
+.reply-submit-row { display: flex; justify-content: flex-end; gap: 8px; margin-top: 6px; }
+.reply-cancel-btn, .reply-submit-btn {
+    padding: 8px 16px; border-radius: 20px; border: none; cursor: pointer; font-size: 14px;
+}
+.reply-cancel-btn { background: none; color: var(--text); }
+.reply-submit-btn { background: #065fd4; color: #fff; opacity: .5; pointer-events: none; }
+.reply-submit-btn.enabled { opacity: 1; pointer-events: auto; }
+
+/* ---- Up Next Sidebar ---- */
+.up-next-heading { font-size: 16px; font-weight: 500; margin-bottom: 16px; }
+.up-next-card {
+    display: flex; gap: 8px; margin-bottom: 8px; cursor: pointer;
+}
+.up-next-card:hover .up-next-thumb { opacity: .85; }
+.up-next-thumb {
+    position: relative; width: 168px; min-width: 168px; aspect-ratio: 16/9;
+    border-radius: 8px; overflow: hidden;
+}
+.up-next-thumb-color { position: absolute; inset: 0; }
+.up-next-dur {
+    position: absolute; bottom: 4px; right: 4px;
+    background: rgba(0,0,0,.8); color: #fff; font-size: 11px; font-weight: 500;
+    padding: 1px 4px; border-radius: 3px; line-height: 1;
+}
+.up-next-meta { flex: 1; min-width: 0; }
+.up-next-title {
+    font-size: 14px; font-weight: 500; line-height: 1.3;
+    display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical;
+    overflow: hidden; margin-bottom: 4px;
+}
+.up-next-channel { font-size: 12px; color: var(--text-secondary); }
+.up-next-stats { font-size: 12px; color: var(--text-secondary); }
+
+/* ==================== RESPONSIVE ==================== */
+@media (max-width: 1000px) {
+    .watch-columns { flex-direction: column; }
+    .watch-right { min-width: 0; }
+    .search-thumb { width: 240px; min-width: 240px; }
+}
+@media (max-width: 700px) {
+    .feed-grid { grid-template-columns: 1fr; }
+    .home-view { padding-left: 16px; padding-right: 16px; }
+    .channel-row { flex-direction: column; align-items: flex-start; }
+}

--- a/eval/vidhub/index.html
+++ b/eval/vidhub/index.html
@@ -1,0 +1,210 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>VidHub</title>
+    <link rel="stylesheet" href="/vidhub/css/vidhub.css">
+</head>
+<body>
+
+<!-- ==================== MASTHEAD ==================== -->
+<header class="masthead">
+    <div class="masthead-left">
+        <button class="masthead-icon hamburger-btn" aria-label="Menu">
+            <svg viewBox="0 0 24 24" width="24" height="24"><path fill="currentColor" d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"/></svg>
+        </button>
+        <a href="/vidhub/" class="logo" id="logo-link">
+            <span class="logo-icon">&#9654;</span> VidHub
+        </a>
+    </div>
+    <div class="masthead-center">
+        <div class="search-wrapper">
+            <input type="text" id="search-input" class="search-input" placeholder="Search">
+            <button class="search-btn" id="search-btn" aria-label="Search">
+                <svg viewBox="0 0 24 24" width="20" height="20"><path fill="currentColor" d="M15.5 14h-.79l-.28-.27A6.47 6.47 0 0016 9.5 6.5 6.5 0 109.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/></svg>
+            </button>
+        </div>
+        <button class="masthead-icon voice-btn" aria-label="Voice search">
+            <svg viewBox="0 0 24 24" width="24" height="24"><path fill="currentColor" d="M12 14c1.66 0 3-1.34 3-3V5c0-1.66-1.34-3-3-3S9 3.34 9 5v6c0 1.66 1.34 3 3 3zm-1-9c0-.55.45-1 1-1s1 .45 1 1v6c0 .55-.45 1-1 1s-1-.45-1-1V5zm6 6c0 2.76-2.24 5-5 5s-5-2.24-5-5H5c0 3.53 2.61 6.43 6 6.92V21h2v-3.08c3.39-.49 6-3.39 6-6.92h-2z"/></svg>
+        </button>
+    </div>
+    <div class="masthead-right">
+        <button class="masthead-icon create-btn" aria-label="Create">
+            <svg viewBox="0 0 24 24" width="24" height="24"><path fill="currentColor" d="M14 13h-3v3H9v-3H6v-2h3V8h2v3h3v2zm3-6H3v12h14v-6.39l4 1.83V8.56l-4 1.83V7m-1-2v2.17l4-1.83v10.32l-4-1.83V18H2V6h14z"/></svg>
+        </button>
+        <button class="masthead-icon notif-btn" aria-label="Notifications">
+            <svg viewBox="0 0 24 24" width="24" height="24"><path fill="currentColor" d="M12 22c1.1 0 2-.9 2-2h-4a2 2 0 002 2zm6-6v-5c0-3.07-1.64-5.64-4.5-6.32V4c0-.83-.67-1.5-1.5-1.5s-1.5.67-1.5 1.5v.68C7.63 5.36 6 7.92 6 11v5l-2 2v1h16v-1l-2-2z"/></svg>
+        </button>
+        <div class="avatar-circle masthead-avatar">Y</div>
+    </div>
+</header>
+
+<!-- ==================== HOME FEED VIEW ==================== -->
+<main id="home-view" class="home-view">
+    <div class="feed-grid" id="feed-grid">
+        <!-- Cards inserted by JS -->
+    </div>
+</main>
+
+<!-- ==================== SEARCH RESULTS VIEW ==================== -->
+<main id="search-view" class="search-view" style="display:none;">
+    <div class="search-filters" id="search-filters">
+        <button class="filter-chip" data-filter="today">Today</button>
+        <button class="filter-chip" data-filter="week">This week</button>
+        <button class="filter-chip" data-filter="medium">4-20 minutes</button>
+    </div>
+    <div class="search-results" id="search-results"></div>
+</main>
+
+<!-- ==================== WATCH VIEW ==================== -->
+<main id="watch-view" class="watch-view" style="display:none;">
+    <div class="watch-columns">
+
+        <!-- LEFT COLUMN -->
+        <div class="watch-left">
+            <!-- Player -->
+            <div class="player-wrapper" id="player-wrapper">
+                <div class="player-area" id="player-area">
+                    <div class="player-surface" id="player-surface"></div>
+
+                    <!-- Control Bar -->
+                    <div class="control-bar" id="control-bar">
+                        <button class="ctrl-btn play-pause-btn" id="play-pause-btn" aria-label="Play">
+                            <svg class="icon-play" viewBox="0 0 24 24" width="28" height="28"><path fill="#fff" d="M8 5v14l11-7z"/></svg>
+                            <svg class="icon-pause" viewBox="0 0 24 24" width="28" height="28" style="display:none"><path fill="#fff" d="M6 19h4V5H6v14zm8-14v14h4V5h-4z"/></svg>
+                        </button>
+                        <button class="ctrl-btn next-btn" aria-label="Next">
+                            <svg viewBox="0 0 24 24" width="22" height="22"><path fill="#fff" d="M6 18l8.5-6L6 6v12zM16 6v12h2V6h-2z"/></svg>
+                        </button>
+
+                        <div class="volume-area" id="volume-area">
+                            <button class="ctrl-btn volume-btn" id="volume-btn" aria-label="Volume">
+                                <svg class="icon-vol-on" viewBox="0 0 24 24" width="22" height="22"><path fill="#fff" d="M3 9v6h4l5 5V4L7 9H3zm13.5 3A4.5 4.5 0 0014 8.5v7a4.47 4.47 0 002.5-3.5zM14 3.23v2.06a6.51 6.51 0 010 13.42v2.06A8.51 8.51 0 0014 3.23z"/></svg>
+                                <svg class="icon-vol-mute" viewBox="0 0 24 24" width="22" height="22" style="display:none"><path fill="#fff" d="M16.5 12A4.5 4.5 0 0014 8.5v2.09l2.44 2.44c.03-.17.06-.34.06-.53zm2.5 0c0 .94-.2 1.82-.54 2.64l1.51 1.51A8.8 8.8 0 0021 12a9 9 0 00-7-8.77v2.06c2.89.86 5 3.54 5 6.71zM4.27 3L3 4.27 7.73 9H3v6h4l5 5v-6.73l4.25 4.25c-.67.52-1.42.93-2.25 1.18v2.06a8.9 8.9 0 003.69-1.81L19.73 21 21 19.73l-9-9L4.27 3zM12 4L9.91 6.09 12 8.18V4z"/></svg>
+                            </button>
+                            <div class="volume-slider-wrap" id="volume-slider-wrap">
+                                <input type="range" class="volume-slider" id="volume-slider" min="0" max="100" value="80">
+                            </div>
+                        </div>
+
+                        <span class="time-display" id="time-display">0:00 / 0:00</span>
+
+                        <div class="progress-area" id="progress-area">
+                            <div class="progress-tooltip" id="progress-tooltip">0:00</div>
+                            <div class="progress-track" id="progress-track">
+                                <div class="progress-buffered"></div>
+                                <div class="progress-played" id="progress-played"></div>
+                                <div class="progress-scrubber" id="progress-scrubber"></div>
+                            </div>
+                        </div>
+
+                        <button class="ctrl-btn cc-btn" aria-label="Subtitles">CC</button>
+                        <button class="ctrl-btn settings-btn" id="settings-btn" aria-label="Settings">
+                            <svg viewBox="0 0 24 24" width="22" height="22"><path fill="#fff" d="M19.14 12.94a7.07 7.07 0 000-1.88l2.03-1.58a.49.49 0 00.12-.61l-1.92-3.32a.49.49 0 00-.59-.22l-2.39.96a7.04 7.04 0 00-1.62-.94l-.36-2.54a.48.48 0 00-.48-.41h-3.84a.48.48 0 00-.48.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96a.49.49 0 00-.59.22L2.74 8.87a.48.48 0 00.12.61l2.03 1.58a7.1 7.1 0 000 1.88l-2.03 1.58a.49.49 0 00-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.36 1.03.7 1.62.94l.36 2.54c.05.24.26.41.48.41h3.84c.24 0 .44-.17.48-.41l.36-2.54c.59-.24 1.13-.57 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61l-2.03-1.58zM12 15.6A3.6 3.6 0 1115.6 12 3.6 3.6 0 0112 15.6z"/></svg>
+                        </button>
+                        <button class="ctrl-btn theater-btn" aria-label="Theater mode">
+                            <svg viewBox="0 0 24 24" width="22" height="22"><rect x="2" y="4" width="20" height="16" rx="2" fill="none" stroke="#fff" stroke-width="2"/></svg>
+                        </button>
+                        <button class="ctrl-btn fullscreen-btn" aria-label="Full screen">
+                            <svg viewBox="0 0 24 24" width="22" height="22"><path fill="#fff" d="M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z"/></svg>
+                        </button>
+                    </div>
+
+                    <!-- Settings Popup -->
+                    <div class="settings-popup" id="settings-popup" style="display:none;">
+                        <!-- populated by JS -->
+                    </div>
+                </div>
+
+                <div class="autoplay-row">
+                    <span>Autoplay</span>
+                    <label class="toggle-switch">
+                        <input type="checkbox" id="autoplay-toggle" checked>
+                        <span class="toggle-slider"></span>
+                    </label>
+                </div>
+            </div>
+
+            <!-- Video Info -->
+            <div class="video-info" id="video-info">
+                <h1 class="video-title" id="watch-title"></h1>
+                <div class="channel-row">
+                    <div class="channel-left">
+                        <div class="avatar-circle channel-avatar" id="watch-channel-avatar"></div>
+                        <div class="channel-meta">
+                            <span class="channel-name" id="watch-channel-name"></span>
+                            <span class="channel-subs" id="watch-channel-subs"></span>
+                        </div>
+                        <button class="subscribe-btn" id="subscribe-btn">Subscribe</button>
+                        <button class="bell-btn" id="bell-btn" aria-label="Notification bell">
+                            <svg viewBox="0 0 24 24" width="20" height="20"><path fill="currentColor" d="M12 22c1.1 0 2-.9 2-2h-4a2 2 0 002 2zm6-6v-5c0-3.07-1.64-5.64-4.5-6.32V4c0-.83-.67-1.5-1.5-1.5s-1.5.67-1.5 1.5v.68C7.63 5.36 6 7.92 6 11v5l-2 2v1h16v-1l-2-2z"/></svg>
+                        </button>
+                    </div>
+                    <div class="action-buttons">
+                        <button class="action-btn like-btn" id="like-btn">
+                            <svg viewBox="0 0 24 24" width="20" height="20"><path fill="currentColor" d="M1 21h4V9H1v12zm22-11a2 2 0 00-2-2h-6.31l.95-4.57.03-.32a1.49 1.49 0 00-.44-1.06L14.17 2 7.59 8.59C7.22 8.95 7 9.45 7 10v10a2 2 0 002 2h9c.83 0 1.54-.5 1.84-1.22l3.02-7.05c.09-.23.14-.47.14-.73v-2z"/></svg>
+                            <span class="like-count" id="like-count"></span>
+                        </button>
+                        <button class="action-btn dislike-btn" id="dislike-btn">
+                            <svg viewBox="0 0 24 24" width="20" height="20"><path fill="currentColor" d="M15 3H6a2 2 0 00-1.84 1.22l-3.02 7.05c-.09.23-.14.47-.14.73v2a2 2 0 002 2h6.31l-.95 4.57-.03.32c0 .41.17.79.44 1.06L9.83 22l6.59-6.59c.36-.36.58-.86.58-1.41V5a2 2 0 00-2-2zm4 0v12h4V3h-4z"/></svg>
+                        </button>
+                        <button class="action-btn share-btn">
+                            <svg viewBox="0 0 24 24" width="20" height="20"><path fill="currentColor" d="M14 9V3l7 7-7 7v-6c-5 0-8.5 1.5-11 5 1-5 4-10 11-11z"/></svg>
+                            <span>Share</span>
+                        </button>
+                        <button class="action-btn more-btn">&#8943;</button>
+                        <button class="action-btn save-btn">
+                            <svg viewBox="0 0 24 24" width="20" height="20"><path fill="currentColor" d="M14 10H2v2h12v-2zm0-4H2v2h12V6zM2 16h8v-2H2v2zm19.5-4.5L23 13l-6.99 7-4.51-4.5L13 14l3.01 3 5.49-5.5z"/></svg>
+                            <span>Save</span>
+                        </button>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Description -->
+            <div class="description-box" id="description-box">
+                <div class="desc-stats" id="desc-stats"></div>
+                <div class="desc-text" id="desc-text"></div>
+                <button class="desc-toggle" id="desc-toggle">...more</button>
+            </div>
+
+            <!-- Comments -->
+            <div class="comments-section" id="comments-section">
+                <div class="comments-header">
+                    <h3 id="comments-count"></h3>
+                    <div class="sort-dropdown" id="sort-dropdown">
+                        <button class="sort-btn" id="sort-btn">
+                            <svg viewBox="0 0 24 24" width="20" height="20"><path fill="currentColor" d="M3 18h6v-2H3v2zM3 6v2h18V6H3zm0 7h12v-2H3v2z"/></svg>
+                            <span id="sort-label">Top comments</span>
+                        </button>
+                        <div class="sort-menu" id="sort-menu" style="display:none;">
+                            <button class="sort-option" data-sort="top">Top comments</button>
+                            <button class="sort-option" data-sort="newest">Newest first</button>
+                        </div>
+                    </div>
+                </div>
+                <div class="comment-input-row">
+                    <div class="avatar-circle comment-avatar">Y</div>
+                    <input type="text" class="comment-input" id="comment-input" placeholder="Add a comment...">
+                </div>
+                <div class="comments-list" id="comments-list">
+                    <!-- inserted by JS -->
+                </div>
+            </div>
+        </div>
+
+        <!-- RIGHT SIDEBAR -->
+        <div class="watch-right">
+            <h3 class="up-next-heading">Up next</h3>
+            <div class="up-next-list" id="up-next-list">
+                <!-- inserted by JS -->
+            </div>
+        </div>
+    </div>
+</main>
+
+<script src="/js/tracker.js"></script>
+<script src="/vidhub/js/vidhub.js"></script>
+</body>
+</html>

--- a/eval/vidhub/js/vidhub.js
+++ b/eval/vidhub/js/vidhub.js
@@ -1,0 +1,805 @@
+/* =====================================================
+   VidHub — YouTube-like Mock Site (single-page, two views)
+   ===================================================== */
+
+// ---------- Tracker ----------
+window.tracker = new AgentTracker('vidhub.com', 'hard');
+
+// ---------- Color palette for thumbnails ----------
+const PALETTE = [
+    '#6c5ce7','#00b894','#e17055','#0984e3','#fdcb6e',
+    '#e84393','#00cec9','#d63031','#a29bfe','#55efc4',
+    '#fab1a0','#74b9ff','#636e72','#2d3436','#b2bec3',
+];
+function thumbColor(idx) { return PALETTE[idx % PALETTE.length]; }
+function avatarColor(name) {
+    let h = 0; for (let i = 0; i < name.length; i++) h = name.charCodeAt(i) + ((h << 5) - h);
+    return PALETTE[Math.abs(h) % PALETTE.length];
+}
+// Lorem Picsum (CC0 Unsplash imagery) — deterministic seed per video so the
+// thumbnail is stable across renders. Size 480x270 matches a 16:9 preview.
+function thumbImage(v)  { return `https://picsum.photos/seed/vidhub-${v.id}/480/270`; }
+function playerImage(v) { return `https://picsum.photos/seed/vidhub-${v.id}/1280/720`; }
+
+// ---------- VIDEO DATA ----------
+const VIDEOS = [
+    { id:'ml-tutorial', title:'Machine Learning Tutorial for Beginners', channel:'TechAcademy', channelId:'tech-academy', subs:'1.2M', views:'1.2M views', ago:'3 months ago', duration:'45:22', durationSec:2722,
+      desc:'A comprehensive introduction to machine learning covering supervised learning, unsupervised learning, neural networks, and more.\n\nTopics covered:\n- What is Machine Learning?\n- Types of ML algorithms\n- Hands-on with Python & scikit-learn\n- Building your first model\n- Evaluation metrics\n- Real-world applications\n\nResources: https://techacademy.example.com/ml', likes:42000 },
+    { id:'transformers-visual-guide', title:'Understanding Transformers — Visual Guide', channel:'AI Explained', channelId:'ai-explained', subs:'890K', views:'890K views', ago:'1 month ago', duration:'28:15', durationSec:1695,
+      desc:'A visual deep-dive into the Transformer architecture that powers GPT, BERT, and modern LLMs.\n\nWe cover:\n- Self-attention mechanism\n- Multi-head attention\n- Positional encoding\n- Encoder-Decoder structure\n- Key/Query/Value intuitions\n\nPaper: "Attention Is All You Need" (Vaswani et al., 2017)', likes:31000 },
+    { id:'rest-api-node', title:'Building a REST API with Node.js', channel:'CodeWithSam', channelId:'code-with-sam', subs:'456K', views:'456K views', ago:'2 weeks ago', duration:'32:10', durationSec:1930,
+      desc:'Learn to build a production-ready REST API from scratch using Node.js, Express, and MongoDB.', likes:18000 },
+    { id:'css-grid-guide', title:'CSS Grid Complete Guide', channel:'DesignCraft', channelId:'design-craft', subs:'350K', views:'678K views', ago:'1 month ago', duration:'24:08', durationSec:1448,
+      desc:'Master CSS Grid layout with practical examples and responsive design patterns.', likes:22000 },
+    { id:'python-data', title:'Python Data Analysis', channel:'DataPro', channelId:'data-pro', subs:'275K', views:'234K views', ago:'5 days ago', duration:'38:45', durationSec:2325,
+      desc:'Pandas, NumPy, and Matplotlib — everything you need for data analysis in Python.', likes:9800 },
+    { id:'react-hooks', title:'React Hooks Deep Dive', channel:'ReactMasters', channelId:'react-masters', subs:'520K', views:'567K views', ago:'3 weeks ago', duration:'41:30', durationSec:2490,
+      desc:'Understand useState, useEffect, useContext, useMemo, useCallback and custom hooks.', likes:24000 },
+    { id:'docker-beginners', title:'Docker for Beginners', channel:'DevOps Daily', channelId:'devops-daily', subs:'310K', views:'345K views', ago:'2 months ago', duration:'29:55', durationSec:1795,
+      desc:'Containers, images, Dockerfiles, and Docker Compose explained from zero.', likes:14000 },
+    { id:'js-es2024', title:'JavaScript ES2024 Features', channel:'JSConf', channelId:'jsconf', subs:'198K', views:'189K views', ago:'1 week ago', duration:'18:22', durationSec:1102,
+      desc:'All the new features landing in ES2024 — Array grouping, Promise.withResolvers, and more.', likes:7600 },
+    { id:'system-design', title:'System Design Interview Prep', channel:'TechAcademy', channelId:'tech-academy', subs:'1.2M', views:'789K views', ago:'4 weeks ago', duration:'52:18', durationSec:3138,
+      desc:'How to approach system design interviews: scaling, caching, load balancing, and real examples.', likes:35000 },
+    { id:'rust-crash', title:'Rust Programming Crash Course', channel:'LowLevel', channelId:'low-level', subs:'145K', views:'123K views', ago:'6 days ago', duration:'55:03', durationSec:3303,
+      desc:'Ownership, borrowing, lifetimes, and why Rust is taking over systems programming.', likes:5400 },
+    { id:'web-security', title:'Web Security Best Practices', channel:'SecureCode', channelId:'secure-code', subs:'220K', views:'234K views', ago:'2 weeks ago', duration:'26:40', durationSec:1600,
+      desc:'XSS, CSRF, SQL injection, CSP headers, and how to protect your web apps.', likes:11000 },
+    { id:'graphql-vs-rest', title:'GraphQL vs REST Explained', channel:'API Guru', channelId:'api-guru', subs:'180K', views:'456K views', ago:'3 weeks ago', duration:'22:15', durationSec:1335,
+      desc:'When to use GraphQL vs REST, pros/cons, and a live migration example.', likes:19000 },
+];
+
+// ---------- COMMENTS DATA ----------
+function getComments(videoId) {
+    const base = [
+        { author:'Alex Rivera', time:'1 week ago', text:'Great content as always! Subscribed.', likes:45 },
+        { author:'Maria K.', time:'3 days ago', text:'Can you do a follow-up on this topic? Would love to see more advanced examples.', likes:23 },
+        { author:'JohnDev42', time:'5 days ago', text:'I was stuck on this for hours. This video fixed it in 10 minutes.', likes:67 },
+        { author:'Priya S.', time:'2 weeks ago', text:'The production quality of these videos keeps getting better.', likes:12 },
+        { author:'TechNerd88', time:'4 days ago', text:'Timestamp 14:22 has a small error — the parameter should be reversed.', likes:89 },
+        { author:'CodeNewbie', time:'1 day ago', text:'Finally someone explains this in plain English. Thank you!', likes:34 },
+        { author:'DevManager', time:'6 days ago', text:'Sharing this with my entire team. Mandatory viewing.', likes:56 },
+        { author:'Lisa Chen', time:'2 days ago', text:'The pacing is perfect — not too fast, not too slow.', likes:18 },
+    ];
+
+    if (videoId === 'transformers-visual-guide') {
+        // Required test comment at top
+        base.unshift({
+            author: 'Dr. Sarah Chen',
+            time: '2 days ago',
+            text: 'This is the best explanation of multi-head attention I\'ve seen. The visual diagrams really help clarify the concept.',
+            likes: 245,
+            replies: [
+                { author:'AI Explained', time:'2 days ago', text:'Thank you Dr. Chen! We spent weeks on those diagrams.', likes:78 },
+                { author:'MLStudent', time:'1 day ago', text:'@Dr. Sarah Chen do you have any paper recommendations for going deeper?', likes:15 },
+                { author:'Dr. Sarah Chen', time:'1 day ago', text:'@MLStudent Definitely read the original "Attention Is All You Need" paper, then Jay Alammar\'s blog posts.', likes:42 },
+                { author:'TransformerFan', time:'12 hours ago', text:'This whole thread is gold. Bookmarked.', likes:9 },
+            ]
+        });
+    }
+    return base;
+}
+
+// ---------- STATE ----------
+let currentView = 'home'; // 'home' | 'watch' | 'search'
+let currentVideoId = null;
+let isPlaying = false;
+let isMuted = false;
+let volumeLevel = 0.8;
+let currentPlaybackSpeed = 1;
+let currentQuality = 'Auto';
+let subscribed = {};
+let liked = {};
+let disliked = {};
+let controlTimeout = null;
+let settingsOpen = false;
+
+// ---------- DOM REFS ----------
+const $home   = document.getElementById('home-view');
+const $search = document.getElementById('search-view');
+const $watch  = document.getElementById('watch-view');
+
+// ---------- HELPERS ----------
+function show(el) { el.style.display = ''; }
+function hide(el) { el.style.display = 'none'; }
+function formatNum(n) {
+    if (typeof n === 'string') return n;
+    if (n >= 1e6) return (n/1e6).toFixed(1).replace(/\.0$/,'') + 'M';
+    if (n >= 1e3) return (n/1e3).toFixed(1).replace(/\.0$/,'') + 'K';
+    return String(n);
+}
+function formatTime(sec) {
+    sec = Math.floor(sec);
+    const m = Math.floor(sec / 60);
+    const s = sec % 60;
+    return m + ':' + String(s).padStart(2, '0');
+}
+
+// ---------- VIEW SWITCHING ----------
+function switchView(view) {
+    currentView = view;
+    hide($home); hide($search); hide($watch);
+    if (view === 'home')   show($home);
+    if (view === 'search') show($search);
+    if (view === 'watch')  show($watch);
+    window.scrollTo(0, 0);
+}
+
+// ---------- RENDER HOME FEED ----------
+function renderFeed() {
+    const grid = document.getElementById('feed-grid');
+    grid.innerHTML = '';
+    VIDEOS.forEach((v, idx) => {
+        const card = document.createElement('div');
+        card.className = 'video-card';
+        card.setAttribute('data-id', v.id);
+        card.innerHTML = `
+            <div class="card-thumb">
+                <div class="card-thumb-color" style="background:${thumbColor(idx)}"></div>
+                <img class="card-thumb-img" src="${thumbImage(v)}" alt="${v.title}" loading="lazy">
+                <span class="card-duration">${v.duration}</span>
+            </div>
+            <div class="card-body">
+                <div class="avatar-circle card-avatar" style="background:${avatarColor(v.channel)}">${v.channel[0]}</div>
+                <div class="card-meta">
+                    <div class="card-title">${v.title}</div>
+                    <div class="card-channel">${v.channel}</div>
+                    <div class="card-stats">${v.views} &middot; ${v.ago}</div>
+                </div>
+            </div>`;
+        card.addEventListener('click', () => openVideo(v.id));
+        grid.appendChild(card);
+    });
+}
+
+// ---------- OPEN VIDEO ----------
+function openVideo(videoId) {
+    currentVideoId = videoId;
+    const v = VIDEOS.find(x => x.id === videoId);
+    if (!v) return;
+
+    tracker.track('video_open', { videoId: v.id, videoTitle: v.title });
+
+    // Fill watch page
+    document.getElementById('watch-title').textContent = v.title;
+    document.getElementById('watch-channel-name').textContent = v.channel;
+    document.getElementById('watch-channel-subs').textContent = v.subs + ' subscribers';
+    const chAv = document.getElementById('watch-channel-avatar');
+    chAv.textContent = v.channel[0];
+    chAv.style.background = avatarColor(v.channel);
+    document.getElementById('like-count').textContent = formatNum(v.likes);
+
+    // Subscribe button state
+    const subBtn = document.getElementById('subscribe-btn');
+    if (subscribed[v.channelId]) {
+        subBtn.textContent = 'Subscribed';
+        subBtn.classList.add('subscribed');
+    } else {
+        subBtn.textContent = 'Subscribe';
+        subBtn.classList.remove('subscribed');
+    }
+
+    // Like/dislike state
+    document.getElementById('like-btn').classList.toggle('active', !!liked[v.id]);
+    document.getElementById('dislike-btn').classList.toggle('active', !!disliked[v.id]);
+
+    // Player surface — fallback color behind a Lorem Picsum hero image
+    const surface = document.getElementById('player-surface');
+    surface.style.background = `${thumbColor(VIDEOS.indexOf(v))} center/cover no-repeat url("${playerImage(v)}")`;
+
+    // Time
+    document.getElementById('time-display').textContent = '0:00 / ' + v.duration;
+
+    // Progress reset
+    document.getElementById('progress-played').style.width = '0%';
+    document.getElementById('progress-scrubber').style.left = '0%';
+
+    // Description
+    const descBox = document.getElementById('description-box');
+    document.getElementById('desc-stats').textContent = v.views + '  ' + v.ago;
+    const descText = document.getElementById('desc-text');
+    descText.textContent = v.desc;
+    descText.classList.add('collapsed');
+    document.getElementById('desc-toggle').textContent = '...more';
+
+    // Reset playing state
+    isPlaying = false;
+    showPlayIcon();
+
+    // Settings popup closed
+    hide(document.getElementById('settings-popup'));
+    settingsOpen = false;
+
+    // Render comments
+    renderComments(v.id);
+
+    // Render up-next
+    renderUpNext(v.id);
+
+    switchView('watch');
+
+    // Track visibility of player area and comments
+    observeVisibility();
+}
+
+// ---------- DESCRIPTION ----------
+(function() {
+    const descBox = document.getElementById('description-box');
+    const descText = document.getElementById('desc-text');
+    const descToggle = document.getElementById('desc-toggle');
+    descBox.addEventListener('click', (e) => {
+        if (descText.classList.contains('collapsed')) {
+            descText.classList.remove('collapsed');
+            descToggle.textContent = 'Show less';
+            tracker.track('description_expand', {});
+        } else {
+            descText.classList.add('collapsed');
+            descToggle.textContent = '...more';
+            tracker.track('description_collapse', {});
+        }
+    });
+})();
+
+// ---------- COMMENTS ----------
+let currentCommentSort = 'top'; // 'top' | 'newest'
+
+function parseAgoHours(s) {
+    // e.g. "2 days ago", "1 week ago", "12 hours ago"
+    const m = String(s || '').match(/^(\d+)\s+(hour|day|week|month|year)s?\s+ago$/i);
+    if (!m) return 1e12;
+    const n = parseInt(m[1], 10);
+    const mult = { hour: 1, day: 24, week: 24 * 7, month: 24 * 30, year: 24 * 365 }[m[2].toLowerCase()];
+    return n * mult;
+}
+
+function renderComments(videoId) {
+    const comments = getComments(videoId).slice();
+    if (currentCommentSort === 'newest') {
+        comments.sort((a, b) => parseAgoHours(a.time) - parseAgoHours(b.time));
+    } else {
+        // 'top' = by likes descending; Dr. Sarah Chen (245) stays first on transformers video
+        comments.sort((a, b) => (b.likes || 0) - (a.likes || 0));
+    }
+    document.getElementById('comments-count').textContent = '1,247 Comments';
+    const list = document.getElementById('comments-list');
+    list.innerHTML = '';
+    comments.forEach(c => {
+        list.appendChild(buildComment(c));
+    });
+}
+
+function buildComment(c) {
+    const item = document.createElement('div');
+    item.className = 'comment-item';
+    item.setAttribute('data-author', c.author);
+    const col = avatarColor(c.author);
+    let html = `
+        <div class="avatar-circle comment-avatar" style="background:${col}">${c.author[0]}</div>
+        <div class="comment-body">
+            <div><span class="comment-author">${c.author}</span><span class="comment-time">${c.time}</span></div>
+            <div class="comment-text">${c.text}</div>
+            <div class="comment-actions">
+                <button class="comment-like-btn">&#128077; ${c.likes}</button>
+                <button class="comment-dislike-btn">&#128078;</button>
+                <button class="comment-reply-btn" data-author="${c.author}">Reply</button>
+            </div>`;
+
+    if (c.replies && c.replies.length) {
+        html += `<button class="reply-toggle" data-count="${c.replies.length}" data-author="${c.author}">${c.replies.length} replies</button>`;
+        html += `<div class="replies-container" style="display:none;" data-parent="${c.author}">`;
+        c.replies.forEach(r => {
+            const rc = avatarColor(r.author);
+            html += `
+                <div class="comment-item" data-author="${r.author}">
+                    <div class="avatar-circle comment-avatar" style="background:${rc}">${r.author[0]}</div>
+                    <div class="comment-body">
+                        <div><span class="comment-author">${r.author}</span><span class="comment-time">${r.time}</span></div>
+                        <div class="comment-text">${r.text}</div>
+                        <div class="comment-actions">
+                            <button class="comment-like-btn">&#128077; ${r.likes}</button>
+                            <button class="comment-dislike-btn">&#128078;</button>
+                            <button class="comment-reply-btn" data-author="${c.author}">Reply</button>
+                        </div>
+                    </div>
+                </div>`;
+        });
+        html += `</div>`;
+    }
+
+    html += `<div class="inline-reply-area" data-parent="${c.author}"></div>`;
+    html += `</div>`;
+    item.innerHTML = html;
+    return item;
+}
+
+// Comment event delegation
+document.getElementById('comments-list').addEventListener('click', (e) => {
+    const target = e.target;
+
+    // Reply toggle (expand/collapse)
+    if (target.classList.contains('reply-toggle')) {
+        const author = target.getAttribute('data-author');
+        const count = parseInt(target.getAttribute('data-count'), 10);
+        const container = target.parentElement.querySelector('.replies-container');
+        if (container) {
+            const isHidden = container.style.display === 'none';
+            container.style.display = isHidden ? '' : 'none';
+            target.textContent = isHidden ? 'Hide replies' : count + ' replies';
+            if (isHidden) {
+                tracker.track('reply_thread_expand', { parentCommentAuthor: author, replyCount: count });
+            }
+        }
+        return;
+    }
+
+    // Reply button
+    if (target.classList.contains('comment-reply-btn')) {
+        const author = target.getAttribute('data-author');
+        tracker.track('reply_click', { parentCommentAuthor: author });
+        // Always resolve to the top-level comment-item (direct child of #comments-list).
+        // Nested replies don't have their own .inline-reply-area, so we hoist up.
+        const commentsList = document.getElementById('comments-list');
+        let topLevel = target.closest('.comment-item');
+        while (topLevel && topLevel.parentElement !== commentsList) {
+            topLevel = topLevel.parentElement && topLevel.parentElement.closest('.comment-item');
+        }
+        const replyArea = topLevel ? topLevel.querySelector('.inline-reply-area') : null;
+        if (!replyArea) return;
+        if (replyArea.querySelector('.reply-input-row')) return; // already open
+        replyArea.innerHTML = `
+            <div class="reply-input-row">
+                <div class="avatar-circle comment-avatar" style="background:#7c4dff">Y</div>
+                <div style="flex:1">
+                    <input type="text" class="reply-input" placeholder="Add a reply..." data-parent="${author}">
+                    <div class="reply-submit-row">
+                        <button class="reply-cancel-btn">Cancel</button>
+                        <button class="reply-submit-btn" data-parent="${author}" disabled>Reply</button>
+                    </div>
+                </div>
+            </div>`;
+        const input = replyArea.querySelector('.reply-input');
+        const submitBtn = replyArea.querySelector('.reply-submit-btn');
+        input.focus();
+        input.addEventListener('input', () => {
+            const hasText = input.value.trim().length > 0;
+            submitBtn.classList.toggle('enabled', hasText);
+            submitBtn.disabled = !hasText;
+            if (hasText) {
+                // Must use key "value" (not value_contains) — evaluator's value_contains
+                // criterion reads event.value and checks substring inclusion.
+                tracker.track('reply_input', { value: input.value.trim() });
+            }
+        });
+        submitBtn.addEventListener('click', () => {
+            if (!input.value.trim()) return;
+            tracker.track('reply_submit', { parentCommentAuthor: author, replyText: input.value.trim() });
+            // Render the new reply visually
+            const newReply = document.createElement('div');
+            newReply.className = 'comment-item';
+            newReply.innerHTML = `
+                <div class="avatar-circle comment-avatar" style="background:#7c4dff">Y</div>
+                <div class="comment-body">
+                    <div><span class="comment-author">You</span><span class="comment-time">Just now</span></div>
+                    <div class="comment-text">${input.value.trim()}</div>
+                </div>`;
+            replyArea.parentElement.querySelector('.replies-container')?.appendChild(newReply);
+            replyArea.innerHTML = '';
+        });
+        replyArea.querySelector('.reply-cancel-btn').addEventListener('click', () => {
+            replyArea.innerHTML = '';
+        });
+        return;
+    }
+});
+
+// Sort dropdown
+(function() {
+    const sortBtn = document.getElementById('sort-btn');
+    const sortMenu = document.getElementById('sort-menu');
+    const sortLabel = document.getElementById('sort-label');
+    sortBtn.addEventListener('click', () => {
+        const open = sortMenu.style.display === 'none';
+        sortMenu.style.display = open ? '' : 'none';
+        if (open) tracker.track('comment_sort_open', {});
+    });
+    sortMenu.addEventListener('click', (e) => {
+        if (e.target.classList.contains('sort-option')) {
+            const sort = e.target.getAttribute('data-sort');
+            sortLabel.textContent = e.target.textContent;
+            sortMenu.style.display = 'none';
+            tracker.track('comment_sort_change', { sort });
+            // Actually re-order the list, then re-attach visibility observers.
+            if (sort !== currentCommentSort) {
+                currentCommentSort = sort;
+                if (currentVideoId) {
+                    renderComments(currentVideoId);
+                    observeVisibility();
+                }
+            }
+        }
+    });
+    document.addEventListener('click', (e) => {
+        if (!sortBtn.contains(e.target) && !sortMenu.contains(e.target)) {
+            sortMenu.style.display = 'none';
+        }
+    });
+})();
+
+// ---------- SUBSCRIBE ----------
+document.getElementById('subscribe-btn').addEventListener('click', () => {
+    const v = VIDEOS.find(x => x.id === currentVideoId);
+    if (!v) return;
+    subscribed[v.channelId] = !subscribed[v.channelId];
+    const btn = document.getElementById('subscribe-btn');
+    if (subscribed[v.channelId]) {
+        btn.textContent = 'Subscribed';
+        btn.classList.add('subscribed');
+        tracker.track('channel_subscribe', { channelId: v.channelId, channelName: v.channel });
+    } else {
+        btn.textContent = 'Subscribe';
+        btn.classList.remove('subscribed');
+    }
+});
+
+// ---------- LIKE / DISLIKE ----------
+document.getElementById('like-btn').addEventListener('click', () => {
+    if (!currentVideoId) return;
+    liked[currentVideoId] = !liked[currentVideoId];
+    if (liked[currentVideoId]) disliked[currentVideoId] = false;
+    document.getElementById('like-btn').classList.toggle('active', liked[currentVideoId]);
+    document.getElementById('dislike-btn').classList.toggle('active', false);
+    tracker.track('video_like', { videoId: currentVideoId });
+});
+document.getElementById('dislike-btn').addEventListener('click', () => {
+    if (!currentVideoId) return;
+    disliked[currentVideoId] = !disliked[currentVideoId];
+    if (disliked[currentVideoId]) liked[currentVideoId] = false;
+    document.getElementById('dislike-btn').classList.toggle('active', disliked[currentVideoId]);
+    document.getElementById('like-btn').classList.toggle('active', false);
+    tracker.track('video_dislike', { videoId: currentVideoId });
+});
+
+// ---------- PLAYER CONTROLS (auto-hide) ----------
+(function() {
+    const playerArea = document.getElementById('player-area');
+
+    function showControls() {
+        playerArea.classList.add('controls-visible');
+        tracker.track('player_controls_show', {});
+        resetControlTimer();
+    }
+    function hideControls() {
+        playerArea.classList.remove('controls-visible');
+        tracker.track('player_controls_hide', {});
+    }
+    function resetControlTimer() {
+        clearTimeout(controlTimeout);
+        controlTimeout = setTimeout(hideControls, 3000);
+    }
+
+    playerArea.addEventListener('mouseenter', showControls);
+    playerArea.addEventListener('mousemove', () => {
+        if (!playerArea.classList.contains('controls-visible')) {
+            showControls();
+        } else {
+            resetControlTimer();
+        }
+    });
+    playerArea.addEventListener('mouseleave', () => {
+        clearTimeout(controlTimeout);
+        hideControls();
+    });
+    playerArea.addEventListener('click', (e) => {
+        // Ignore clicks on control bar itself
+        if (e.target.closest('.control-bar') || e.target.closest('.settings-popup')) return;
+        togglePlay();
+    });
+})();
+
+// ---------- PLAY / PAUSE ----------
+function showPlayIcon() {
+    document.querySelector('.icon-play').style.display = '';
+    document.querySelector('.icon-pause').style.display = 'none';
+}
+function showPauseIcon() {
+    document.querySelector('.icon-play').style.display = 'none';
+    document.querySelector('.icon-pause').style.display = '';
+}
+function togglePlay() {
+    isPlaying = !isPlaying;
+    if (isPlaying) { showPauseIcon(); tracker.track('player_play', {}); }
+    else           { showPlayIcon();  tracker.track('player_pause', {}); }
+}
+document.getElementById('play-pause-btn').addEventListener('click', (e) => {
+    e.stopPropagation();
+    togglePlay();
+});
+
+// ---------- VOLUME ----------
+(function() {
+    const area   = document.getElementById('volume-area');
+    const btn    = document.getElementById('volume-btn');
+    const slider = document.getElementById('volume-slider');
+
+    area.addEventListener('mouseenter', () => {
+        area.classList.add('slider-visible');
+        tracker.track('volume_slider_reveal', {});
+    });
+    area.addEventListener('mouseleave', () => {
+        area.classList.remove('slider-visible');
+    });
+
+    btn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        isMuted = !isMuted;
+        document.querySelector('.icon-vol-on').style.display  = isMuted ? 'none' : '';
+        document.querySelector('.icon-vol-mute').style.display = isMuted ? ''     : 'none';
+        slider.value = isMuted ? 0 : volumeLevel * 100;
+        tracker.track('volume_change', { level: isMuted ? 0 : volumeLevel });
+    });
+
+    slider.addEventListener('input', () => {
+        volumeLevel = slider.value / 100;
+        isMuted = volumeLevel === 0;
+        document.querySelector('.icon-vol-on').style.display  = isMuted ? 'none' : '';
+        document.querySelector('.icon-vol-mute').style.display = isMuted ? ''     : 'none';
+        tracker.track('volume_change', { level: volumeLevel });
+    });
+})();
+
+// ---------- PROGRESS BAR ----------
+(function() {
+    const area     = document.getElementById('progress-area');
+    const track    = document.getElementById('progress-track');
+    const played   = document.getElementById('progress-played');
+    const scrubber = document.getElementById('progress-scrubber');
+    const tooltip  = document.getElementById('progress-tooltip');
+
+    area.addEventListener('mousemove', (e) => {
+        const rect = track.getBoundingClientRect();
+        let frac = (e.clientX - rect.left) / rect.width;
+        frac = Math.max(0, Math.min(1, frac));
+        tooltip.style.left = (frac * 100) + '%';
+        const v = VIDEOS.find(x => x.id === currentVideoId);
+        if (v) tooltip.textContent = formatTime(frac * v.durationSec);
+    });
+
+    area.addEventListener('click', (e) => {
+        const rect = track.getBoundingClientRect();
+        let frac = (e.clientX - rect.left) / rect.width;
+        frac = Math.max(0, Math.min(1, frac));
+        played.style.width = (frac * 100) + '%';
+        scrubber.style.left = (frac * 100) + '%';
+        const v = VIDEOS.find(x => x.id === currentVideoId);
+        if (v) {
+            document.getElementById('time-display').textContent = formatTime(frac * v.durationSec) + ' / ' + v.duration;
+        }
+        tracker.track('player_seek', { position: parseFloat(frac.toFixed(3)) });
+    });
+})();
+
+// ---------- SETTINGS POPUP ----------
+(function() {
+    const btn   = document.getElementById('settings-btn');
+    const popup = document.getElementById('settings-popup');
+
+    btn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        if (settingsOpen) { closeSettings(); return; }
+        openSettingsMain();
+    });
+
+    // Close settings when clicking outside
+    document.addEventListener('click', (e) => {
+        if (settingsOpen && !popup.contains(e.target) && e.target !== btn) {
+            closeSettings();
+        }
+    });
+
+    function closeSettings() {
+        hide(popup);
+        settingsOpen = false;
+    }
+
+    function openSettingsMain() {
+        settingsOpen = true;
+        show(popup);
+        tracker.track('settings_open', {});
+        popup.innerHTML = `
+            <div class="sp-item" data-sub="playback-speed">
+                <span>Playback speed</span><span>${currentPlaybackSpeed === 1 ? 'Normal' : currentPlaybackSpeed + 'x'}</span>
+            </div>
+            <div class="sp-item" data-sub="quality">
+                <span>Quality</span><span>${currentQuality}</span>
+            </div>
+            <div class="sp-item" data-sub="subtitles">
+                <span>Subtitles/CC</span><span>Off</span>
+            </div>`;
+        popup.querySelectorAll('.sp-item').forEach(item => {
+            item.addEventListener('click', (ev) => {
+                ev.stopPropagation();
+                const sub = item.getAttribute('data-sub');
+                tracker.track('settings_submenu_open', { submenu: sub });
+                if (sub === 'playback-speed') openSpeedSub();
+                else if (sub === 'quality') openQualitySub();
+                else if (sub === 'subtitles') openSubtitlesSub();
+            });
+        });
+    }
+
+    function openSpeedSub() {
+        const speeds = [0.25, 0.5, 1, 1.25, 1.5, 2];
+        popup.innerHTML = `<div class="sp-back">&larr; Playback speed</div>` +
+            speeds.map(s => `<div class="sp-option ${s === currentPlaybackSpeed ? 'active' : ''}" data-speed="${s}">${s === 1 ? 'Normal' : s + 'x'}</div>`).join('');
+        popup.querySelector('.sp-back').addEventListener('click', (ev) => { ev.stopPropagation(); openSettingsMain(); });
+        popup.querySelectorAll('.sp-option').forEach(opt => {
+            opt.addEventListener('click', (ev) => {
+                ev.stopPropagation();
+                currentPlaybackSpeed = parseFloat(opt.getAttribute('data-speed'));
+                tracker.track('playback_speed_change', { speed: currentPlaybackSpeed });
+                openSettingsMain();
+            });
+        });
+    }
+
+    function openQualitySub() {
+        const quals = ['1080p', '720p', '480p', '360p', 'Auto'];
+        popup.innerHTML = `<div class="sp-back">&larr; Quality</div>` +
+            quals.map(q => `<div class="sp-option ${q === currentQuality ? 'active' : ''}" data-q="${q}">${q}</div>`).join('');
+        popup.querySelector('.sp-back').addEventListener('click', (ev) => { ev.stopPropagation(); openSettingsMain(); });
+        popup.querySelectorAll('.sp-option').forEach(opt => {
+            opt.addEventListener('click', (ev) => {
+                ev.stopPropagation();
+                currentQuality = opt.getAttribute('data-q');
+                tracker.track('quality_change', { quality: currentQuality });
+                openSettingsMain();
+            });
+        });
+    }
+
+    function openSubtitlesSub() {
+        const opts = ['Off', 'English', 'English (auto-generated)'];
+        popup.innerHTML = `<div class="sp-back">&larr; Subtitles/CC</div>` +
+            opts.map(o => `<div class="sp-option ${o === 'Off' ? 'active' : ''}" data-cc="${o}">${o}</div>`).join('');
+        popup.querySelector('.sp-back').addEventListener('click', (ev) => { ev.stopPropagation(); openSettingsMain(); });
+    }
+})();
+
+// ---------- SEARCH ----------
+(function() {
+    const input = document.getElementById('search-input');
+    const btn   = document.getElementById('search-btn');
+
+    function doSearch() {
+        const q = input.value.trim();
+        if (!q) return;
+        tracker.track('search_submit', { query: q });
+        const results = VIDEOS.filter(v => v.title.toLowerCase().includes(q.toLowerCase()) || v.channel.toLowerCase().includes(q.toLowerCase()));
+        renderSearchResults(results, q);
+        switchView('search');
+    }
+
+    btn.addEventListener('click', doSearch);
+    input.addEventListener('keydown', (e) => { if (e.key === 'Enter') doSearch(); });
+})();
+
+function renderSearchResults(results, query) {
+    const container = document.getElementById('search-results');
+    container.innerHTML = '';
+    if (results.length === 0) {
+        container.innerHTML = '<p style="color:#606060;padding:40px 0;">No results found for "' + query + '"</p>';
+        return;
+    }
+    results.forEach((v, idx) => {
+        const card = document.createElement('div');
+        card.className = 'search-result-card';
+        card.innerHTML = `
+            <div class="search-thumb">
+                <div class="search-thumb-color" style="background:${thumbColor(VIDEOS.indexOf(v))}"></div>
+                <img class="search-thumb-img" src="${thumbImage(v)}" alt="${v.title}" loading="lazy">
+                <span class="card-duration">${v.duration}</span>
+            </div>
+            <div class="search-result-meta">
+                <h3>${v.title}</h3>
+                <div class="meta-line">${v.views} &middot; ${v.ago}</div>
+                <div class="meta-line">${v.channel}</div>
+                <div class="meta-line" style="margin-top:8px;">${v.desc.substring(0, 120)}...</div>
+            </div>`;
+        card.addEventListener('click', () => openVideo(v.id));
+        container.appendChild(card);
+    });
+}
+
+// ---------- UP NEXT SIDEBAR ----------
+function renderUpNext(currentId) {
+    const list = document.getElementById('up-next-list');
+    list.innerHTML = '';
+    const others = VIDEOS.filter(v => v.id !== currentId);
+    // Show up to 8
+    others.slice(0, 8).forEach((v) => {
+        const card = document.createElement('div');
+        card.className = 'up-next-card';
+        card.innerHTML = `
+            <div class="up-next-thumb">
+                <div class="up-next-thumb-color" style="background:${thumbColor(VIDEOS.indexOf(v))}"></div>
+                <img class="up-next-thumb-img" src="${thumbImage(v)}" alt="${v.title}" loading="lazy">
+                <span class="up-next-dur">${v.duration}</span>
+            </div>
+            <div class="up-next-meta">
+                <div class="up-next-title">${v.title}</div>
+                <div class="up-next-channel">${v.channel}</div>
+                <div class="up-next-stats">${v.views} &middot; ${v.ago}</div>
+            </div>`;
+        card.addEventListener('click', () => openVideo(v.id));
+        list.appendChild(card);
+    });
+}
+
+// ---------- LOGO → HOME ----------
+document.getElementById('logo-link').addEventListener('click', (e) => {
+    e.preventDefault();
+    switchView('home');
+});
+
+// ---------- INTERSECTION OBSERVERS (visibility tracking) ----------
+let playerObserver = null;
+let commentsObserver = null;
+let commentItemObservers = [];
+
+function observeVisibility() {
+    // Clean up previous observers
+    if (playerObserver) playerObserver.disconnect();
+    if (commentsObserver) commentsObserver.disconnect();
+    commentItemObservers.forEach(o => o.disconnect());
+    commentItemObservers = [];
+
+    // Track player_area_visible, but only after the user has scrolled away
+    // from the player first — the player starts above the fold so the naive
+    // observer would fire immediately on watch-page load and auto-credit any
+    // "scroll back to the player" criterion.
+    let playerHasLeftViewport = false;
+    playerObserver = new IntersectionObserver((entries) => {
+        entries.forEach(e => {
+            if (!e.isIntersecting) {
+                playerHasLeftViewport = true;
+                return;
+            }
+            if (playerHasLeftViewport) {
+                tracker.track('player_area_visible', {});
+                playerObserver.disconnect();
+            }
+        });
+    }, { threshold: 0.5 });
+    playerObserver.observe(document.getElementById('player-area'));
+
+    // Track comments_section_visible
+    commentsObserver = new IntersectionObserver((entries) => {
+        entries.forEach(e => {
+            if (e.isIntersecting) {
+                tracker.track('comments_section_visible', {});
+                commentsObserver.disconnect();
+            }
+        });
+    }, { threshold: 0.1 });
+    commentsObserver.observe(document.getElementById('comments-section'));
+
+    // Track individual comment visibility
+    document.querySelectorAll('#comments-list > .comment-item').forEach(item => {
+        const author = item.getAttribute('data-author');
+        if (!author) return;
+        const obs = new IntersectionObserver((entries) => {
+            entries.forEach(e => {
+                if (e.isIntersecting) {
+                    tracker.track('comment_visible', { authorName: author });
+                    obs.disconnect();
+                }
+            });
+        }, { threshold: 0.5 });
+        obs.observe(item);
+        commentItemObservers.push(obs);
+    });
+}
+
+// ---------- INIT ----------
+renderFeed();
+switchView('home');


### PR DESCRIPTION
## Summary
- Adds 4 new mock eval sites (MapQuest, StayBnB, TaskFlow, VidHub) with 8 test-case YAMLs targeting interaction primitives not covered by the existing suite (panel-state navigation, dual-handle price slider, HTML5 drag-and-drop, auto-hide player controls).
- Adds `eval/AGENTS.md` with non-obvious implementation gotchas (stacking contexts, default-state event anti-pattern, tracker case normalization).
- Adds full-eval observation report from a 105-run benchmark pass across qwen3.5-flash, qwen3.5-plus, and qwen3.6-plus. Documents 7 recurring OpenBrowser agent issues with per-test evidence and proposed fixes.

## Test plan
- [x] All 35 tests load without schema errors
- [x] Full 105-run eval completed (~3h, 82.9% avg pass rate across models)
- [ ] Reviewer sanity-checks site implementations and the observation report

🤖 Generated with [Claude Code](https://claude.com/claude-code)