### PR TITLE
Bundle keyframes into event_detail; recover stalled compiler agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,7 +80,3 @@ eval/output
 # Claude Code local state
 .claude/
 CLAUDE.local.md
-catchup.md
-debug_toggle.js
-servererror
-tmp/

--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,11 @@ reference/
 eval/.server_port
 eval/.locks/
 eval/output
+
+# Claude Code local state
+.claude/
+CLAUDE.local.md
+catchup.md
+debug_toggle.js
+servererror
+tmp/

--- a/extension/src/__tests__/recording-keyframe-policy.test.ts
+++ b/extension/src/__tests__/recording-keyframe-policy.test.ts
@@ -46,8 +46,8 @@ describe('recording keyframe policy', () => {
     const options = getRecordingKeyframeCaptureOptions();
 
     expect(options.preferredFormat).toBe('jpeg');
-    expect(options.maxOutputWidth).toBe(960);
-    expect(options.maxOutputHeight).toBe(540);
+    expect(options.maxOutputWidth).toBe(1920);
+    expect(options.maxOutputHeight).toBe(1080);
     expect(options.warmupBeforeCapture).toBe(true);
     expect(options.settleBeforeCapture).toBe(true);
   });
@@ -57,8 +57,8 @@ describe('recording keyframe policy', () => {
 
     expect(getRecordingPreActionWaitForRender()).toBe(0);
     expect(options.preferredFormat).toBe('jpeg');
-    expect(options.maxOutputWidth).toBe(960);
-    expect(options.maxOutputHeight).toBe(540);
+    expect(options.maxOutputWidth).toBe(1920);
+    expect(options.maxOutputHeight).toBe(1080);
     expect(options.warmupBeforeCapture).toBe(false);
     expect(options.settleBeforeCapture).toBe(false);
   });

--- a/extension/src/content/index.ts
+++ b/extension/src/content/index.ts
@@ -19,6 +19,16 @@ let scrollTimeoutId: number | null = null;
 const CONTAINER_TEXT_MAX_LENGTH = 280;
 const ELEMENT_HTML_MAX_LENGTH = 1500;
 
+// Drag-and-drop recording state
+const DRAG_DISTANCE_THRESHOLD = 30;
+let pendingDrag: {
+  sourceElement: Element;
+  startX: number;
+  startY: number;
+} | null = null;
+let dragConfirmedByHtml5 = false;
+let suppressNextClickRecording = false;
+
 function isOpenBrowserUiPage(): boolean {
   if (
     window.location.protocol !== 'http:' &&
@@ -537,6 +547,14 @@ function findOwningForm(element: Element): HTMLFormElement | null {
   return element instanceof HTMLFormElement ? element : element.closest('form');
 }
 
+function isSliderLikeElement(el: Element): boolean {
+  if (el instanceof HTMLInputElement && el.type === 'range') {
+    return true;
+  }
+  const role = el.getAttribute('role');
+  return role === 'slider' && el.hasAttribute('aria-valuemin');
+}
+
 function installRecordingListeners(): void {
   document.addEventListener(
     'pointerdown',
@@ -553,6 +571,13 @@ function installRecordingListeners(): void {
         return;
       }
 
+      pendingDrag = {
+        sourceElement: event.target,
+        startX: pointerEvent.clientX,
+        startY: pointerEvent.clientY,
+      };
+      dragConfirmedByHtml5 = false;
+
       const form = findOwningForm(event.target);
       sendRecordingPreAction('click', {
         element: serializeElement(event.target),
@@ -564,9 +589,97 @@ function installRecordingListeners(): void {
     true,
   );
 
+  // HTML5 drag-and-drop detection
+  document.addEventListener(
+    'dragstart',
+    (event) => {
+      if (!shouldRecordTrustedEvent(event) || !pendingDrag) {
+        return;
+      }
+      dragConfirmedByHtml5 = true;
+    },
+    true,
+  );
+
+  document.addEventListener(
+    'drop',
+    (event) => {
+      if (
+        !shouldRecordTrustedEvent(event) ||
+        !isElement(event.target) ||
+        !pendingDrag ||
+        !dragConfirmedByHtml5
+      ) {
+        return;
+      }
+
+      sendRecordingEvent('drag_and_drop', {
+        sourceElement: serializeElement(pendingDrag.sourceElement),
+        targetElement: serializeElement(event.target),
+        startX: pendingDrag.startX,
+        startY: pendingDrag.startY,
+        endX: (event as DragEvent).clientX,
+        endY: (event as DragEvent).clientY,
+      });
+      suppressNextClickRecording = true;
+      pendingDrag = null;
+      dragConfirmedByHtml5 = false;
+    },
+    true,
+  );
+
+  document.addEventListener(
+    'dragend',
+    () => {
+      // Cleanup for cancelled HTML5 drags where drop never fired
+      pendingDrag = null;
+      dragConfirmedByHtml5 = false;
+    },
+    true,
+  );
+
+  // Pointer-based drag detection (for non-HTML5 DnD libraries)
+  document.addEventListener(
+    'pointerup',
+    (event) => {
+      if (!pendingDrag || dragConfirmedByHtml5) {
+        pendingDrag = null;
+        return;
+      }
+
+      if (!shouldRecordTrustedEvent(event) || !isElement(event.target)) {
+        pendingDrag = null;
+        return;
+      }
+
+      const dx = (event as PointerEvent).clientX - pendingDrag.startX;
+      const dy = (event as PointerEvent).clientY - pendingDrag.startY;
+      const distance = Math.sqrt(dx * dx + dy * dy);
+
+      if (distance > DRAG_DISTANCE_THRESHOLD) {
+        sendRecordingEvent('drag_and_drop', {
+          sourceElement: serializeElement(pendingDrag.sourceElement),
+          targetElement: serializeElement(event.target),
+          startX: pendingDrag.startX,
+          startY: pendingDrag.startY,
+          endX: (event as PointerEvent).clientX,
+          endY: (event as PointerEvent).clientY,
+        });
+        suppressNextClickRecording = true;
+      }
+
+      pendingDrag = null;
+    },
+    true,
+  );
+
   document.addEventListener(
     'click',
     (event) => {
+      if (suppressNextClickRecording) {
+        suppressNextClickRecording = false;
+        return;
+      }
       if (!shouldRecordTrustedEvent(event) || !isElement(event.target)) {
         return;
       }
@@ -598,6 +711,15 @@ function installRecordingListeners(): void {
         return;
       }
 
+      // Suppress per-frame input events from range sliders — the final
+      // value is captured by the change handler as a set_slider event.
+      if (
+        event.target instanceof HTMLInputElement &&
+        event.target.type === 'range'
+      ) {
+        return;
+      }
+
       sendRecordingEvent('input', {
         element: serializeElement(event.target),
       });
@@ -609,6 +731,26 @@ function installRecordingListeners(): void {
     'change',
     (event) => {
       if (!shouldRecordTrustedEvent(event) || !isElement(event.target)) {
+        return;
+      }
+
+      if (isSliderLikeElement(event.target)) {
+        const el = event.target;
+        sendRecordingEvent('set_slider', {
+          element: serializeElement(el),
+          value:
+            el instanceof HTMLInputElement
+              ? el.value
+              : el.getAttribute('aria-valuenow'),
+          min:
+            el instanceof HTMLInputElement
+              ? el.min
+              : el.getAttribute('aria-valuemin'),
+          max:
+            el instanceof HTMLInputElement
+              ? el.max
+              : el.getAttribute('aria-valuemax'),
+        });
         return;
       }
 

--- a/extension/src/recording/keyframe-annotation.ts
+++ b/extension/src/recording/keyframe-annotation.ts
@@ -1,6 +1,12 @@
 import { calculateConfirmationBannerLayout } from '../commands/single-highlight';
 
-type AnnotatableRecordingEventType = 'click' | 'focus' | 'change' | 'submit';
+type AnnotatableRecordingEventType =
+  | 'click'
+  | 'focus'
+  | 'change'
+  | 'submit'
+  | 'drag_and_drop'
+  | 'set_slider';
 
 interface RecordingEventBBox {
   x: number;
@@ -11,7 +17,7 @@ interface RecordingEventBBox {
 
 interface RecordingKeyframeAnnotationTarget {
   bbox: RecordingEventBBox;
-  intendedAction: 'click' | 'keyboard_input';
+  intendedAction: 'click' | 'keyboard_input' | 'drag_and_drop' | 'set_slider';
   message: string;
 }
 
@@ -57,7 +63,14 @@ function getEventTargetRecord(
   eventType: AnnotatableRecordingEventType,
   eventData: Record<string, unknown>,
 ): Record<string, unknown> | null {
-  const candidate = eventType === 'submit' ? eventData.form : eventData.element;
+  let candidate: unknown;
+  if (eventType === 'submit') {
+    candidate = eventData.form;
+  } else if (eventType === 'drag_and_drop') {
+    candidate = eventData.targetElement;
+  } else {
+    candidate = eventData.element;
+  }
 
   return isObjectRecord(candidate) ? candidate : null;
 }
@@ -77,6 +90,14 @@ export function getRecordingAnnotationMessage(
     return 'This is the input the user just focused.';
   }
 
+  if (eventType === 'drag_and_drop') {
+    return 'This is where the user dropped the dragged element.';
+  }
+
+  if (eventType === 'set_slider') {
+    return 'This is the slider the user adjusted.';
+  }
+
   return 'This is the element the user just typed into.';
 }
 
@@ -88,7 +109,9 @@ export function resolveRecordingKeyframeAnnotationTarget(
     eventType !== 'click' &&
     eventType !== 'focus' &&
     eventType !== 'change' &&
-    eventType !== 'submit'
+    eventType !== 'submit' &&
+    eventType !== 'drag_and_drop' &&
+    eventType !== 'set_slider'
   ) {
     return null;
   }
@@ -103,9 +126,20 @@ export function resolveRecordingKeyframeAnnotationTarget(
     return null;
   }
 
+  let intendedAction: RecordingKeyframeAnnotationTarget['intendedAction'];
+  if (eventType === 'click') {
+    intendedAction = 'click';
+  } else if (eventType === 'drag_and_drop') {
+    intendedAction = 'drag_and_drop';
+  } else if (eventType === 'set_slider') {
+    intendedAction = 'set_slider';
+  } else {
+    intendedAction = 'keyboard_input';
+  }
+
   return {
     bbox,
-    intendedAction: eventType === 'click' ? 'click' : 'keyboard_input',
+    intendedAction,
     message: getRecordingAnnotationMessage(eventType),
   };
 }

--- a/extension/src/recording/keyframe-policy.ts
+++ b/extension/src/recording/keyframe-policy.ts
@@ -1,6 +1,12 @@
 import type { ScreenshotCaptureOptions } from '../utils/highlight-screenshot';
 
-const ACTION_KEYFRAME_EVENT_TYPES = new Set(['click', 'change', 'submit']);
+const ACTION_KEYFRAME_EVENT_TYPES = new Set([
+  'click',
+  'change',
+  'submit',
+  'drag_and_drop',
+  'set_slider',
+]);
 const DEFAULT_RECORDING_KEYFRAME_WAIT_MS = 180;
 const ACTION_RECORDING_KEYFRAME_WAIT_MS = 60;
 const PRE_ACTION_RECORDING_KEYFRAME_WAIT_MS = 0;

--- a/extension/src/recording/keyframe-policy.ts
+++ b/extension/src/recording/keyframe-policy.ts
@@ -10,10 +10,11 @@ const ACTION_KEYFRAME_EVENT_TYPES = new Set([
 const DEFAULT_RECORDING_KEYFRAME_WAIT_MS = 180;
 const ACTION_RECORDING_KEYFRAME_WAIT_MS = 60;
 const PRE_ACTION_RECORDING_KEYFRAME_WAIT_MS = 0;
+const AFTER_ACTION_RECORDING_KEYFRAME_WAIT_MS = 400;
 const RECORDING_KEYFRAME_CAPTURE_OPTIONS: ScreenshotCaptureOptions = {
   preferredFormat: 'jpeg',
-  maxOutputWidth: 960,
-  maxOutputHeight: 540,
+  maxOutputWidth: 1920,
+  maxOutputHeight: 1080,
   warmupBeforeCapture: true,
   warmupMaxAttempts: 1,
   settleBeforeCapture: true,
@@ -23,8 +24,8 @@ const RECORDING_KEYFRAME_CAPTURE_OPTIONS: ScreenshotCaptureOptions = {
 const PRE_ACTION_RECORDING_KEYFRAME_CAPTURE_OPTIONS: ScreenshotCaptureOptions =
   {
     preferredFormat: 'jpeg',
-    maxOutputWidth: 960,
-    maxOutputHeight: 540,
+    maxOutputWidth: 1920,
+    maxOutputHeight: 1080,
     warmupBeforeCapture: false,
     settleBeforeCapture: false,
   };
@@ -110,6 +111,14 @@ export function getRecordingPreActionWaitForRender(): number {
 
 export function getRecordingPreActionCaptureOptions(): ScreenshotCaptureOptions {
   return { ...PRE_ACTION_RECORDING_KEYFRAME_CAPTURE_OPTIONS };
+}
+
+export function shouldCaptureAfterKeyframe(eventType: string): boolean {
+  return ACTION_KEYFRAME_EVENT_TYPES.has(eventType);
+}
+
+export function getRecordingAfterKeyframeWaitForRender(): number {
+  return AFTER_ACTION_RECORDING_KEYFRAME_WAIT_MS;
 }
 
 export function shouldDiscardPostCaptureRecordingKeyframe(

--- a/extension/src/recording/recorder.ts
+++ b/extension/src/recording/recorder.ts
@@ -1318,7 +1318,12 @@ async function enrichEventDataWithKeyframe(
         eventData,
         preActionKeyframe,
       );
-      return attachAfterKeyframeIfApplicable(recording, eventType, tab, withBefore);
+      return attachAfterKeyframeIfApplicable(
+        recording,
+        eventType,
+        tab,
+        withBefore,
+      );
     }
   }
 

--- a/extension/src/recording/recorder.ts
+++ b/extension/src/recording/recorder.ts
@@ -4,11 +4,13 @@ import { captureScreenshot, compressIfNeeded } from '../commands/screenshot';
 import { debuggerSessionManager } from '../commands/debugger-manager';
 import { annotateRecordingKeyframe } from './keyframe-annotation';
 import {
+  getRecordingAfterKeyframeWaitForRender,
   getRecordingKeyframeCaptureOptions,
   getRecordingKeyframeWaitForRender,
   getRecordingPreActionCaptureOptions,
   getRecordingPreActionWaitForRender,
   isInputLikeRecordingTarget,
+  shouldCaptureAfterKeyframe,
   shouldCaptureRecordingKeyframe,
   shouldDiscardPostCaptureRecordingKeyframe,
 } from './keyframe-policy';
@@ -18,8 +20,8 @@ const DEFAULT_RECORDING_LAUNCH_MODE: RecordingLaunchMode = 'dedicated_window';
 const RECORDING_GROUP_TITLE_PREFIX = 'OpenBrowser Recording';
 const RECORDING_GROUP_COLOR = 'grey' as chrome.tabGroups.Color;
 const RECORDING_GROUP_COLLAPSED = false;
-const RECORDING_KEYFRAME_THRESHOLD_BYTES = 380 * 1024;
-const RECORDING_KEYFRAME_MIN_QUALITY = 40;
+const RECORDING_KEYFRAME_THRESHOLD_BYTES = 1024 * 1024;
+const RECORDING_KEYFRAME_MIN_QUALITY = 65;
 const RECORDING_SCREENSHOT_CONVERSATION_PREFIX = 'recording';
 const ACTIVE_RECORDING_STORAGE_KEY = 'openbrowser_active_recording';
 const PRE_ACTION_KEYFRAME_TTL_MS = 1500;
@@ -1012,7 +1014,7 @@ async function buildRecordingKeyframe(
       tabId,
       conversationId,
       false,
-      65,
+      80,
       false,
       waitForRender,
       captureOptions,
@@ -1311,11 +1313,12 @@ async function enrichEventDataWithKeyframe(
       eventData,
     );
     if (preActionKeyframe) {
-      return attachRecordingKeyframeToEventData(
+      const withBefore = await attachRecordingKeyframeToEventData(
         eventType,
         eventData,
         preActionKeyframe,
       );
+      return attachAfterKeyframeIfApplicable(recording, eventType, tab, withBefore);
     }
   }
 
@@ -1362,7 +1365,39 @@ async function enrichEventDataWithKeyframe(
     return eventData;
   }
 
+  // Fallback path (no pre-action keyframe): the captured keyframe already
+  // reflects post-action state, so we don't capture an additional keyframeAfter.
   return attachRecordingKeyframeToEventData(eventType, eventData, keyframe);
+}
+
+async function attachAfterKeyframeIfApplicable(
+  recording: ActiveRecording,
+  eventType: string,
+  tab: chrome.tabs.Tab,
+  eventData: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  if (!tab.id || !shouldCaptureAfterKeyframe(eventType)) {
+    return eventData;
+  }
+
+  const afterKeyframe = await buildRecordingKeyframe(
+    tab.id,
+    recording.recordingId,
+    `after_${eventType}`,
+    getRecordingAfterKeyframeWaitForRender(),
+  );
+  if (!afterKeyframe) {
+    return eventData;
+  }
+
+  // Intentionally do NOT run shouldDiscardPostCaptureRecordingKeyframe: clicks
+  // that navigate are expected to land on a new URL, and the destination page
+  // is precisely what we want the compiler to see.
+  afterKeyframe.annotationMessage = `Page state immediately after the ${eventType} action.`;
+  return {
+    ...eventData,
+    keyframeAfter: afterKeyframe,
+  };
 }
 
 function isTabIdInRecordingScope(

--- a/extension/src/recording/recorder.ts
+++ b/extension/src/recording/recorder.ts
@@ -272,7 +272,7 @@ function getPreActionBindingType(
   eventType: string,
   eventData: Record<string, unknown>,
 ): RecordingPreActionType | null {
-  if (eventType === 'click') {
+  if (eventType === 'click' || eventType === 'drag_and_drop') {
     return 'click';
   }
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2331,8 +2331,7 @@
             display: inline;
         }
 
-        .compiler-log-entry.collapsed .compiler-log-full,
-        .compiler-log-entry.collapsed .compiler-log-image {
+        .compiler-log-entry.collapsed .compiler-log-full {
             display: none;
         }
 
@@ -2348,10 +2347,6 @@
             display: none;
         }
 
-        .compiler-log-entry:not(.collapsed) .compiler-log-image {
-            display: block;
-        }
-
         .compiler-log-ellipsis {
             color: rgba(255, 210, 140, 0.5);
             margin-left: 2px;
@@ -2362,10 +2357,16 @@
         .compiler-log-image {
             display: block;
             max-width: 100%;
-            max-height: 240px;
+            max-height: 80px;
+            width: auto;
             margin-top: 6px;
-            border-radius: 6px;
+            border-radius: 4px;
             border: 1px solid var(--panel-border);
+            cursor: zoom-in;
+        }
+
+        .compiler-log-entry:not(.collapsed) .compiler-log-image {
+            max-height: 240px;
         }
 
         .recording-compiler-draft {
@@ -5190,7 +5191,7 @@
                                 ></textarea>
                                 <button class="ghost-button" id="recording-intent-note-save" onclick="void saveIntentNote()">Save</button>
                                 <span class="recording-intent-note-status" id="recording-intent-note-status"></span>
-                                <button class="cta-button-primary" id="review-to-compile-btn" onclick="void goToRecordingPhase('compile')">
+                                <button class="cta-button-primary" id="review-to-compile-btn" onclick="void continueToCompile()">
                                     Continue to Compile <span class="cta-arrow">→</span>
                                 </button>
                             </div>
@@ -6270,7 +6271,7 @@
                 <div class="recording-keyframe">
                     ${metaText}
                     <img
-                        class="recording-keyframe-image"
+                        class="recording-keyframe-image event-image"
                         src="${keyframe.imageData}"
                         alt="${altText}"
                         loading="lazy"
@@ -6360,6 +6361,7 @@
             }).join('');
 
             container.innerHTML = itemsHtml;
+            setupImageClickHandlers();
         }
 
         function getRecordingEntryKey(entry, fallbackIndex = 0) {
@@ -6504,6 +6506,7 @@
                 </details>
             `;
             for (const c of containers) c.innerHTML = html;
+            setupImageClickHandlers();
         }
 
         function formatRelativeTime(value) {
@@ -6895,6 +6898,7 @@
             compilerRoutine = null;
             compilerCompiling = false;
             compilerQuestion = null;
+            compilerStalled = false;
             compilerReviewActive = false;
             compilerReviewSummary = '';
             openRecordingPanel('detail');
@@ -8363,6 +8367,11 @@
         let compilerRoutine = null;
         let compilerCompiling = false;
         let compilerQuestion = null;
+        // True when the agent stopped without calling ask_user — e.g. it
+        // replied in prose after a vague user answer. The UI reuses the
+        // question panel so the user can send a follow-up and resume the
+        // agent loop.
+        let compilerStalled = false;
         // When the agent has called submit_workflow successfully and is
         // waiting for the user to either approve or send revision feedback,
         // these hold the wrap-up message and the Routine currently in review.
@@ -8455,7 +8464,7 @@
             const noteInput = document.getElementById('recording-intent-note-input');
             const statusNode = document.getElementById('recording-intent-note-status');
             if (!recordingId || !noteInput) {
-                return;
+                return false;
             }
 
             const note = noteInput.value.trim();
@@ -8482,11 +8491,24 @@
                     statusNode.textContent = 'Saved';
                     setTimeout(() => { statusNode.textContent = ''; }, 2000);
                 }
+                return true;
             } catch (error) {
                 if (statusNode) {
                     statusNode.textContent = `Error: ${error.message}`;
                 }
+                return false;
             }
+        }
+
+        async function continueToCompile() {
+            const noteInput = document.getElementById('recording-intent-note-input');
+            const savedNote = recordingPanelSession?.metadata?.intent_note ?? '';
+            const currentNote = noteInput ? noteInput.value.trim() : '';
+            if (noteInput && currentNote !== String(savedNote).trim()) {
+                const ok = await saveIntentNote();
+                if (!ok) return;
+            }
+            goToRecordingPhase('compile');
         }
 
         function updateCompilerSection() {
@@ -8502,16 +8524,21 @@
             if (compileBtn) {
                 compileBtn.disabled = compilerCompiling
                     || Boolean(compilerQuestion)
+                    || compilerStalled
                     || compilerReviewActive;
                 compileBtn.textContent = compilerCompiling
                     ? 'Compiling...'
                     : (compilerRoutine ? 'Recompile Routine' : 'Compile Routine');
             }
 
-            // Show question UI when the agent is asking
+            // Show question UI when the agent is asking OR when the agent
+            // stalled with a free-form message (we reuse the same panel so
+            // the user can reply and resume the loop).
             if (questionNode && questionText) {
                 if (compilerQuestion) {
-                    questionText.textContent = compilerQuestion;
+                    questionText.textContent = compilerStalled
+                        ? `The compiler agent replied without asking a structured question — send a follow-up to resume:\n\n${compilerQuestion}`
+                        : compilerQuestion;
                     questionNode.hidden = false;
                 } else {
                     questionNode.hidden = true;
@@ -8655,15 +8682,29 @@
 
             if (result.status === 'asking') {
                 compilerQuestion = result.question || 'The compiler agent has a question.';
+                compilerStalled = false;
                 compilerReviewActive = false;
                 compilerReviewSummary = '';
                 if (compileStatus) {
                     compileStatus.textContent = 'Waiting for your answer...';
                 }
+            } else if (result.status === 'stalled') {
+                // Agent stopped with a direct message instead of calling
+                // ask_user or submit_workflow. Keep session alive and prompt
+                // the user for a follow-up.
+                compilerQuestion = result.message
+                    || 'The compiler agent stopped without asking a question or submitting a Routine. Send a follow-up to resume.';
+                compilerStalled = true;
+                compilerReviewActive = false;
+                compilerReviewSummary = '';
+                if (compileStatus) {
+                    compileStatus.textContent = 'Agent paused — send a follow-up to resume.';
+                }
             } else if (result.status === 'review') {
                 // Agent submitted a Routine and is waiting for the user to
                 // approve it or send revision feedback.
                 compilerQuestion = null;
+                compilerStalled = false;
                 compilerRoutine = result;
                 compilerReviewActive = true;
                 compilerReviewSummary = result.summary_message || '';
@@ -8683,6 +8724,7 @@
             } else {
                 // status === 'completed' (or anything else terminal)
                 compilerQuestion = null;
+                compilerStalled = false;
                 compilerRoutine = result;
                 compilerReviewActive = false;
                 compilerReviewSummary = '';
@@ -8764,19 +8806,27 @@
 
             // Image support (keyframe screenshots from trace_viewer)
             let imageHtml = '';
-            const imageUrl = data.image || '';
-            if (imageUrl) {
-                imageHtml = `<img class="compiler-log-image" src="${escapeHtml(imageUrl)}" alt="keyframe" loading="lazy">`;
+            const imageUrls = Array.isArray(data.images) && data.images.length
+                ? data.images
+                : (data.image ? [data.image] : []);
+            if (imageUrls.length) {
+                imageHtml = imageUrls
+                    .map((url) => `<img class="compiler-log-image event-image" src="${escapeHtml(url)}" alt="keyframe" loading="lazy">`)
+                    .join('');
             }
 
             entry.innerHTML = `<span class="compiler-log-label ${labelClass}">${label}</span> <span class="compiler-log-text">${textHtml}</span>${imageHtml}`;
 
             // Make every entry clickable: short ones can still hold tool_call_id
             // and we want a consistent affordance.
-            entry.addEventListener('click', () => entry.classList.toggle('collapsed'));
+            entry.addEventListener('click', (event) => {
+                if (event.target instanceof HTMLImageElement) return;
+                entry.classList.toggle('collapsed');
+            });
 
             logNode.appendChild(entry);
             logNode.scrollTop = logNode.scrollHeight;
+            setupImageClickHandlers();
         }
 
         async function streamCompilerSSE(url, body) {
@@ -8881,6 +8931,7 @@
             compilerCompiling = true;
             compilerRoutine = null;
             compilerQuestion = null;
+            compilerStalled = false;
             compilerReviewActive = false;
             compilerReviewSummary = '';
 
@@ -8919,13 +8970,19 @@
             const answer = textarea.value.trim();
             if (!answer) return;
 
+            const wasStalled = compilerStalled;
             compilerCompiling = true;
             compilerQuestion = null;
+            compilerStalled = false;
             textarea.value = '';
             updateRecordingPanel();
 
             const compileStatus = document.getElementById('recording-compile-status');
-            if (compileStatus) compileStatus.textContent = 'Continuing compilation...';
+            if (compileStatus) {
+                compileStatus.textContent = wasStalled
+                    ? 'Resuming compiler agent...'
+                    : 'Continuing compilation...';
+            }
 
             try {
                 await streamCompilerSSE(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,5 +76,5 @@ override-dependencies = [
 ]
 
 [tool.uv.sources]
-openhands-sdk = { git = "https://github.com/softpudding/agent-sdk.git", subdirectory = "openhands-sdk", rev = "a602ebc94bfcbefc2cfe3348d0f7a46a83c7967d" }
-openhands-tools = { git = "https://github.com/softpudding/agent-sdk.git", subdirectory = "openhands-tools", rev = "a602ebc94bfcbefc2cfe3348d0f7a46a83c7967d" }
+openhands-sdk = { git = "https://github.com/softpudding/agent-sdk.git", subdirectory = "openhands-sdk", rev = "764fb87256d7bc20b3eccf82c8a4d241e6740d63" }
+openhands-tools = { git = "https://github.com/softpudding/agent-sdk.git", subdirectory = "openhands-tools", rev = "764fb87256d7bc20b3eccf82c8a4d241e6740d63" }

--- a/server/agent/visualizer.py
+++ b/server/agent/visualizer.py
@@ -128,6 +128,9 @@ class QueueVisualizer(ConversationVisualizerBase):
                 # Check for image content in observations from browser-related tools
                 if hasattr(obs, "screenshot_data_url") and obs.screenshot_data_url:
                     sse_data["image"] = obs.screenshot_data_url
+                elif hasattr(obs, "image_urls") and obs.image_urls:
+                    sse_data["images"] = list(obs.image_urls)
+                    sse_data["image"] = obs.image_urls[0]
                 elif hasattr(obs, "image_url") and obs.image_url:
                     sse_data["image"] = obs.image_url
                 elif hasattr(obs, "image") and obs.image:

--- a/server/core/compiler_agent.py
+++ b/server/core/compiler_agent.py
@@ -77,7 +77,6 @@ class TraceViewerAction(Action):
         "summary",
         "events",
         "event_detail",
-        "keyframe",
         "normalized_steps",
     ] = Field(description="The trace viewer command to execute.")
     start: int = Field(
@@ -90,7 +89,7 @@ class TraceViewerAction(Action):
     )
     event_index: int = Field(
         default=0,
-        description="Event index for 'event_detail' and 'keyframe' commands.",
+        description="Event index for the 'event_detail' command.",
     )
 
     @property
@@ -99,7 +98,7 @@ class TraceViewerAction(Action):
         content.append(f"trace_viewer {self.command}", style="bold cyan")
         if self.command == "events":
             content.append(f" start={self.start} count={self.count}")
-        elif self.command in ("event_detail", "keyframe"):
+        elif self.command == "event_detail":
             content.append(f" event_index={self.event_index}")
         return content
 
@@ -109,7 +108,7 @@ class TraceViewerObservation(Observation):
 
     success: bool = Field(default=True)
     text_result: str = Field(default="")
-    image_url: Optional[str] = Field(default=None)
+    image_urls: list[str] = Field(default_factory=list)
 
     @property
     def visualize(self) -> Text:
@@ -118,8 +117,8 @@ class TraceViewerObservation(Observation):
     @property
     def to_llm_content(self) -> Sequence[TextContent | ImageContent]:
         items: list[TextContent | ImageContent] = []
-        if self.image_url:
-            items.append(ImageContent(image_urls=[self.image_url]))
+        for url in self.image_urls:
+            items.append(ImageContent(image_urls=[url]))
         items.append(TextContent(text=self.text_result))
         return items
 
@@ -151,8 +150,6 @@ class TraceViewerExecutor(ToolExecutor[TraceViewerAction, TraceViewerObservation
             return self._handle_events(action.start, action.count)
         if action.command == "event_detail":
             return self._handle_event_detail(action.event_index)
-        if action.command == "keyframe":
-            return self._handle_keyframe(action.event_index)
         if action.command == "normalized_steps":
             return self._handle_normalized_steps()
         return TraceViewerObservation(
@@ -228,6 +225,10 @@ class TraceViewerExecutor(ToolExecutor[TraceViewerAction, TraceViewerObservation
             has_keyframe = bool(
                 isinstance(event_data.get("keyframe"), dict)
                 and event_data["keyframe"].get("imageData")
+            )
+            has_keyframe_after = bool(
+                isinstance(event_data.get("keyframeAfter"), dict)
+                and event_data["keyframeAfter"].get("imageData")
             )
 
             parts = [f"[{event_index}] {event_type}"]
@@ -306,6 +307,8 @@ class TraceViewerExecutor(ToolExecutor[TraceViewerAction, TraceViewerObservation
 
             if has_keyframe:
                 parts.append("[has keyframe]")
+            if has_keyframe_after:
+                parts.append("[has after]")
 
             value = element.get("value")
             if isinstance(value, str) and value and event_type != "set_slider":
@@ -336,51 +339,44 @@ class TraceViewerExecutor(ToolExecutor[TraceViewerAction, TraceViewerObservation
 
         detail = json.loads(json.dumps(event))
         event_data = detail.get("event_data") or {}
-        keyframe = event_data.get("keyframe")
-        if isinstance(keyframe, dict) and keyframe.get("imageData"):
-            keyframe["imageData"] = (
-                f"[image data, {len(keyframe['imageData'])} chars "
-                f"— use 'keyframe' command to view]"
+
+        # Strip imageData from the JSON payload (it would explode the text size)
+        # and instead surface the keyframes as inline images in the observation.
+        image_urls: list[str] = []
+        image_captions: list[str] = []
+        for slot, label in (("keyframe", "before"), ("keyframeAfter", "after")):
+            kf = event_data.get(slot)
+            if not (isinstance(kf, dict) and kf.get("imageData")):
+                continue
+            image_data = kf["imageData"]
+            kf["imageData"] = (
+                f"[{label}-keyframe attached as image #{len(image_urls) + 1}]"
             )
+            url = (
+                image_data
+                if image_data.startswith("data:")
+                else f"data:image/png;base64,{image_data}"
+            )
+            image_urls.append(url)
+            caption = f"Image #{len(image_urls)} ({label})"
+            annotation = kf.get("annotationMessage")
+            if annotation:
+                caption += f": {annotation}"
+            image_captions.append(caption)
 
         formatted = json.dumps(detail, indent=2, ensure_ascii=False)
-        return TraceViewerObservation(success=True, text_result=formatted)
-
-    def _handle_keyframe(self, event_index: int) -> TraceViewerObservation:
-        event = self._events_by_index.get(event_index)
-        if event is None:
-            return TraceViewerObservation(
-                success=False,
-                text_result=f"Event index {event_index} not found.",
+        if image_captions:
+            formatted = (
+                "Attached keyframes:\n  "
+                + "\n  ".join(image_captions)
+                + "\n\n"
+                + formatted
             )
-
-        event_data = event.get("event_data") or {}
-        keyframe = event_data.get("keyframe")
-        if not isinstance(keyframe, dict):
-            return TraceViewerObservation(
-                success=False,
-                text_result=f"Event {event_index} has no keyframe.",
-            )
-
-        image_data = keyframe.get("imageData", "")
-        if not image_data:
-            return TraceViewerObservation(
-                success=False,
-                text_result=f"Event {event_index} keyframe has no image data.",
-            )
-
-        if image_data.startswith("data:"):
-            url = image_data
-        else:
-            url = f"data:image/png;base64,{image_data}"
-
-        annotation = keyframe.get("annotationMessage") or ""
-        event_type = event.get("event_type", "?")
-        text = f"Keyframe for event [{event_index}] ({event_type})"
-        if annotation:
-            text += f"\nAnnotation: {annotation}"
-
-        return TraceViewerObservation(success=True, text_result=text, image_url=url)
+        return TraceViewerObservation(
+            success=True,
+            text_result=formatted,
+            image_urls=image_urls,
+        )
 
     def _handle_normalized_steps(self) -> TraceViewerObservation:
         lines: list[str] = []
@@ -415,8 +411,12 @@ class TraceViewerTool(ToolDefinition[TraceViewerAction, TraceViewerObservation])
                 description=(
                     "Browse the recorded browser trace. Use commands: "
                     "summary, events (with start/count), event_detail "
-                    "(with event_index), keyframe (with event_index), "
-                    "normalized_steps."
+                    "(with event_index), normalized_steps. "
+                    "event_detail returns the full event JSON plus any "
+                    "attached keyframes inline: a before-keyframe (page "
+                    "state immediately before the action) and, when the "
+                    "event is listed with [has after], an after-keyframe "
+                    "(page state immediately after the action)."
                 ),
                 action_type=TraceViewerAction,
                 observation_type=TraceViewerObservation,
@@ -1159,6 +1159,9 @@ async def compile_with_agent(
             system_message_suffix="",
         ),
         system_prompt_filename=COMPILER_PROMPT_FILENAME,
+        # Keep every keyframe in context — compiler reasoning depends on
+        # seeing all trace_viewer screenshots, not just the most recent.
+        tool_image_window=None,
     )
 
     # Build the initial user message
@@ -1272,6 +1275,16 @@ def _read_routine_from_session(session: CompilerSession) -> dict[str, Any]:
         return {"routine_markdown": last_text, "goal": "", "step_count": 0}
 
 
+def _get_last_agent_message(events: Sequence[Event]) -> str | None:
+    """Return the most recent agent MessageEvent text, or None."""
+    for event in reversed(events):
+        if isinstance(event, MessageEvent) and event.source == "agent":
+            text = _extract_message_text(event)
+            if text:
+                return text
+    return None
+
+
 def _collect_result(session: CompilerSession) -> dict[str, Any]:
     """Check conversation state and return the appropriate result.
 
@@ -1280,8 +1293,10 @@ def _collect_result(session: CompilerSession) -> dict[str, Any]:
     - "review"    — submit_workflow succeeded and the agent is waiting for
                     the user to approve or send revision feedback; keep
                     session alive
-    - "completed" — terminal (no submit happened, conversation just ran out
-                    of work); cleanup session
+    - "stalled"   — the agent stopped without calling ask_user or
+                    submit_workflow (e.g. it replied in free-form prose to a
+                    vague user answer). Keep the session alive so the user
+                    can send a follow-up via /compile/answer.
     """
     recording_id = session.recording_id
 
@@ -1320,20 +1335,20 @@ def _collect_result(session: CompilerSession) -> dict[str, Any]:
         _compiler_sessions[recording_id] = session
         return routine_doc
 
-    # 3. Terminal — no submit happened, conversation just ended.
-    routine_doc = _read_routine_from_session(session)
-    routine_doc["status"] = "completed"
-    routine_doc["recording_id"] = recording_id
-    routine_doc["model"] = session.model
-    routine_doc["trace_path"] = dumped_trace_path
-
-    _compiler_sessions.pop(recording_id, None)
-    try:
-        session.conversation.close()
-    except Exception:
-        pass
-
-    return routine_doc
+    # 3. Agent stalled — no submit happened and no ask_user is pending, but
+    # the conversation ran out of work. Treat this as a resumable state: the
+    # agent most likely replied in prose to the previous user message instead
+    # of calling ask_user. Keep the session alive and surface the agent's
+    # last message so the frontend can prompt the user for a follow-up.
+    stalled_message = _get_last_agent_message(events)
+    _compiler_sessions[recording_id] = session
+    return {
+        "status": "stalled",
+        "message": stalled_message or "",
+        "recording_id": recording_id,
+        "model": session.model,
+        "trace_path": dumped_trace_path,
+    }
 
 
 def finalize_compiler_session(recording_id: str) -> dict[str, Any]:

--- a/server/core/compiler_agent.py
+++ b/server/core/compiler_agent.py
@@ -235,28 +235,80 @@ class TraceViewerExecutor(ToolExecutor[TraceViewerAction, TraceViewerObservation
                 parts.append(f"page={url[:120]}")
             if title:
                 parts.append(f"title={title[:80]}")
-            if tag:
-                parts.append(f"tag={tag}")
-            if text:
-                parts.append(f'text="{text}"')
-            if selector:
-                parts.append(f"sel={selector}")
-            if aria:
-                parts.append(f"aria={aria[:60]}")
-            if html:
-                # Show the opening tag + attributes so the agent can spot
-                # native controls (<select>, <input type=checkbox>, <a href>)
-                # without expanding to event_detail. Full HTML is available
-                # via the event_detail command.
-                html_peek = html[:140]
-                if len(html) > 140:
-                    html_peek += "…"
-                parts.append(f"html={html_peek}")
+
+            # For drag_and_drop events, show source and target elements
+            if event_type == "drag_and_drop":
+                source_el = event_data.get("sourceElement") or {}
+                target_el = event_data.get("targetElement") or {}
+                src_text = (source_el.get("text") or "")[:60]
+                src_sel = (source_el.get("selector") or "")[:60]
+                tgt_text = (target_el.get("text") or "")[:60]
+                tgt_sel = (target_el.get("selector") or "")[:60]
+                if src_text:
+                    parts.append(f'source="{src_text}"')
+                elif src_sel:
+                    parts.append(f"source_sel={src_sel}")
+                if tgt_text:
+                    parts.append(f'target="{tgt_text}"')
+                elif tgt_sel:
+                    parts.append(f"target_sel={tgt_sel}")
+                src_html = source_el.get("html") or ""
+                if src_html:
+                    peek = src_html[:120]
+                    if len(src_html) > 120:
+                        peek += "…"
+                    parts.append(f"source_html={peek}")
+                tgt_html = target_el.get("html") or ""
+                if tgt_html:
+                    peek = tgt_html[:120]
+                    if len(tgt_html) > 120:
+                        peek += "…"
+                    parts.append(f"target_html={peek}")
+            elif event_type == "set_slider":
+                if tag:
+                    parts.append(f"tag={tag}")
+                if text:
+                    parts.append(f'text="{text}"')
+                if selector:
+                    parts.append(f"sel={selector}")
+                slider_value = event_data.get("value")
+                if slider_value is not None:
+                    parts.append(f"value={slider_value}")
+                slider_min = event_data.get("min")
+                slider_max = event_data.get("max")
+                if slider_min is not None:
+                    parts.append(f"min={slider_min}")
+                if slider_max is not None:
+                    parts.append(f"max={slider_max}")
+                if html:
+                    html_peek = html[:140]
+                    if len(html) > 140:
+                        html_peek += "…"
+                    parts.append(f"html={html_peek}")
+            else:
+                if tag:
+                    parts.append(f"tag={tag}")
+                if text:
+                    parts.append(f'text="{text}"')
+                if selector:
+                    parts.append(f"sel={selector}")
+                if aria:
+                    parts.append(f"aria={aria[:60]}")
+                if html:
+                    # Show the opening tag + attributes so the agent can spot
+                    # native controls (<select>, <input type=checkbox>, <a href>)
+                    # without expanding to event_detail. Full HTML is available
+                    # via the event_detail command.
+                    html_peek = html[:140]
+                    if len(html) > 140:
+                        html_peek += "…"
+                    parts.append(f"html={html_peek}")
+
             if has_keyframe:
                 parts.append("[has keyframe]")
 
             value = element.get("value")
-            if isinstance(value, str) and value:
+            if isinstance(value, str) and value and event_type != "set_slider":
                 parts.append(f'value="{value[:80]}"')
 
             selected_text = element.get("selectedText")

--- a/server/core/recording_manager.py
+++ b/server/core/recording_manager.py
@@ -511,7 +511,14 @@ class RecordingManager:
     def _strip_large_payloads(self, event_data: dict[str, Any]) -> dict[str, Any]:
         """Drop obviously large fields that do not belong in trace storage."""
         stripped = dict(event_data)
-        for key in ["image", "image_url", "screenshot", "screenshot_data_url"]:
+        for key in [
+            "image",
+            "images",
+            "image_url",
+            "image_urls",
+            "screenshot",
+            "screenshot_data_url",
+        ]:
             stripped.pop(key, None)
         return stripped
 

--- a/server/core/session_manager.py
+++ b/server/core/session_manager.py
@@ -402,10 +402,14 @@ class SessionManager:
         # Remove common image fields
         if "image" in stripped:
             del stripped["image"]
+        if "images" in stripped:
+            del stripped["images"]
         if "screenshot_data_url" in stripped:
             del stripped["screenshot_data_url"]
         if "image_url" in stripped:
             del stripped["image_url"]
+        if "image_urls" in stripped:
+            del stripped["image_urls"]
 
         # Also strip from nested data structures
         if "data" in stripped and isinstance(stripped["data"], dict):

--- a/server/core/workflow_compiler.py
+++ b/server/core/workflow_compiler.py
@@ -469,6 +469,122 @@ def _build_form_step(
     }
 
 
+def _build_anchor_from_element(element: dict[str, Any], event_data: dict[str, Any]) -> dict[str, Any]:
+    """Build an anchor dict from an element payload (not necessarily event_data['element'])."""
+    container = element.get("container")
+    if not isinstance(container, dict):
+        container = {}
+
+    return {
+        "selector": _normalize_text(element.get("selector")),
+        "text": _normalize_text(element.get("text")),
+        "aria_label": _normalize_text(element.get("ariaLabel")),
+        "placeholder": _normalize_text(element.get("placeholder")),
+        "container": {
+            "kind": _normalize_text(container.get("kind")),
+            "selector": _normalize_text(container.get("selector")),
+            "title": _normalize_text(container.get("title")),
+            "href": _normalize_text(container.get("href")),
+        },
+        "page_url": _get_page_url(event_data),
+    }
+
+
+def _build_drag_and_drop_step(
+    event: dict[str, Any],
+    sorted_index: int,
+) -> dict[str, Any]:
+    event_data = _event_data(event)
+    event_index = event.get("event_index")
+
+    source_element = event_data.get("sourceElement")
+    if not isinstance(source_element, dict):
+        source_element = {}
+    target_element = event_data.get("targetElement")
+    if not isinstance(target_element, dict):
+        target_element = {}
+
+    source_anchor = _build_anchor_from_element(source_element, event_data)
+    target_anchor = _build_anchor_from_element(target_element, event_data)
+
+    source_label = (
+        _normalize_text(source_element.get("text"))
+        or _normalize_text(source_element.get("ariaLabel"))
+        or _normalize_text(source_element.get("selector"))
+        or "source"
+    )
+    target_label = (
+        _normalize_text(target_element.get("text"))
+        or _normalize_text(target_element.get("ariaLabel"))
+        or _normalize_text(target_element.get("selector"))
+        or "target"
+    )
+
+    return {
+        "id": f"step_{sorted_index + 1:03d}",
+        "type": "drag_and_drop",
+        "action": "drag_and_drop",
+        "description": f"Drag {source_label} to {target_label}",
+        "target": {
+            "source": source_anchor,
+            "destination": target_anchor,
+        },
+        "source_event_indexes": [event_index] if event_index is not None else [],
+        "anchors": [source_anchor, target_anchor],
+        "preconditions": [
+            {
+                "type": "page_url_contains",
+                "value": _get_page_url(event_data),
+            }
+        ],
+        "postconditions": [],
+        "executor_preference": "agent",
+    }
+
+
+def _build_set_slider_step(
+    event: dict[str, Any],
+    sorted_index: int,
+) -> dict[str, Any]:
+    event_data = _event_data(event)
+    anchor = _build_anchor(event_data)
+    event_index = event.get("event_index")
+
+    label = anchor.get("text") or anchor.get("aria_label") or anchor.get("selector") or "slider"
+    value = event_data.get("value")
+    min_val = event_data.get("min")
+    max_val = event_data.get("max")
+
+    value_desc = f" to {value}" if value else ""
+    description = f"Set {label}{value_desc}"
+
+    target: dict[str, Any] = {"anchor": anchor}
+    if value is not None:
+        target["value"] = value
+    if min_val is not None:
+        target["min"] = min_val
+    if max_val is not None:
+        target["max"] = max_val
+
+    return {
+        "id": f"step_{sorted_index + 1:03d}",
+        "type": "set_slider",
+        "action": "set_slider",
+        "description": description,
+        "target": target,
+        "source_event_indexes": [event_index] if event_index is not None else [],
+        "anchors": [anchor],
+        "preconditions": [
+            {
+                "type": "page_url_contains",
+                "value": _get_page_url(event_data),
+            }
+        ],
+        "postconditions": [],
+        "executor_preference": "agent",
+    }
+
+
 def normalize_trace_events(
     events: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
@@ -522,6 +638,16 @@ def normalize_trace_events(
 
         if event_type == "click":
             steps.append(_build_click_step(event, len(steps)))
+            index += 1
+            continue
+
+        if event_type == "drag_and_drop":
+            steps.append(_build_drag_and_drop_step(event, len(steps)))
+            index += 1
+            continue
+
+        if event_type == "set_slider":
+            steps.append(_build_set_slider_step(event, len(steps)))
             index += 1
             continue
 

--- a/server/core/workflow_compiler.py
+++ b/server/core/workflow_compiler.py
@@ -469,7 +469,9 @@ def _build_form_step(
     }
 
 
-def _build_anchor_from_element(element: dict[str, Any], event_data: dict[str, Any]) -> dict[str, Any]:
+def _build_anchor_from_element(
+    element: dict[str, Any], event_data: dict[str, Any]
+) -> dict[str, Any]:
     """Build an anchor dict from an element payload (not necessarily event_data['element'])."""
     container = element.get("container")
     if not isinstance(container, dict):
@@ -550,7 +552,12 @@ def _build_set_slider_step(
     anchor = _build_anchor(event_data)
     event_index = event.get("event_index")
 
-    label = anchor.get("text") or anchor.get("aria_label") or anchor.get("selector") or "slider"
+    label = (
+        anchor.get("text")
+        or anchor.get("aria_label")
+        or anchor.get("selector")
+        or "slider"
+    )
     value = event_data.get("value")
     min_val = event_data.get("min")
     max_val = event_data.get("max")

--- a/uv.lock
+++ b/uv.lock
@@ -1678,8 +1678,8 @@ requires-dist = [
     { name = "litellm", git = "https://github.com/softpudding/litellm.git?rev=2eb7db59461e9117b1e3e0519616b39f1497c0f9" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.7.0" },
     { name = "numpy", specifier = ">=1.24.0" },
-    { name = "openhands-sdk", git = "https://github.com/softpudding/agent-sdk.git?subdirectory=openhands-sdk&rev=a602ebc94bfcbefc2cfe3348d0f7a46a83c7967d" },
-    { name = "openhands-tools", git = "https://github.com/softpudding/agent-sdk.git?subdirectory=openhands-tools&rev=a602ebc94bfcbefc2cfe3348d0f7a46a83c7967d" },
+    { name = "openhands-sdk", git = "https://github.com/softpudding/agent-sdk.git?subdirectory=openhands-sdk&rev=764fb87256d7bc20b3eccf82c8a4d241e6740d63" },
+    { name = "openhands-tools", git = "https://github.com/softpudding/agent-sdk.git?subdirectory=openhands-tools&rev=764fb87256d7bc20b3eccf82c8a4d241e6740d63" },
     { name = "pillow", specifier = ">=10.0.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "pydantic", specifier = ">=2.5.0" },
@@ -2224,7 +2224,7 @@ wheels = [
 [[package]]
 name = "openhands-sdk"
 version = "1.12.0"
-source = { git = "https://github.com/softpudding/agent-sdk.git?subdirectory=openhands-sdk&rev=a602ebc94bfcbefc2cfe3348d0f7a46a83c7967d#a602ebc94bfcbefc2cfe3348d0f7a46a83c7967d" }
+source = { git = "https://github.com/softpudding/agent-sdk.git?subdirectory=openhands-sdk&rev=764fb87256d7bc20b3eccf82c8a4d241e6740d63#764fb87256d7bc20b3eccf82c8a4d241e6740d63" }
 dependencies = [
     { name = "agent-client-protocol" },
     { name = "deprecation" },
@@ -2244,7 +2244,7 @@ dependencies = [
 [[package]]
 name = "openhands-tools"
 version = "1.12.0"
-source = { git = "https://github.com/softpudding/agent-sdk.git?subdirectory=openhands-tools&rev=a602ebc94bfcbefc2cfe3348d0f7a46a83c7967d#a602ebc94bfcbefc2cfe3348d0f7a46a83c7967d" }
+source = { git = "https://github.com/softpudding/agent-sdk.git?subdirectory=openhands-tools&rev=764fb87256d7bc20b3eccf82c8a4d241e6740d63#764fb87256d7bc20b3eccf82c8a4d241e6740d63" }
 dependencies = [
     { name = "bashlex" },
     { name = "binaryornot" },


### PR DESCRIPTION
## Summary
- Recording keyframes now match runtime capture quality (1920x1080 jpeg) and include an after-action keyframe for every action event, so the compiler sees both before and after page state.
- `TraceViewerTool` drops the separate `keyframe` command — `event_detail` returns an `image_urls` list (before + after) inline with the event JSON. Prompt and agent-sdk rev updated to match.
- Compiler agent sessions are no longer torn down when the agent stops without calling `ask_user` or `submit_workflow`. `_collect_result` now returns `status="stalled"` with the agent's last message, and the Compile Routine UI reuses the question panel to let the user send a follow-up that resumes the loop via `/compile/answer`.
- Gitignore Claude Code local state (`.claude/`, `CLAUDE.local.md`).

## Test plan
- [x] `bun test` in `extension/` (191 pass)
- [x] `uv run pytest server/tests/unit/test_compiler_agent_finalize.py server/tests/unit/test_base_classes.py` (24 pass)
- [ ] Record a new trace, compile through the UI, confirm `event_detail` shows both before/after keyframes inline
- [ ] Answer an `ask_user` question vaguely, confirm the stalled-agent follow-up panel appears and `/compile/answer` resumes the loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)